### PR TITLE
[draft] Translate NET API Reference to Italian

### DIFF
--- a/italian/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/_index.md
+++ b/italian/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LinearGradientBrush.InterpolationColors"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LinearGradientBrush. Ottiene o imposta un ColorBlend che definisce un gradiente lineare multicolore"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/
+---
+{{< psd/tize >}}
+## LinearGradientBrush.InterpolationColors property
+
+Ottiene o imposta un [`ColorBlend`](../../../aspose.psd/colorblend/) che definisce un gradiente lineare multicolore.
+
+```csharp
+[Obsolete("This property is not used anymore in this class. Use instance of the LinearMulticolorGradientBrush class instead.")]
+public ColorBlend InterpolationColors { get; set; }
+```
+
+### Property Value
+
+Un [`ColorBlend`](../../../aspose.psd/colorblend/) che definisce un gradiente lineare multicolore.
+
+### Vedi anche
+
+* class [ColorBlend](../../../aspose.psd/colorblend/)
+* class [LinearGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.brushes/lineargradientbrush/linearcolors/_index.md
+++ b/italian/net/aspose.psd.brushes/lineargradientbrush/linearcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LinearGradientBrush.LinearColors"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LinearGradientBrush. Ottiene o imposta i colori di inizio e fine del gradiente"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.brushes/lineargradientbrush/linearcolors/
+---
+{{< psd/tize >}}
+## LinearGradientBrush.LinearColors property
+
+Ottiene o imposta i colori di inizio e fine del gradiente.
+
+```csharp
+[Obsolete("Use StartColor and EndColor properties instead.")]
+public Color[] LinearColors { get; set; }
+```
+
+### Property Value
+
+Un array di due strutture [`Color`](../../../aspose.psd/color/) che rappresentano i colori di inizio e fine del gradiente.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [LinearGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/_index.md
+++ b/italian/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PathGradientBrush.InterpolationColors"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PathGradientBrush. Ottiene o imposta un ColorBlend che definisce un gradiente lineare multicolore"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/
+---
+{{< psd/tize >}}
+## PathGradientBrush.InterpolationColors property
+
+Ottiene o imposta un [`ColorBlend`](../../../aspose.psd/colorblend/) che definisce un gradiente lineare multicolore.
+
+```csharp
+[Obsolete("This property is not used in this class anymore. Use PathMulticolorGradientBrush class instead.")]
+public ColorBlend InterpolationColors { get; set; }
+```
+
+### Property Value
+
+Un [`ColorBlend`](../../../aspose.psd/colorblend/) che definisce un gradiente lineare multicolore.
+
+### Vedi anche
+
+* class [ColorBlend](../../../aspose.psd/colorblend/)
+* class [PathGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.customfonthandler/_index.md
+++ b/italian/net/aspose.psd.customfonthandler/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.PSD.CustomFontHandler"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Lo spazio dei nomi gestisce l'elaborazione dei font personalizzati"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.customfonthandler/
+---
+{{< psd/tize >}}
+Lo spazio dei nomi gestisce l'elaborazione dei font personalizzati.
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [CustomFontData](./customfontdata/) | Classe dati font personalizzato |
+
+

--- a/italian/net/aspose.psd.customfonthandler/customfontdata/_index.md
+++ b/italian/net/aspose.psd.customfonthandler/customfontdata/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Classe CustomFontData"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.CustomFontHandler.CustomFontData. Classe di dati del font personalizzato"
+type: docs
+weight: 700
+url: /it/net/aspose.psd.customfonthandler/customfontdata/
+---
+{{< psd/tize >}}
+## CustomFontData class
+
+Classe dati font personalizzato
+
+```csharp
+public class CustomFontData
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [CustomFontData](customfontdata/)(string, byte[]) | Inizializza una nuova istanza della classe `CustomFontData`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [FontData](../../aspose.psd.customfonthandler/customfontdata/fontdata/) { get; } | Ottiene i dati del font. |
+| [FontName](../../aspose.psd.customfonthandler/customfontdata/fontname/) { get; } | Ottiene il nome del font. |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.CustomFontHandler](../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.customfonthandler/customfontdata/customfontdata/_index.md
+++ b/italian/net/aspose.psd.customfonthandler/customfontdata/customfontdata/_index.md
@@ -1,0 +1,29 @@
+---
+title: "CustomFontData.CustomFontData"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore CustomFontData. Inizializza una nuova istanza della classe CustomFontData"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.customfonthandler/customfontdata/customfontdata/
+---
+{{< psd/tize >}}
+## CustomFontData constructor
+
+Inizializza una nuova istanza della classe [`CustomFontData`](../).
+
+```csharp
+public CustomFontData(string fontName, byte[] fontData)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| fontName | Stringa | Nome del font. |
+| fontData | Byte[] | I dati del font. |
+
+### Vedi anche
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.customfonthandler/customfontdata/fontdata/_index.md
+++ b/italian/net/aspose.psd.customfonthandler/customfontdata/fontdata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "CustomFontData.FontData"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà CustomFontData. Restituisce i dati del font"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.customfonthandler/customfontdata/fontdata/
+---
+{{< psd/tize >}}
+## CustomFontData.FontData property
+
+Ottiene i dati del font.
+
+```csharp
+public byte[] FontData { get; }
+```
+
+### Property Value
+
+I dati del font.
+
+### Vedi anche
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.customfonthandler/customfontdata/fontname/_index.md
+++ b/italian/net/aspose.psd.customfonthandler/customfontdata/fontname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "CustomFontData.FontName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà CustomFontData. Restituisce il nome del font"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.customfonthandler/customfontdata/fontname/
+---
+{{< psd/tize >}}
+## CustomFontData.FontName property
+
+Ottiene il nome del font.
+
+```csharp
+public string FontName { get; }
+```
+
+### Property Value
+
+Il nome del font.
+
+### Vedi anche
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.extensions/imageextensions/togdiimage/_index.md
+++ b/italian/net/aspose.psd.extensions/imageextensions/togdiimage/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ImageExtensions.ToGdiImage"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ImageExtensions. Converte l'Image nella Image"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.extensions/imageextensions/togdiimage/
+---
+{{< psd/tize >}}
+## ImageExtensions.ToGdiImage method
+
+Converte l'Image nella Image.
+
+```csharp
+[Obsolete("Please do not use this method as you may get OutOfMemoryException if image is too large for GDI to fit.")]
+public static Image ToGdiImage(Image image)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| immagine | Immagine | L'Image da convertire. |
+
+### Valore di ritorno
+
+L'Image convertita.
+
+## Osservazioni
+
+Attenzione, l'immagine GDI potrebbe avere limiti inferiori rispetto a *image*. Per ottenere tutte le parti dell'immagine utilizzare un metodo di estensione più sicuro, ToGdiImageFull.
+
+### Vedi anche
+
+* class [Image](../../../aspose.psd/image/)
+* class [ImageExtensions](../)
+* namespace [Aspose.PSD.Extensions](../../../aspose.psd.extensions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.ai/aiimage/activepageindex/_index.md
+++ b/italian/net/aspose.psd.fileformats.ai/aiimage/activepageindex/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AiImage.ActivePageIndex"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà AiImage. Ottiene o imposta l'indice della pagina attiva"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.ai/aiimage/activepageindex/
+---
+{{< psd/tize >}}
+## AiImage.ActivePageIndex property
+
+Ottiene o imposta l'indice della pagina attiva.
+
+```csharp
+public int ActivePageIndex { get; set; }
+```
+
+### Property Value
+
+Questa proprietà è valida solo per le immagini AI in formato PDF. Se l'immagine non è in formato PDF o non ci sono pagine, la proprietà sarà -1. Questa proprietà indica quale pagina dell'immagine AI sarà la base per il rendering.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della possibilità di cambiare la pagina attiva nelle immagini Ai.
+
+```csharp
+[C#]
+
+string sourceFile = "threePages.ai";
+string firstPageOutputPng = "firstPageOutput.png";
+string secondPageOutputPng = "secondPageOutput.png";
+string thirdPageOutputPng = "thirdPageOutput.png";
+
+// Carica l'immagine AI.
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    // Per impostazione predefinita, ActivePageIndex è 0.
+    // Quindi, se salvi l'immagine AI senza modificare questa proprietà, verrà renderizzata e salvata la prima pagina.
+    image.Save(firstPageOutputPng, new PngOptions());
+
+    // Modifica l'indice della pagina attiva alla seconda pagina.
+    image.ActivePageIndex = 1;
+
+    // Salva la seconda pagina dell'immagine AI come immagine PNG.
+    image.Save(secondPageOutputPng, new PngOptions());
+
+    // Modifica l'indice della pagina attiva alla terza pagina.
+    image.ActivePageIndex = 2;
+
+    // Salva la terza pagina dell'immagine AI come immagine PNG.
+    image.Save(thirdPageOutputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.ai/aiimage/pagecount/_index.md
+++ b/italian/net/aspose.psd.fileformats.ai/aiimage/pagecount/_index.md
@@ -1,0 +1,63 @@
+---
+title: "AiImage.PageCount"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà AiImage. Il numero di pagine. Per le immagini del vecchio formato AI è sempre uguale a 0"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.ai/aiimage/pagecount/
+---
+{{< psd/tize >}}
+## AiImage.PageCount property
+
+Il numero di pagine. Per le immagini del vecchio formato AI è sempre uguale a 0.
+
+```csharp
+public int PageCount { get; }
+```
+
+### Property Value
+
+Il numero di pagine.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà AiImage per il numero di pagine AiImage.PageCount.
+
+```csharp
+[C#]
+
+string sourceFile = "2241.ai";
+string[] outputFiles = new string[3]
+{
+    "2241_pageNumber_0.png",
+    "2241_pageNumber_1.png",
+    "2241_pageNumber_2.png",
+};
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.PageCount, 3);
+
+    for (int i = 0; i < image.PageCount; i++)
+    {
+        image.ActivePageIndex = i;
+        image.Save(outputFiles[i], new PngOptions());
+    }
+}
+```
+
+### Vedi anche
+
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.ai/aiimage/xmpdata/_index.md
+++ b/italian/net/aspose.psd.fileformats.ai/aiimage/xmpdata/_index.md
@@ -1,0 +1,92 @@
+---
+title: "AiImage.XmpData"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà AiImage. Ottiene i metadati XMP"
+type: docs
+weight: 150
+url: /it/net/aspose.psd.fileformats.ai/aiimage/xmpdata/
+---
+{{< psd/tize >}}
+## AiImage.XmpData property
+
+Ottiene i metadati XMP.
+
+```csharp
+public XmpPacketWrapper XmpData { get; }
+```
+
+### Property Value
+
+I dati XMP.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà AiImage.XmpData.
+
+```csharp
+[C#]
+
+string sourceFile = "ai_one.ai";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object testObject)
+{
+    if (testObject == null)
+    {
+        throw new Exception("Test object are null.");
+    }
+}
+
+string creatorToolKey = ":CreatorTool";
+string nPagesKey = "xmpTPg:NPages";
+string unitKey = "stDim:unit";
+string heightKey = "stDim:h";
+string widthKey = "stDim:w";
+
+string expectedCreatorTool = "Adobe Illustrator CC 22.1 (Windows)";
+string expectedNPages = "1";
+string expectedUnit = "Pixels";
+double expectedHeight = 768;
+double expectedWidth = 1366;
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    // I metadati XMP sono stati aggiunti.
+    var xmpMetaData = image.XmpData;
+
+    AssertIsNotNull(xmpMetaData);
+
+    // Ora possiamo accedere ai pacchetti XMP dei file AI.
+    var basicPackage = xmpMetaData.GetPackage(Namespaces.XmpBasic) as XmpBasicPackage;
+    var package = xmpMetaData.Packages[4];
+
+    // E abbiamo accesso al contenuto di questi pacchetti.
+    var creatorTool = basicPackage[creatorToolKey].ToString();
+    var nPages = package[nPagesKey];
+    var unit = package[unitKey];
+    var height = double.Parse(package[heightKey].ToString(), CultureInfo.InvariantCulture);
+    var width = double.Parse(package[widthKey].ToString(), CultureInfo.InvariantCulture);
+
+    AssertAreEqual(creatorTool, expectedCreatorTool);
+    AssertAreEqual(nPages, expectedNPages);
+    AssertAreEqual(unit, expectedUnit);
+    AssertAreEqual(height, expectedHeight);
+    AssertAreEqual(width, expectedWidth);
+}
+```
+
+### Vedi anche
+
+* class [XmpPacketWrapper](../../../aspose.psd.xmp/xmppacketwrapper/)
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.ai/ailayersection/colorindex/_index.md
+++ b/italian/net/aspose.psd.fileformats.ai/ailayersection/colorindex/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AiLayerSection.ColorIndex"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà AiLayerSection. Ottiene o imposta l'indice del colore. Questo argomento può assumere valori compresi tra 1 e 26. Ogni intero rappresenta un colore che può essere assegnato al livello per scopi di identificazione dell'utente."
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.ai/ailayersection/colorindex/
+---
+{{< psd/tize >}}
+## AiLayerSection.ColorIndex property
+
+Ottiene o imposta l'indice del colore. Questo argomento può assumere valori compresi tra –1 e 26. Ogni intero rappresenta un colore che può essere assegnato al livello per scopi di identificazione dell'utente.
+
+```csharp
+public int ColorIndex { get; set; }
+```
+
+### Property Value
+
+L'indice del colore.
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle proprietà HasMultiLayerMasks e ColorIndex in AiLayerSection.
+
+```csharp
+[C#]
+
+string sourceFile = "example.ai";
+string outputFilePath = "example.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.Layers.Length, 2);
+    AssertAreEqual(image.Layers[0].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[0].ColorIndex, -1);
+    AssertAreEqual(image.Layers[1].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[1].ColorIndex, -1);
+
+    image.Save(outputFilePath, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [AiLayerSection](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/_index.md
+++ b/italian/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AiLayerSection.HasMultiLayerMasks"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà AiLayerSection. Ottiene o imposta un valore che indica se questa istanza ha maschere multilivello"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/
+---
+{{< psd/tize >}}
+## AiLayerSection.HasMultiLayerMasks property
+
+Ottiene o imposta un valore che indica se questa istanza ha maschere multilivello.
+
+```csharp
+public bool HasMultiLayerMasks { get; set; }
+```
+
+### Property Value
+
+`true` se questa istanza ha maschere multilivello; altrimenti, `false`.
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle proprietà HasMultiLayerMasks e ColorIndex in AiLayerSection.
+
+```csharp
+[C#]
+
+string sourceFile = "example.ai";
+string outputFilePath = "example.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.Layers.Length, 2);
+    AssertAreEqual(image.Layers[0].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[0].ColorIndex, -1);
+    AssertAreEqual(image.Layers[1].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[1].ColorIndex, -1);
+
+    image.Save(outputFilePath, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [AiLayerSection](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/_index.md
+++ b/italian/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "VectorShapeBoundingBox.PointsUnitType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorShapeBoundingBox. Ottiene o imposta il tipo di unità dei punti che determinano gli angoli della scatola"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/
+---
+{{< psd/tize >}}
+## VectorShapeBoundingBox.PointsUnitType property
+
+Ottiene o imposta il tipo di unità dei punti che determinano gli angoli della scatola.
+
+```csharp
+public UnitTypes PointsUnitType { get; set; }
+```
+
+### Vedi anche
+
+* enum [UnitTypes](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/unittypes/)
+* class [VectorShapeBoundingBox](../)
+* namespace [Aspose.PSD.FileFormats.Core.VectorPaths](../../../aspose.psd.fileformats.core.vectorpaths/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/_index.md
@@ -1,0 +1,20 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Core.RawColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Lo spazio dei nomi contiene la gerarchia della classe PSD RawColor includendo ColorComponent"
+type: docs
+weight: 220
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/
+---
+{{< psd/tize >}}
+Lo spazio dei nomi contiene la gerarchia della classe PSD RawColor includendo ColorComponent
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [ColorComponent](./colorcomponent/) | Il componente colore è un'astrazione su Valore Canale e Valore Canale. Qualsiasi colore è composto da un array di ColorComponent |
+| [RawColor](./rawcolor/) | La classe Raw Color aiuta a memorizzare i colori con qualsiasi numero di canali, qualsiasi modalità colore e qualsiasi profondità di bit. Si prega di notare che alcune classi interne possono avere problemi nella conversione di RawColor nel suo formato nativo, quindi se l'API fornisce un colore CMYK, è più affidabile utilizzare il formato fornito. Inoltre, possono esserci alcuni casi in cui Raw Color può essere convertito. |
+| [RawColorHelper](./rawcolorhelper/) | La classe Raw Color Helper aiuta a creare RawColor più rapidamente, utilizzando metadati di canale predefiniti. |
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Classe ColorComponent"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.ColorComponent class. Il componente colore è un'astrazione su Channel Value e Channel Value. Qualsiasi colore è composto da un array di ColorComponent"
+type: docs
+weight: 1640
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/
+---
+{{< psd/tize >}}
+## ColorComponent class
+
+Il componente colore è un'astrazione su Valore Canale e Valore Canale. Qualsiasi colore è composto da un array di ColorComponent
+
+```csharp
+public sealed class ColorComponent
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorComponent](colorcomponent/)(byte, string) | Inizializza una nuova istanza della classe `ColorComponent`. Si prega di verificare |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BitDepth](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/) { get; } | Ottiene la profondità di bit del Component/Canale colore |
+| [Description](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/) { get; } | Ottiene la descrizione del Component colore |
+| [FullName](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/) { get; } | Ottiene il nome completo del componente colore con nome e descrizione separata da spazi |
+| [Name](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/) { get; } | Ottiene il nome del componente colore. |
+| [Value](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/) { get; set; } | Ottiene o imposta il valore. Si noti che, se si tenta di impostare un valore superiore a quello possibile da memorizzare nella profondità di bit corrente, verrà generata un'eccezione |
+| static [PermittedFullNames](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/) { get; } | Ottiene i nomi completi consentiti. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/)() | Ottiene il codice hash dell'oggetto corrente. |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.BitDepth"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ColorComponent proprietà. Ottiene la profondità in bit del componente/canale di colore"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/
+---
+{{< psd/tize >}}
+## ColorComponent.BitDepth property
+
+Ottiene la profondità di bit del Component/Canale colore
+
+```csharp
+public byte BitDepth { get; }
+```
+
+### Property Value
+
+La profondità in bit.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/_index.md
@@ -1,0 +1,29 @@
+---
+title: "ColorComponent.ColorComponent"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore ColorComponent. Inizializza una nuova istanza della classe ColorComponent. Si prega di verificare"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/
+---
+{{< psd/tize >}}
+## ColorComponent constructor
+
+Inizializza una nuova istanza della classe [`ColorComponent`](../). Si prega di verificare
+
+```csharp
+public ColorComponent(byte bitDepth, string fullName)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| bitDepth | Byte | La profondità in bit. |
+| fullName | Stringa | Il nome completo. |
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Description"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ColorComponent proprietà. Ottiene la descrizione del componente di colore"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/
+---
+{{< psd/tize >}}
+## ColorComponent.Description property
+
+Ottiene la descrizione del Component colore
+
+```csharp
+public string Description { get; }
+```
+
+### Property Value
+
+La descrizione.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.FullName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ColorComponent. Restituisce il nome completo del componente colore con nome e descrizione separata da spazi"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/
+---
+{{< psd/tize >}}
+## ColorComponent.FullName property
+
+Ottiene il nome completo del componente colore con nome e descrizione separata da spazi
+
+```csharp
+public string FullName { get; }
+```
+
+### Property Value
+
+Il nome completo.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.GetHashCode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ColorComponent. Restituisce il codice hash dell'oggetto corrente"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/
+---
+{{< psd/tize >}}
+## ColorComponent.GetHashCode method
+
+Ottiene il codice hash dell'oggetto corrente.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Valore di ritorno
+
+Il codice hash.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Name"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ColorComponent proprietà. Ottiene il nome del componente di colore"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/
+---
+{{< psd/tize >}}
+## ColorComponent.Name property
+
+Ottiene il nome del componente colore.
+
+```csharp
+public string Name { get; }
+```
+
+### Property Value
+
+Il nome.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.PermittedFullNames"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ColorComponent proprietà. Ottiene i nomi completi consentiti"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/
+---
+{{< psd/tize >}}
+## ColorComponent.PermittedFullNames property
+
+Ottiene i nomi completi consentiti.
+
+```csharp
+public static string[] PermittedFullNames { get; }
+```
+
+### Property Value
+
+I nomi completi consentiti.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Value"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ColorComponent proprietà. Ottiene o imposta il valore. Nota che se provi a impostare un valore superiore a quello possibile da memorizzare nella profondità in bit corrente, otterrai un'eccezione"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/
+---
+{{< psd/tize >}}
+## ColorComponent.Value property
+
+Ottiene o imposta il valore. Si noti che, se si tenta di impostare un valore superiore a quello possibile da memorizzare nella profondità di bit corrente, verrà generata un'eccezione
+
+```csharp
+public ulong Value { get; set; }
+```
+
+### Property Value
+
+Il valore.
+
+### Vedi anche
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/_index.md
@@ -1,0 +1,87 @@
+---
+title: "Classe RawColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.RawColor classe. La classe Raw Color aiuta a memorizzare colori con qualsiasi numero di canali, qualsiasi modalità colore e qualsiasi profondità di bit. Si noti che alcune classi interne possono avere problemi nella conversione di RawColor al suo formato nativo, quindi se l'API fornisce un colore CMYK è più affidabile utilizzare il formato fornito. Inoltre possono esserci alcuni casi in cui Raw Color può essere convertito."
+type: docs
+weight: 1650
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/
+---
+{{< psd/tize >}}
+## RawColor class
+
+La classe Raw Color aiuta a memorizzare i colori con qualsiasi numero di canali, qualsiasi modalità colore e qualsiasi profondità di bit. Si prega di notare che alcune classi interne possono avere problemi nella conversione di RawColor nel suo formato nativo, quindi se l'API fornisce un colore CMYK, è più affidabile utilizzare il formato fornito. Inoltre, possono esserci alcuni casi in cui Raw Color può essere convertito.
+
+```csharp
+public sealed class RawColor
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [RawColor](rawcolor/#constructor)(ColorComponent[]) | Inizializza una nuova istanza della classe `RawColor`. |
+| [RawColor](rawcolor/#constructor_1)(PixelDataFormat, short) | Inizializza una nuova istanza della classe `RawColor` dal formato dei dati pixel utilizzando modalità colore predefinite |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorMode](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/) { get; set; } | Modalità da seguire per il colore. |
+| [Components](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/) { get; } | Ottiene i componenti del colore. Ogni componente è un canale separato e, se utilizzi uno schema colore non comune, è meglio lavorare con ciascun canale separatamente. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Equals](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/)(object) | Determina se l'Object specificato è uguale a questa istanza. |
+| [GetAsInt](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/)() | Ottiene il colore come int nel caso sia possibile ottenerlo. |
+| [GetAsLong](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/)() | Ottiene il colore come long nel caso sia possibile ottenerlo. |
+| [GetBitDepth](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/)() | Ottiene la profondità di bit del Raw Color. Ad esempio, per un colore ARGB con 8 bit per canale/componente la profondità è 32 bit; per un colore ARGB completo con 16 bit per canale/componente è 64. La profondità di bit è accumulata dalla somma delle profondità di bit dei canali. È possibile se i diversi canali hanno profondità di bit differenti. |
+| [GetColorModeName](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/)() | Ottiene il nome della modalità colore. Il nome della modalità colore è accumulato dai nomi dei canali/componenti. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/)() | Ottiene il codice hash dell'oggetto corrente. |
+| [SetAsInt](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/)(int) | Imposta i dati a tutti i canali dall'argomento int se è possibile. |
+| [SetAsLong](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/)(long) | Imposta i dati a tutti i canali dall'argomento int se è possibile. |
+| [operator ==](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/) | Implementa l'operatore ==. |
+| [operator !=](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/) | Implementa l'operatore !=. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della classe RawColor al posto della struttura Color obsoleta.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+var color = new RawColor(PixelDataFormat.Rgba32Bpp);
+var oldColor = Color.FromArgb(5, 1, 2, 3);
+
+var argbValue = oldColor.ToArgb();
+color.SetAsInt(argbValue);
+
+AssertAreEqual("ARGB", color.GetColorModeName());
+AssertAreEqual(32, color.GetBitDepth());
+AssertAreEqual("A Alpha", color.Components[0].FullName);
+AssertAreEqual(5, (int)color.Components[0].Value);
+AssertAreEqual("R Red", color.Components[1].FullName);
+AssertAreEqual(1, (int)color.Components[1].Value);
+AssertAreEqual("G Green", color.Components[2].FullName);
+AssertAreEqual(2, (int)color.Components[2].Value);
+AssertAreEqual("B Blue", color.Components[3].FullName);
+AssertAreEqual(3, (int)color.Components[3].Value);
+
+AssertAreEqual(argbValue, color.GetAsInt());
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/_index.md
@@ -1,0 +1,24 @@
+---
+title: "RawColor.ColorMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà RawColor. Modalità per il colore da seguire"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/
+---
+{{< psd/tize >}}
+## RawColor.ColorMode property
+
+Modalità da seguire per il colore.
+
+```csharp
+public short ColorMode { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/_index.md
@@ -1,0 +1,29 @@
+---
+title: "RawColor.Components"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "RawColor proprietà. Ottiene i componenti del colore. Ogni componente è un canale separato e, se utilizzi uno schema di colore non popolare, è meglio lavorare con ciascun canale separatamente."
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/
+---
+{{< psd/tize >}}
+## RawColor.Components property
+
+Ottiene i componenti del colore. Ogni componente è un canale separato e, se utilizzi uno schema colore non comune, è meglio lavorare con ciascun canale separatamente.
+
+```csharp
+public ColorComponent[] Components { get; }
+```
+
+### Property Value
+
+I componenti del colore
+
+### Vedi anche
+
+* class [ColorComponent](../../colorcomponent/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/_index.md
@@ -1,0 +1,32 @@
+---
+title: "RawColor.Equals"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "RawColor metodo. Determina se l'oggetto specificato è uguale a questa istanza"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/
+---
+{{< psd/tize >}}
+## RawColor.Equals method
+
+Determina se l'Object specificato è uguale a questa istanza.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | Object | L'Object da confrontare con questa istanza. |
+
+### Valore di ritorno
+
+`true` se l'Object specificato è uguale a questa istanza; altrimenti, `false`.
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.GetAsInt"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Ottiene il colore come int nel caso sia possibile ottenerlo"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/
+---
+{{< psd/tize >}}
+## RawColor.GetAsInt method
+
+Ottiene il colore come int nel caso sia possibile ottenerlo.
+
+```csharp
+public int GetAsInt()
+```
+
+### Valore di ritorno
+
+Dati dei canali memorizzati in Int
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| ArgumentException | La profondità di bit di Raw Color è {depth} che è superiore a 32, non è possibile leggerla come Int |
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.GetAsLong"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Ottiene il colore come long nel caso sia possibile ottenerlo"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/
+---
+{{< psd/tize >}}
+## RawColor.GetAsLong method
+
+Ottiene il colore come long nel caso sia possibile ottenerlo.
+
+```csharp
+public long GetAsLong()
+```
+
+### Valore di ritorno
+
+Dati dei canali memorizzati in Int
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| ArgumentException | La profondità di bit di Raw Color è {depth} che è superiore a 32, non è possibile leggerla come Int |
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetBitDepth"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "RawColor metodo. Ottiene la profondità in bit del colore grezzo. Ad esempio, per un colore ARGB con 8 bit per canale/componente la profondità è 32 bit; per un colore ARGB completo con 16 bit per canale/componente è 64. La profondità in bit è la somma delle profondità in bit dei canali. È possibile che canali diversi abbiano profondità in bit differenti."
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/
+---
+{{< psd/tize >}}
+## RawColor.GetBitDepth method
+
+Ottiene la profondità di bit del Raw Color. Ad esempio, per un colore ARGB con 8 bit per canale/componente la profondità è 32 bit; per un colore ARGB completo con 16 bit per canale/componente è 64. La profondità di bit è accumulata dalla somma delle profondità di bit dei canali. È possibile se i diversi canali hanno profondità di bit differenti.
+
+```csharp
+public int GetBitDepth()
+```
+
+### Valore di ritorno
+
+La somma delle profondità in bit di tutti i canali
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetColorModeName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Restituisce il nome della modalità colore. Il nome della modalità colore è accumulato dai nomi dei canali/componenti"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/
+---
+{{< psd/tize >}}
+## RawColor.GetColorModeName method
+
+Ottiene il nome della modalità colore. Il nome della modalità colore è accumulato dai nomi dei canali/componenti.
+
+```csharp
+public string GetColorModeName()
+```
+
+### Valore di ritorno
+
+Stringa con il nome della modalità colore
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetHashCode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "RawColor metodo. Ottiene il codice hash dell'oggetto corrente"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/
+---
+{{< psd/tize >}}
+## RawColor.GetHashCode method
+
+Ottiene il codice hash dell'oggetto corrente.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Valore di ritorno
+
+Il codice hash.
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/_index.md
@@ -1,0 +1,33 @@
+---
+title: "RawColor.op_Equality"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Implementa l'operatore"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/
+---
+{{< psd/tize >}}
+## RawColor Equality operator
+
+Implementa l'operatore ==.
+
+```csharp
+public static bool operator ==(RawColor left, RawColor right)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sinistra | RawColor | Il primo RawColor. |
+| destra | RawColor | Il secondo RawColor. |
+
+### Valore di ritorno
+
+Il risultato dell'operatore.
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/_index.md
@@ -1,0 +1,33 @@
+---
+title: "RawColor.op_Inequality"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Implementa l'operatore"
+type: docs
+weight: 130
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/
+---
+{{< psd/tize >}}
+## RawColor Inequality operator
+
+Implementa l'operatore !=.
+
+```csharp
+public static bool operator !=(RawColor left, RawColor right)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sinistra | RawColor | Il primo RawColor. |
+| destra | RawColor | Il secondo RawColor. |
+
+### Valore di ritorno
+
+Il risultato dell'operatore.
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/_index.md
@@ -1,0 +1,57 @@
+---
+title: "RawColor.RawColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore RawColor. Inizializza una nuova istanza della classe RawColor"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/
+---
+{{< psd/tize >}}
+## RawColor(ColorComponent[]) {#constructor}
+
+Inizializza una nuova istanza della classe [`RawColor`](../).
+
+```csharp
+public RawColor(ColorComponent[] components)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| componenti | ColorComponent[] | I componenti di colore personalizzati. |
+
+### Vedi anche
+
+* class [ColorComponent](../../colorcomponent/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## RawColor(PixelDataFormat, short) {#constructor_1}
+
+Inizializza una nuova istanza della classe [`RawColor`](../) dal formato dati pixel utilizzando modalità colore predefinite
+
+```csharp
+public RawColor(PixelDataFormat pixelDataFormat, short colorMode = 0)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixelDataFormat | PixelDataFormat | Il formato dati pixel. |
+| colorMode | Int16 | Modalità da seguire per il colore. |
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| ArgumentException | Il conteggio dei canali differisce da PixelFormat, l'indice dei canali non può essere ottenuto. Si prega di creare RawColor con l'argomento Array dei Componenti |
+
+### Vedi anche
+
+* class [PixelDataFormat](../../../aspose.psd/pixeldataformat/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.SetAsInt"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Imposta i dati su tutti i canali dall'argomento int se è possibile"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/
+---
+{{< psd/tize >}}
+## RawColor.SetAsInt method
+
+Imposta i dati a tutti i canali dall'argomento int se è possibile.
+
+```csharp
+public void SetAsInt(int value)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | Int32 | Il valore int che contiene i dati del componente |
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| ArgumentException | La profondità di bit di Raw Color è {depth}. Non è possibile impostarla come Int, per favore imposta i dati dei singoli canali |
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.SetAsLong"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColor. Imposta i dati su tutti i canali dall'argomento int se è possibile"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/
+---
+{{< psd/tize >}}
+## RawColor.SetAsLong method
+
+Imposta i dati a tutti i canali dall'argomento int se è possibile.
+
+```csharp
+public void SetAsLong(long value)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | Int64 | Il valore int che contiene i dati del componente |
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| ArgumentException | La profondità di bit di Raw Color è {depth}. Non è possibile impostarla come Int, per favore imposta i dati dei singoli canali |
+
+### Vedi anche
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/_index.md
@@ -1,0 +1,39 @@
+---
+title: "Classe RawColorHelper"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.RawColorHelper class. La classe Raw Color Helper aiuta a creare RawColor più rapidamente usando metadati di canale predefiniti"
+type: docs
+weight: 1660
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/
+---
+{{< psd/tize >}}
+## RawColorHelper class
+
+La classe Raw Color Helper aiuta a creare RawColor più rapidamente, utilizzando metadati di canale predefiniti.
+
+```csharp
+public class RawColorHelper
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [RawColorHelper](rawcolorhelper/)() | Il costruttore predefinito. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| static [CreateArgb16BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/)(ushort, ushort, ushort, ushort) | Crea un colore ARGB a 16 bit per canale. |
+| static [CreateArgb8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/#createargb8bitcolor)(Color) | Crea un colore ARGB a 8 bit per canale da Drawing.Color |
+| static [CreateArgb8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/#createargb8bitcolor_1)(byte, byte, byte, byte) | Crea un colore ARGB a 8 bit per canale. |
+| static [CreateCmyk16BitBitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/)(ushort, ushort, ushort, ushort) | Crea un colore CMYK a 16 bit per canale. |
+| static [CreateCmyk8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/)(byte, byte, byte, byte) | Crea un colore CMYK a 8 bit per canale. |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateArgb16BitColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColorHelper. Crea un colore ARGB a 16 bit per canale"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateArgb16BitColor method
+
+Crea un colore ARGB a 16 bit per canale.
+
+```csharp
+public static RawColor CreateArgb16BitColor(ushort a, ushort r, ushort g, ushort b)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| a | UInt16 | Il valore del componente alfa (0-65535). |
+| r | UInt16 | Il valore del componente rosso (0-65535). |
+| g | UInt16 | Il valore del componente verde (0-65535). |
+| b | UInt16 | Il valore del componente blu (0-65535). |
+
+### Valore di ritorno
+
+Una nuova istanza di [`RawColor`](../../rawcolor/) che rappresenta il colore ARGB.
+
+## Osservazioni
+
+I componenti di colore sono impacchettati in un intero a 64 bit nell'ordine: alfa (bit 48-63), rosso (bit 32-47), verde (bit 16-31) e blu (bit 0-15).
+
+### Vedi anche
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "RawColorHelper.CreateArgb8BitColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColorHelper. Crea un colore ARGB a 8 bit per canale"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/
+---
+{{< psd/tize >}}
+## CreateArgb8BitColor(byte, byte, byte, byte) {#createargb8bitcolor_1}
+
+Crea un colore ARGB a 8 bit per canale.
+
+```csharp
+public static RawColor CreateArgb8BitColor(byte a, byte r, byte g, byte b)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| a | Byte | Il valore del componente alfa (0-255). |
+| r | Byte | Il valore del componente rosso (0-255). |
+| g | Byte | Il valore del componente verde (0-255). |
+| b | Byte | Il valore del componente blu (0-255). |
+
+### Valore di ritorno
+
+Una nuova istanza di [`RawColor`](../../rawcolor/) che rappresenta il colore ARGB.
+
+## Osservazioni
+
+I componenti di colore sono impacchettati in un intero a 32 bit nell'ordine: alfa (bit 24-31), rosso (bit 16-23), verde (bit 8-15) e blu (bit 0-7).
+
+### Vedi anche
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## CreateArgb8BitColor(Color) {#createargb8bitcolor}
+
+Crea un colore ARGB a 8 bit per canale da Drawing.Color
+
+```csharp
+public static RawColor CreateArgb8BitColor(Color drawingColor)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| drawingColor | Color | Il colore System.Drawing |
+
+### Valore di ritorno
+
+Una nuova istanza di [`RawColor`](../../rawcolor/) che rappresenta il colore ARGB.
+
+## Osservazioni
+
+I componenti di colore sono impacchettati in un intero a 32 bit nell'ordine: alfa (bit 24-31), rosso (bit 16-23), verde (bit 8-15) e blu (bit 0-7).
+
+### Vedi anche
+
+* class [RawColor](../../rawcolor/)
+* struct [Color](../../../aspose.psd/color/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateCmyk16BitBitColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColorHelper. Crea un colore CMYK a 16 bit per canale"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateCmyk16BitBitColor method
+
+Crea un colore CMYK a 16 bit per canale.
+
+```csharp
+public static RawColor CreateCmyk16BitBitColor(ushort c, ushort m, ushort y, ushort k)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| c | UInt16 | Il valore del componente ciano (0-65535). |
+| m | UInt16 | Il valore del componente magenta (0-65535). |
+| y | UInt16 | Il valore del componente giallo (0-65535). |
+| k | UInt16 | Il valore del componente chiave (nero) (0-65535). |
+
+### Valore di ritorno
+
+Una nuova istanza di [`RawColor`](../../rawcolor/) che rappresenta il colore CMYK.
+
+## Osservazioni
+
+I componenti di colore sono impacchettati in un intero a 64 bit nell'ordine: ciano (bit 48-63), magenta (bit 32-47), giallo (bit 16-31) e chiave/nero (bit 0-15).
+
+### Vedi anche
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateCmyk8BitColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RawColorHelper. Crea un colore CMYK a 8 bit per canale"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateCmyk8BitColor method
+
+Crea un colore CMYK a 8 bit per canale.
+
+```csharp
+public static RawColor CreateCmyk8BitColor(byte c, byte m, byte y, byte k)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| c | Byte | Il valore del componente ciano (0-255). |
+| m | Byte | Il valore del componente magenta (0-255). |
+| y | Byte | Il valore del componente giallo (0-255). |
+| k | Byte | Il valore del componente chiave (nero) (0-255). |
+
+### Valore di ritorno
+
+Una nuova istanza di [`RawColor`](../../rawcolor/) che rappresenta il colore CMYK.
+
+## Osservazioni
+
+I componenti di colore sono impacchettati in un intero a 32 bit nell'ordine: ciano (bit 24-31), magenta (bit 16-23), giallo (bit 8-15) e chiave/nero (bit 0-7).
+
+### Vedi anche
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/_index.md
@@ -1,0 +1,24 @@
+---
+title: "RawColorHelper.RawColorHelper"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore RawColorHelper. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/
+---
+{{< psd/tize >}}
+## RawColorHelper constructor
+
+Il costruttore predefinito.
+
+```csharp
+public RawColorHelper()
+```
+
+### Vedi anche
+
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "Classe CmykCorrection"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.CmykCorrection. Correzione dei colori nel livello di regolazione colore selettivo"
+type: docs
+weight: 1750
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/
+---
+{{< psd/tize >}}
+## CmykCorrection class
+
+Correzione dei colori nel livello di regolazione colore selettivo.
+
+```csharp
+public class CmykCorrection
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [CmykCorrection](cmykcorrection/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Black](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/) { get; set; } | Ottiene o imposta la correzione del colore nero. |
+| [Cyan](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/) { get; set; } | Ottiene o imposta la correzione del colore ciano. |
+| [Magenta](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/) { get; set; } | Ottiene o imposta la correzione del colore magenta. |
+| [Yellow](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/) { get; set; } | Ottiene o imposta la correzione del colore giallo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Black"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "CmykCorrection proprietà. Ottiene o imposta la correzione del colore nero"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/
+---
+{{< psd/tize >}}
+## CmykCorrection.Black property
+
+Ottiene o imposta la correzione del colore nero.
+
+```csharp
+public short Black { get; set; }
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.CmykCorrection"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore CmykCorrection. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/
+---
+{{< psd/tize >}}
+## CmykCorrection constructor
+
+Il costruttore predefinito.
+
+```csharp
+public CmykCorrection()
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Cyan"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "CmykCorrection proprietà. Ottiene o imposta la correzione del colore ciano"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/
+---
+{{< psd/tize >}}
+## CmykCorrection.Cyan property
+
+Ottiene o imposta la correzione del colore ciano.
+
+```csharp
+public short Cyan { get; set; }
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Magenta"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà CmykCorrection. Ottiene o imposta la correzione del colore magenta"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/
+---
+{{< psd/tize >}}
+## CmykCorrection.Magenta property
+
+Ottiene o imposta la correzione del colore magenta.
+
+```csharp
+public short Magenta { get; set; }
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Yellow"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà CmykCorrection. Ottiene o imposta la correzione del colore giallo"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/
+---
+{{< psd/tize >}}
+## CmykCorrection.Yellow property
+
+Ottiene o imposta la correzione del colore giallo.
+
+```csharp
+public short Yellow { get; set; }
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/_index.md
@@ -1,0 +1,125 @@
+---
+title: "Enum CorrectionMethodTypes"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.CorrectionMethodTypes enum. Metodo di correzione nel livello di regolazione colore selettivo"
+type: docs
+weight: 1780
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/
+---
+{{< psd/tize >}}
+## CorrectionMethodTypes enumeration
+
+Metodo di correzione nel livello di regolazione colore selettivo.
+
+```csharp
+public enum CorrectionMethodTypes
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Relative | `0` | Applica la correzione del colore in modalità relativa. |
+| Absolute | `1` | Applica la correzione del colore in modalità assoluta. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/_index.md
@@ -1,0 +1,222 @@
+---
+title: "Classe GradientMapLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.GradientMapLayer. Livello mappa gradiente. Gestisce il rendering della mappa gradiente utilizzando i dati da GrdmResource"
+type: docs
+weight: 1810
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/
+---
+{{< psd/tize >}}
+## GradientMapLayer class
+
+Livello mappa gradiente. Gestisce il rendering della mappa gradiente utilizzando i dati da GrdmResource.
+
+```csharp
+public class GradientMapLayer : AdjustmentLayer
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Ottiene o imposta un valore che indica se regolare automaticamente la tavolozza. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Ottiene o imposta un valore per il colore di sfondo. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Ottiene il conteggio dei bit per pixel dell'immagine. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Ottiene o imposta la fusione dell'elemento ritagliato. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Ottiene le opzioni di fusione. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Ottiene la firma della modalità di fusione. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Ottiene o imposta la posizione del livello inferiore. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Ottiene i limiti dell'immagine. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Ottiene o imposta le informazioni del canale. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Ottiene il conteggio dei canali del livello. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Ottiene o imposta il ritaglio del livello. 0 = base, 1 = non-base. |
+| [Container](../../aspose.psd/image/container/) { get; } | Ottiene il contenitore [`Image`](../../aspose.psd/image/). |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Ottiene il flusso di dati dell'oggetto. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Ottiene o imposta il nome visualizzato del livello. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Ottiene un valore che indica se questa istanza è stata eliminata. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Ottiene la lunghezza delle informazioni aggiuntive del livello in byte. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Ottiene un valore del formato file |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Ottiene o imposta il riempitore del livello. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Ottiene o imposta l'opacità del riempimento. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Ottiene o imposta i flag del livello. bit 0 = trasparenza protetta; bit 1 = visibile; bit 2 = obsoleto; bit 3 = 1 per Photoshop 5.0 e versioni successive, indica se il bit 4 contiene informazioni utili; bit 4 = dati pixel irrilevanti per l'aspetto del documento. |
+| [GradientSettings](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/) { get; set; } | Ottiene o imposta l'istanza delle impostazioni Gradient passata dall'istanza GrdmResource. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Ottiene un valore che indica se questa istanza ha alfa. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Ottiene o imposta un valore che indica se l'immagine ha un colore di sfondo. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Ottiene un valore che indica se l'immagine ha un colore trasparente. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Ottiene l'altezza dell'immagine. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Ottiene o imposta la risoluzione orizzontale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Ottiene l'opacità di questa immagine. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Ottiene o imposta il monitor di interruzione. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Restituisce un valore che indica se i dati dell'immagine sono attualmente memorizzati nella cache. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Restituisce un valore che indica se il caricamento dei dati grezzi è disponibile. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Ottiene o imposta un valore che indica se il livello è visibile |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Restituisce un valore che indica se questa istanza è visibile nel gruppo (se il livello non è in un gruppo significa gruppo radice). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Ottiene o imposta i dati degli intervalli di fusione del livello. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Ottiene o imposta la data e l'ora di creazione del livello. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Ottiene o imposta il blocco del livello. Nota che se il flag LayerFlags.TransparencyProtected è impostato verrà sovrascritto dal flag di blocco del livello. Per restituire il flag LayerFlags.TransparencyProtected è necessario applicarlo all'opzione del livello layer.Flags &#x7C;= LayerFlags.TransparencyProtected |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Ottiene o imposta i dati della maschera del livello. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Restituisce le opzioni del livello. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Ottiene o imposta la posizione sinistra del livello. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Restituisce la lunghezza complessiva del livello in byte. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Ottiene o imposta il nome del livello. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Ottiene o imposta l'opacità del livello. 0 = trasparente, 255 = opaco. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Ottiene o imposta la tavolozza dei colori. La tavolozza dei colori non viene utilizzata quando i pixel sono rappresentati direttamente. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Ottiene o imposta un valore che indica se i componenti dell'immagine devono essere premoltiplicati. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore personalizzato |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Restituisce il formato dei dati grezzi. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Restituisce le impostazioni attuali dei dati grezzi. Nota che quando si usano queste impostazioni i dati vengono caricati senza conversione. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Ottiene o imposta l'indice di fallback da utilizzare quando l'indice della tavolozza è fuori dai limiti |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore indicizzato |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Restituisce la dimensione della riga grezza in byte. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Ottiene o imposta le risorse del livello. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Ottiene o imposta la posizione destra del livello. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Ottiene o imposta l'evidenziazione del colore del foglio decorativo nell'elenco dei livelli. |
+| [Size](../../aspose.psd/image/size/) { get; } | Ottiene le dimensioni dell'immagine. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Ottiene o imposta la posizione del livello superiore. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Ottiene il colore trasparente dell'immagine. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Ottiene o imposta un valore che indica se aggiornare i metadati XMP. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Ottiene un valore che indica se la palette dell'immagine è utilizzata. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Ottiene o imposta un valore che indica se utilizzare il caricamento di dati grezzi quando è disponibile. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Ottiene o imposta la risoluzione verticale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Ottiene la larghezza dell'immagine. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Ottiene o imposta i metadati XMP. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Aggiunge la maschera al livello corrente. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Regola la luminosità dell'immagine. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Contrasto dell'immagine |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Correzione gamma di un'immagine. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Correzione gamma di un'immagine. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Applica la maschera di livello al livello, quindi elimina la maschera. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarizzazione di un'immagine con soglia predefinita |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarizzazione di un'immagine con sogliatura di Otsu |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Memorizza nella cache i dati e garantisce che non vengano effettuati ulteriori caricamenti di dati dal [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/) sottostante. |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Determina se l'immagine può essere salvata nel formato file specificato rappresentato dalle opzioni di salvataggio fornite. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Ritaglio dell'immagine. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Ritaglia l'immagine con spostamenti. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Elimina l'istanza corrente. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Esegue il dithering sull'immagine corrente. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Esegue il dithering sull'immagine corrente. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Disegna l'immagine sul livello. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtra il rettangolo specificato. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Ottiene un pixel immagine a 32-bit ARGB. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Ottiene l'array predefinito di pixel ARGB a 32-bit. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Ottiene le opzioni predefinite. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Ottiene l'array predefinito di pixel usando il caricatore di pixel parziali. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Ottiene l'array predefinito di dati grezzi. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Ottiene l'array predefinito di dati grezzi usando il caricatore di pixel parziali. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Restituisce un codice hash per questa istanza. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Ottiene la data e l'ora dell'ultima modifica dell'immagine di risorsa. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Ottiene le opzioni basate sulle impostazioni del file originale. Questo può essere utile per mantenere inalterata la profondità di bit e altri parametri dell'immagine originale. Ad esempio, se carichiamo un'immagine PNG in bianco e nero a 1 bit per pixel e poi la salviamo usando il metodo [`Save`](../../aspose.psd/datastreamsupporter/save/), verrà generata un'immagine PNG di output a 8 bit per pixel. Per evitarlo e salvare l'immagine PNG a 1 bit per pixel, utilizza questo metodo per ottenere le opzioni di salvataggio corrispondenti e passale al metodo [`Save`](../../aspose.psd/image/save/) come secondo parametro. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Ottiene un pixel immagine. Avviso sulle prestazioni: evita di utilizzare questo metodo per iterare su tutti i pixel dell'immagine poiché può causare notevoli problemi di prestazioni. Per una manipolazione dei pixel più efficiente, utilizza il metodo `LoadArgb32Pixels` per recuperare l'intero array di pixel simultaneamente. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Ottiene l'angolo di inclinazione. Questo metodo è applicabile ai documenti di testo scansionati, per determinare l'angolo di inclinazione durante la scansione. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Trasformazione di un'immagine nella sua rappresentazione in scala di grigi |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Carica pixel ARGB a 32-bit. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Carica pixel ARGB a 64-bit. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Carica pixel in formato CMYK. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Carica pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare in modo più efficace il metodo [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/). |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Carica parzialmente pixel ARGB a 32-bit per pacchetti. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Carica pixel parzialmente per pacchetti. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Carica pixel. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Unisce il livello al livello specificato |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Ridimensiona l'immagine. Viene utilizzato il NearestNeighbourResample predefinito. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Ridimensiona l'immagine. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Ridimensiona l'immagine. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Ridimensiona l'altezza proporzionalmente. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Ridimensiona la larghezza proporzionalmente. Viene utilizzato il NearestNeighbourResample predefinito. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Ruota l'immagine attorno al centro. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Ruota l'immagine attorno al centro. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Ruota, capovolge o ruota e capovolge l'immagine. |
+| [Save](../../aspose.psd/image/save/)() | Salva i dati dell'immagine nello stream sottostante. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Salva i dati dell'oggetto nello stream specificato. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Salva i dati dell'oggetto nella posizione file specificata. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Salva i dati dell'oggetto nella posizione file specificata. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Salva i pixel ARGB a 32 bit. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Salva i pixel. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo più efficace [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/). |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Salva i pixel. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Salva i dati grezzi. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Imposta un pixel ARGB a 32 bit dell'immagine per la posizione specificata. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Imposta la tavolozza dell'immagine. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Imposta un pixel dell'immagine per la posizione specificata. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Imposta la risoluzione per questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Crea una copia superficiale del Layer corrente. Si prega di [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) per spiegazione. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converte l'immagine raster in bitmap. |
+| [Update](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/)() | Aggiorna i dati del livello nella risorsa del livello correlata [`GrdmResource`](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/). |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello mappa gradiente.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Aggiungi un livello di regolazione mappa gradiente.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/_index.md
@@ -1,0 +1,67 @@
+---
+title: "GradientMapLayer.GradientSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientMapLayer. Ottiene o imposta l'istanza delle impostazioni del gradiente passata dall'istanza GrdmResource"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/
+---
+{{< psd/tize >}}
+## GradientMapLayer.GradientSettings property
+
+Ottiene o imposta l'istanza delle impostazioni Gradient passata dall'istanza GrdmResource.
+
+```csharp
+public GradientMapSettings GradientSettings { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello mappa gradiente.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Aggiungi un livello di regolazione mappa gradiente.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GradientMapSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/)
+* class [GradientMapLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientMapLayer.Update"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo GradientMapLayer. Aggiorna i dati del livello nella risorsa di livello correlata GrdmResource"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/
+---
+{{< psd/tize >}}
+## GradientMapLayer.Update method
+
+Aggiorna i dati del livello nella risorsa di livello correlata [`GrdmResource`](../../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/).
+
+```csharp
+public void Update()
+```
+
+### Vedi anche
+
+* class [GradientMapLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/_index.md
@@ -1,0 +1,277 @@
+---
+title: "Classe SelectiveColorLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.SelectiveColorLayer classe. Livello di regolazione colore selettivo"
+type: docs
+weight: 1900
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer class
+
+Livello di regolazione colore selettivo.
+
+```csharp
+public class SelectiveColorLayer : AdjustmentLayer
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Ottiene o imposta un valore che indica se regolare automaticamente la tavolozza. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Ottiene o imposta un valore per il colore di sfondo. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Ottiene il conteggio dei bit per pixel dell'immagine. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Ottiene o imposta la fusione dell'elemento ritagliato. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Ottiene le opzioni di fusione. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Ottiene la firma della modalità di fusione. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Ottiene o imposta la posizione del livello inferiore. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Ottiene i limiti dell'immagine. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Ottiene o imposta le informazioni del canale. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Ottiene il conteggio dei canali del livello. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Ottiene o imposta il ritaglio del livello. 0 = base, 1 = non-base. |
+| [Container](../../aspose.psd/image/container/) { get; } | Ottiene il contenitore [`Image`](../../aspose.psd/image/). |
+| [CorrectionMethod](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/) { get; set; } | Ottiene o imposta il metodo di correzione. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Ottiene il flusso di dati dell'oggetto. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Ottiene o imposta il nome visualizzato del livello. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Ottiene un valore che indica se questa istanza è stata eliminata. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Ottiene la lunghezza delle informazioni aggiuntive del livello in byte. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Ottiene un valore del formato file |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Ottiene o imposta il riempitore del livello. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Ottiene o imposta l'opacità del riempimento. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Ottiene o imposta i flag del livello. bit 0 = trasparenza protetta; bit 1 = visibile; bit 2 = obsoleto; bit 3 = 1 per Photoshop 5.0 e versioni successive, indica se il bit 4 contiene informazioni utili; bit 4 = dati pixel irrilevanti per l'aspetto del documento. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Ottiene un valore che indica se questa istanza ha alfa. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Ottiene o imposta un valore che indica se l'immagine ha un colore di sfondo. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Ottiene un valore che indica se l'immagine ha un colore trasparente. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Ottiene l'altezza dell'immagine. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Ottiene o imposta la risoluzione orizzontale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Ottiene l'opacità di questa immagine. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Ottiene o imposta il monitor di interruzione. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Restituisce un valore che indica se i dati dell'immagine sono attualmente memorizzati nella cache. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Restituisce un valore che indica se il caricamento dei dati grezzi è disponibile. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Ottiene o imposta un valore che indica se il livello è visibile |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Restituisce un valore che indica se questa istanza è visibile nel gruppo (se il livello non è in un gruppo significa gruppo radice). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Ottiene o imposta i dati degli intervalli di fusione del livello. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Ottiene o imposta la data e l'ora di creazione del livello. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Ottiene o imposta il blocco del livello. Nota che se il flag LayerFlags.TransparencyProtected è impostato verrà sovrascritto dal flag di blocco del livello. Per restituire il flag LayerFlags.TransparencyProtected è necessario applicarlo all'opzione del livello layer.Flags &#x7C;= LayerFlags.TransparencyProtected |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Ottiene o imposta i dati della maschera del livello. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Restituisce le opzioni del livello. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Ottiene o imposta la posizione sinistra del livello. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Restituisce la lunghezza complessiva del livello in byte. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Ottiene o imposta il nome del livello. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Ottiene o imposta l'opacità del livello. 0 = trasparente, 255 = opaco. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Ottiene o imposta la tavolozza dei colori. La tavolozza dei colori non viene utilizzata quando i pixel sono rappresentati direttamente. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Ottiene o imposta un valore che indica se i componenti dell'immagine devono essere premoltiplicati. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore personalizzato |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Restituisce il formato dei dati grezzi. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Restituisce le impostazioni attuali dei dati grezzi. Nota che quando si usano queste impostazioni i dati vengono caricati senza conversione. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Ottiene o imposta l'indice di fallback da utilizzare quando l'indice della tavolozza è fuori dai limiti |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore indicizzato |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Restituisce la dimensione della riga grezza in byte. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Ottiene o imposta le risorse del livello. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Ottiene o imposta la posizione destra del livello. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Ottiene o imposta l'evidenziazione del colore del foglio decorativo nell'elenco dei livelli. |
+| [Size](../../aspose.psd/image/size/) { get; } | Ottiene le dimensioni dell'immagine. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Ottiene o imposta la posizione del livello superiore. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Ottiene il colore trasparente dell'immagine. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Ottiene o imposta un valore che indica se aggiornare i metadati XMP. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Ottiene un valore che indica se la palette dell'immagine è utilizzata. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Ottiene o imposta un valore che indica se utilizzare il caricamento di dati grezzi quando è disponibile. |
+| [Version](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/) { get; } | Ottiene la versione. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Ottiene o imposta la risoluzione verticale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Ottiene la larghezza dell'immagine. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Ottiene o imposta i metadati XMP. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Aggiunge la maschera al livello corrente. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Regola la luminosità dell'immagine. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Contrasto dell'immagine |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Correzione gamma di un'immagine. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Correzione gamma di un'immagine. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Applica la maschera di livello al livello, quindi elimina la maschera. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarizzazione di un'immagine con soglia predefinita |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarizzazione di un'immagine con sogliatura di Otsu |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Memorizza nella cache i dati e garantisce che non vengano effettuati ulteriori caricamenti di dati dal [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/) sottostante. |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Determina se l'immagine può essere salvata nel formato file specificato rappresentato dalle opzioni di salvataggio fornite. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Ritaglio dell'immagine. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Ritaglia l'immagine con spostamenti. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Elimina l'istanza corrente. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Esegue il dithering sull'immagine corrente. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Esegue il dithering sull'immagine corrente. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Disegna l'immagine sul livello. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtra il rettangolo specificato. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Ottiene un pixel immagine a 32-bit ARGB. |
+| [GetCmykCorrection](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/)(SelectiveColorsTypes) | Ottiene la correzione cmyk per colore selettivo. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Ottiene l'array predefinito di pixel ARGB a 32-bit. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Ottiene le opzioni predefinite. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Ottiene l'array predefinito di pixel usando il caricatore di pixel parziali. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Ottiene l'array predefinito di dati grezzi. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Ottiene l'array predefinito di dati grezzi usando il caricatore di pixel parziali. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Restituisce un codice hash per questa istanza. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Ottiene la data e l'ora dell'ultima modifica dell'immagine di risorsa. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Ottiene le opzioni basate sulle impostazioni del file originale. Questo può essere utile per mantenere inalterata la profondità di bit e altri parametri dell'immagine originale. Ad esempio, se carichiamo un'immagine PNG in bianco e nero a 1 bit per pixel e poi la salviamo usando il metodo [`Save`](../../aspose.psd/datastreamsupporter/save/), verrà generata un'immagine PNG di output a 8 bit per pixel. Per evitarlo e salvare l'immagine PNG a 1 bit per pixel, utilizza questo metodo per ottenere le opzioni di salvataggio corrispondenti e passale al metodo [`Save`](../../aspose.psd/image/save/) come secondo parametro. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Ottiene un pixel immagine. Avviso sulle prestazioni: evita di utilizzare questo metodo per iterare su tutti i pixel dell'immagine poiché può causare notevoli problemi di prestazioni. Per una manipolazione dei pixel più efficiente, utilizza il metodo `LoadArgb32Pixels` per recuperare l'intero array di pixel simultaneamente. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Ottiene l'angolo di inclinazione. Questo metodo è applicabile ai documenti di testo scansionati, per determinare l'angolo di inclinazione durante la scansione. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Trasformazione di un'immagine nella sua rappresentazione in scala di grigi |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Carica pixel ARGB a 32-bit. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Carica pixel ARGB a 64-bit. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Carica pixel in formato CMYK. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Carica pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare in modo più efficace il metodo [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/). |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Carica parzialmente pixel ARGB a 32-bit per pacchetti. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Carica pixel parzialmente per pacchetti. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Carica pixel. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Unisce il livello al livello specificato |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Ridimensiona l'immagine. Viene utilizzato il NearestNeighbourResample predefinito. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Ridimensiona l'immagine. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Ridimensiona l'immagine. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Ridimensiona l'altezza proporzionalmente. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Ridimensiona la larghezza proporzionalmente. Viene utilizzato il NearestNeighbourResample predefinito. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Ruota l'immagine attorno al centro. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Ruota l'immagine attorno al centro. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Ruota, capovolge o ruota e capovolge l'immagine. |
+| [Save](../../aspose.psd/image/save/)() | Salva i dati dell'immagine nello stream sottostante. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Salva i dati dell'oggetto nello stream specificato. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Salva i dati dell'oggetto nella posizione file specificata. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Salva i dati dell'oggetto nella posizione file specificata. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Salva i pixel ARGB a 32 bit. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Salva i pixel. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo più efficace [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/). |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Salva i pixel. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Salva i dati grezzi. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Imposta un pixel ARGB a 32 bit dell'immagine per la posizione specificata. |
+| [SetCmykCorrection](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/)(SelectiveColorsTypes, CmykCorrection) | Imposta la correzione cmyk per colore selettivo. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Imposta la tavolozza dell'immagine. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Imposta un pixel dell'immagine per la posizione specificata. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Imposta la risoluzione per questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Crea una copia superficiale del Layer corrente. Si prega di [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) per spiegazione. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converte l'immagine raster in bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/_index.md
@@ -1,0 +1,124 @@
+---
+title: "SelectiveColorLayer.CorrectionMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "SelectiveColorLayer proprietà. Ottiene o imposta il metodo di correzione"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.CorrectionMethod property
+
+Ottiene o imposta il metodo di correzione.
+
+```csharp
+public CorrectionMethodTypes CorrectionMethod { get; set; }
+```
+
+### Property Value
+
+Il metodo di correzione.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* enum [CorrectionMethodTypes](../../correctionmethodtypes/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/_index.md
@@ -1,0 +1,129 @@
+---
+title: "SelectiveColorLayer.GetCmykCorrection"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "SelectiveColorLayer metodo. Ottiene la correzione cmyk per colore selettivo"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.GetCmykCorrection method
+
+Ottiene la correzione cmyk per colore selettivo.
+
+```csharp
+public CmykCorrection GetCmykCorrection(SelectiveColorsTypes selectiveColorsType)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| selectiveColorsType | SelectiveColorsTypes | Colori selettivi. |
+
+### Valore di ritorno
+
+Correzione Cmyk.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [CmykCorrection](../../cmykcorrection/)
+* enum [SelectiveColorsTypes](../../selectivecolorstypes/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/_index.md
@@ -1,0 +1,126 @@
+---
+title: "SelectiveColorLayer.SetCmykCorrection"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "SelectiveColorLayer metodo. Imposta la correzione cmyk per colore selettivo"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.SetCmykCorrection method
+
+Imposta la correzione cmyk per colore selettivo.
+
+```csharp
+public void SetCmykCorrection(SelectiveColorsTypes selectiveColorsType, CmykCorrection correction)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| selectiveColorsType | SelectiveColorsTypes | Tipo dei colori selettivi. |
+| correzione | CmykCorrection | Correzione Cmyk. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* enum [SelectiveColorsTypes](../../selectivecolorstypes/)
+* class [CmykCorrection](../../cmykcorrection/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SelectiveColorLayer.Version"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "SelectiveColorLayer proprietà. Ottiene la versione"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.Version property
+
+Ottiene la versione.
+
+```csharp
+public short Version { get; }
+```
+
+### Property Value
+
+La versione.
+
+### Vedi anche
+
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/_index.md
@@ -1,0 +1,132 @@
+---
+title: "Enum SelectiveColorsTypes"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Enum Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.SelectiveColorsTypes. Tipi di colore nel livello di regolazione colore selettivo"
+type: docs
+weight: 1910
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/
+---
+{{< psd/tize >}}
+## SelectiveColorsTypes enumeration
+
+Tipi di colore nel livello di regolazione colore selettivo.
+
+```csharp
+public enum SelectiveColorsTypes
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Reds | `0` | I colori rossi. |
+| Yellows | `1` | I colori gialli. |
+| Greens | `2` | I colori verdi. |
+| Cyans | `3` | I colori ciano. |
+| Blues | `4` | I colori blu. |
+| Magentas | `5` | I colori magenta. |
+| Whites | `6` | I colori bianchi. |
+| Neutrals | `7` | I colori neutri. |
+| Blacks | `8` | I colori neri. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/_index.md
@@ -1,0 +1,239 @@
+---
+title: "Classe ThresholdLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.ThresholdLayer classe. Livello di regolazione soglia"
+type: docs
+weight: 1920
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/
+---
+{{< psd/tize >}}
+## ThresholdLayer class
+
+Livello di regolazione soglia.
+
+```csharp
+public class ThresholdLayer : AdjustmentLayer
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Ottiene o imposta un valore che indica se regolare automaticamente la tavolozza. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Ottiene o imposta un valore per il colore di sfondo. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Ottiene il conteggio dei bit per pixel dell'immagine. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Ottiene o imposta la fusione dell'elemento ritagliato. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Ottiene le opzioni di fusione. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Ottiene la firma della modalità di fusione. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Ottiene o imposta la posizione del livello inferiore. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Ottiene i limiti dell'immagine. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Ottiene o imposta le informazioni del canale. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Ottiene il conteggio dei canali del livello. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Ottiene o imposta il ritaglio del livello. 0 = base, 1 = non-base. |
+| [Container](../../aspose.psd/image/container/) { get; } | Ottiene il contenitore [`Image`](../../aspose.psd/image/). |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Ottiene il flusso di dati dell'oggetto. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Ottiene o imposta il nome visualizzato del livello. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Ottiene un valore che indica se questa istanza è stata eliminata. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Ottiene la lunghezza delle informazioni aggiuntive del livello in byte. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Ottiene un valore del formato file |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Ottiene o imposta il riempitore del livello. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Ottiene o imposta l'opacità del riempimento. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Ottiene o imposta i flag del livello. bit 0 = trasparenza protetta; bit 1 = visibile; bit 2 = obsoleto; bit 3 = 1 per Photoshop 5.0 e versioni successive, indica se il bit 4 contiene informazioni utili; bit 4 = dati pixel irrilevanti per l'aspetto del documento. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Ottiene un valore che indica se questa istanza ha alfa. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Ottiene o imposta un valore che indica se l'immagine ha un colore di sfondo. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Ottiene un valore che indica se l'immagine ha un colore trasparente. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Ottiene l'altezza dell'immagine. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Ottiene o imposta la risoluzione orizzontale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Ottiene l'opacità di questa immagine. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Ottiene o imposta il monitor di interruzione. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Restituisce un valore che indica se i dati dell'immagine sono attualmente memorizzati nella cache. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Restituisce un valore che indica se il caricamento dei dati grezzi è disponibile. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Ottiene o imposta un valore che indica se il livello è visibile |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Restituisce un valore che indica se questa istanza è visibile nel gruppo (se il livello non è in un gruppo significa gruppo radice). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Ottiene o imposta i dati degli intervalli di fusione del livello. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Ottiene o imposta la data e l'ora di creazione del livello. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Ottiene o imposta il blocco del livello. Nota che se il flag LayerFlags.TransparencyProtected è impostato verrà sovrascritto dal flag di blocco del livello. Per restituire il flag LayerFlags.TransparencyProtected è necessario applicarlo all'opzione del livello layer.Flags &#x7C;= LayerFlags.TransparencyProtected |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Ottiene o imposta i dati della maschera del livello. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Restituisce le opzioni del livello. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Ottiene o imposta la posizione sinistra del livello. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Restituisce la lunghezza complessiva del livello in byte. |
+| [Level](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/) { get; set; } | Ottiene e imposta il livello di soglia. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Ottiene o imposta il nome del livello. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Ottiene o imposta l'opacità del livello. 0 = trasparente, 255 = opaco. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Ottiene o imposta la tavolozza dei colori. La tavolozza dei colori non viene utilizzata quando i pixel sono rappresentati direttamente. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Ottiene o imposta un valore che indica se i componenti dell'immagine devono essere premoltiplicati. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore personalizzato |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Restituisce il formato dei dati grezzi. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Restituisce le impostazioni attuali dei dati grezzi. Nota che quando si usano queste impostazioni i dati vengono caricati senza conversione. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Ottiene o imposta l'indice di fallback da utilizzare quando l'indice della tavolozza è fuori dai limiti |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore indicizzato |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Restituisce la dimensione della riga grezza in byte. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Ottiene o imposta le risorse del livello. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Ottiene o imposta la posizione destra del livello. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Ottiene o imposta l'evidenziazione del colore del foglio decorativo nell'elenco dei livelli. |
+| [Size](../../aspose.psd/image/size/) { get; } | Ottiene le dimensioni dell'immagine. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Ottiene o imposta la posizione del livello superiore. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Ottiene il colore trasparente dell'immagine. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Ottiene o imposta un valore che indica se aggiornare i metadati XMP. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Ottiene un valore che indica se la palette dell'immagine è utilizzata. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Ottiene o imposta un valore che indica se utilizzare il caricamento di dati grezzi quando è disponibile. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Ottiene o imposta la risoluzione verticale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Ottiene la larghezza dell'immagine. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Ottiene o imposta i metadati XMP. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Aggiunge la maschera al livello corrente. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Regola la luminosità dell'immagine. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Contrasto dell'immagine |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Correzione gamma di un'immagine. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Correzione gamma di un'immagine. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Applica la maschera di livello al livello, quindi elimina la maschera. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarizzazione di un'immagine con soglia predefinita |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarizzazione di un'immagine con sogliatura di Otsu |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Memorizza nella cache i dati e garantisce che non vengano effettuati ulteriori caricamenti di dati dal [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/) sottostante. |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Determina se l'immagine può essere salvata nel formato file specificato rappresentato dalle opzioni di salvataggio fornite. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Ritaglio dell'immagine. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Ritaglia l'immagine con spostamenti. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Elimina l'istanza corrente. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Esegue il dithering sull'immagine corrente. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Esegue il dithering sull'immagine corrente. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Disegna l'immagine sul livello. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtra il rettangolo specificato. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Ottiene un pixel immagine a 32-bit ARGB. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Ottiene l'array predefinito di pixel ARGB a 32-bit. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Ottiene le opzioni predefinite. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Ottiene l'array predefinito di pixel usando il caricatore di pixel parziali. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Ottiene l'array predefinito di dati grezzi. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Ottiene l'array predefinito di dati grezzi usando il caricatore di pixel parziali. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Restituisce un codice hash per questa istanza. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Ottiene la data e l'ora dell'ultima modifica dell'immagine di risorsa. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Ottiene le opzioni basate sulle impostazioni del file originale. Questo può essere utile per mantenere inalterata la profondità di bit e altri parametri dell'immagine originale. Ad esempio, se carichiamo un'immagine PNG in bianco e nero a 1 bit per pixel e poi la salviamo usando il metodo [`Save`](../../aspose.psd/datastreamsupporter/save/), verrà generata un'immagine PNG di output a 8 bit per pixel. Per evitarlo e salvare l'immagine PNG a 1 bit per pixel, utilizza questo metodo per ottenere le opzioni di salvataggio corrispondenti e passale al metodo [`Save`](../../aspose.psd/image/save/) come secondo parametro. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Ottiene un pixel immagine. Avviso sulle prestazioni: evita di utilizzare questo metodo per iterare su tutti i pixel dell'immagine poiché può causare notevoli problemi di prestazioni. Per una manipolazione dei pixel più efficiente, utilizza il metodo `LoadArgb32Pixels` per recuperare l'intero array di pixel simultaneamente. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Ottiene l'angolo di inclinazione. Questo metodo è applicabile ai documenti di testo scansionati, per determinare l'angolo di inclinazione durante la scansione. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Trasformazione di un'immagine nella sua rappresentazione in scala di grigi |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Carica pixel ARGB a 32-bit. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Carica pixel ARGB a 64-bit. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Carica pixel in formato CMYK. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Carica pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare in modo più efficace il metodo [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/). |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Carica parzialmente pixel ARGB a 32-bit per pacchetti. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Carica pixel parzialmente per pacchetti. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Carica pixel. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Unisce il livello al livello specificato |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Ridimensiona l'immagine. Viene utilizzato il NearestNeighbourResample predefinito. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Ridimensiona l'immagine. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Ridimensiona l'immagine. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Ridimensiona l'altezza proporzionalmente. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Ridimensiona la larghezza proporzionalmente. Viene utilizzato il NearestNeighbourResample predefinito. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Ruota l'immagine attorno al centro. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Ruota l'immagine attorno al centro. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Ruota, capovolge o ruota e capovolge l'immagine. |
+| [Save](../../aspose.psd/image/save/)() | Salva i dati dell'immagine nello stream sottostante. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Salva i dati dell'oggetto nello stream specificato. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Salva i dati dell'oggetto nella posizione file specificata. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Salva i dati dell'oggetto nella posizione file specificata. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Salva i pixel ARGB a 32 bit. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Salva i pixel. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo più efficace [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/). |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Salva i pixel. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Salva i dati grezzi. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Imposta un pixel ARGB a 32 bit dell'immagine per la posizione specificata. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Imposta la tavolozza dell'immagine. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Imposta un pixel dell'immagine per la posizione specificata. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Imposta la risoluzione per questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Crea una copia superficiale del Layer corrente. Si prega di [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) per spiegazione. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converte l'immagine raster in bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione ThresholdLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Threshold dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Ottieni il livello di regolazione Threshold.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(level, (short)115);
+
+            // Imposta i parametri dei livelli.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Threshold sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Aggiungi livello di regolazione Threshold.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/_index.md
@@ -1,0 +1,88 @@
+---
+title: "ThresholdLayer.Level"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ThresholdLayer proprietà. Ottiene e imposta il livello di soglia"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/
+---
+{{< psd/tize >}}
+## ThresholdLayer.Level property
+
+Ottiene e imposta il livello di soglia.
+
+```csharp
+public short Level { get; set; }
+```
+
+### Property Value
+
+Il livello.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione ThresholdLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Threshold dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Ottieni il livello di regolazione Threshold.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(level, (short)115);
+
+            // Imposta i parametri dei livelli.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Threshold sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Aggiungi livello di regolazione Threshold.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [ThresholdLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/_index.md
@@ -1,0 +1,49 @@
+---
+title: "Timeline.ActiveFrameIndex"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà Timeline. Ottiene l'indice del fotogramma attivo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/
+---
+{{< psd/tize >}}
+## Timeline.ActiveFrameIndex property
+
+Ottiene l'indice del fotogramma attivo.
+
+```csharp
+public int ActiveFrameIndex { get; }
+```
+
+## Esempi
+
+Il codice seguente dimostra un nuovo approccio per lavorare con la Timeline.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Aggiungi un altro fotogramma
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Vedi anche
+
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/_index.md
@@ -1,0 +1,84 @@
+---
+title: "Timeline.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Timeline. Salva le PsdImages e i dati della Timeline nella posizione file specificata nel formato specificato secondo le opzioni di salvataggio"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/
+---
+{{< psd/tize >}}
+## Save(string, ImageOptionsBase) {#save_1}
+
+Salva le PsdImage e i dati della Timeline nella posizione file specificata nel formato specificato secondo le opzioni di salvataggio.
+
+```csharp
+public void Save(string filePath, ImageOptionsBase options)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| filePath | Stringa | Il percorso del file. |
+| options | ImageOptionsBase | Le opzioni. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione della Timeline in un'immagine Gif.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputGif = "out_4_animated.psd.gif";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Timeline.Save(outputGif, new GifOptions());
+}
+```
+
+### Vedi anche
+
+* class [ImageOptionsBase](../../../aspose.psd/imageoptionsbase/)
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## Save(Stream, ImageOptionsBase) {#save}
+
+Salva le PsdImage e i dati della Timeline nello stream specificato nel formato specificato secondo le opzioni di salvataggio.
+
+```csharp
+public void Save(Stream outputStream, ImageOptionsBase options)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| outputStream | Flusso | Lo stream di output. |
+| options | ImageOptionsBase | Le opzioni. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione della Timeline in un'immagine Gif.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputGif = "out_4_animated.psd.gif";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Timeline.Save(outputGif, new GifOptions());
+}
+```
+
+### Vedi anche
+
+* class [ImageOptionsBase](../../../aspose.psd/imageoptionsbase/)
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/_index.md
@@ -1,0 +1,59 @@
+---
+title: "Timeline.SwitchActiveFrame"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Timeline. Cambia il fotogramma attivo a quello destinato"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/
+---
+{{< psd/tize >}}
+## Timeline.SwitchActiveFrame method
+
+Cambia il fotogramma attivo a quello destinato.
+
+```csharp
+public void SwitchActiveFrame(int targetActiveFrameIndex)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| targetActiveFrameIndex | Int32 | L'indice del fotogramma di destinazione. |
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| IndexOutOfRangeException | Il nuovo indice del fotogramma attivo deve rientrare nell'intervallo del conteggio dei fotogrammi. |
+
+## Esempi
+
+Il codice seguente dimostra un nuovo approccio per lavorare con la Timeline.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Aggiungi un altro fotogramma
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Vedi anche
+
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Classe BaseGradientFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.BaseGradientFillSettings classe. Classe di definizione del gradiente di base. Contiene proprietà comuni per entrambi i tipi di gradiente Solido e Rumore."
+type: docs
+weight: 2030
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings class
+
+Classe di definizione del gradiente di base. Contiene proprietà comuni per entrambi i tipi di gradiente (Solido e Rumore).
+
+```csharp
+public abstract class BaseGradientFillSettings : BaseFillSettings, IGradientFillSettings
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [BaseGradientFillSettings](basegradientfillsettings/)() | Inizializza una nuova istanza della classe `BaseGradientFillSettings`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AlignWithLayer](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/) { get; set; } | Ottiene o imposta un valore che indica se [allinea con il livello]. |
+| [Angle](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/) { get; set; } | Ottiene o imposta l'angolo. |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/) { get; set; } | Ottiene o imposta un valore che indica se questo `BaseGradientFillSettings` è dither. |
+| override [FillType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/) { get; } | Il tipo di riempimento. |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/) { get; } | Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/) { get; set; } | Ottiene o imposta il nome del gradiente. |
+| [GradientType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/) { get; set; } | Ottiene o imposta il tipo del gradiente. |
+| [HorizontalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/) { get; set; } | Ottiene o imposta lo spostamento orizzontale in percentuale. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/) { get; set; } | Ottiene o imposta un valore che indica se questo `BaseGradientFillSettings` è invertito. |
+| [Scale](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/) { get; set; } | Ottiene o imposta la scala. |
+| [VerticalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/) { get; set; } | Ottiene o imposta lo spostamento verticale in percentuale. |
+
+### Vedi anche
+
+* class [BaseFillSettings](../basefillsettings/)
+* interface [IGradientFillSettings](../igradientfillsettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.AlignWithLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta un valore che indica se allineare con il livello"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.AlignWithLayer property
+
+Ottiene o imposta un valore che indica se [allinea con il livello].
+
+```csharp
+public bool AlignWithLayer { get; set; }
+```
+
+### Property Value
+
+`true` se [allinea con il livello]; altrimenti, `false`.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/_index.md
@@ -1,0 +1,34 @@
+---
+title: "BaseGradientFillSettings.Angle"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta l'angolo"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Angle property
+
+Ottiene o imposta l'angolo.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+L'angolo.
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | L'angolo deve essere nell'intervallo da -180.0 a 180.0 |
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseGradientFillSettings.BaseGradientFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore BaseGradientFillSettings. Inizializza una nuova istanza della classe BaseGradientFillSettings"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings constructor
+
+Inizializza una nuova istanza della classe [`BaseGradientFillSettings`](../).
+
+```csharp
+public BaseGradientFillSettings()
+```
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.Color"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta il colore"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Color property
+
+Ottiene o imposta il colore.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+Il colore.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.ColorPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta i punti di colore"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.ColorPoints property
+
+Ottiene o imposta i punti di colore.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+I punti di colore.
+
+### Vedi anche
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.Dither"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta un valore che indica se questo BaseGradientFillSettings è dither"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Dither property
+
+Ottiene o imposta un valore che indica se questo [`BaseGradientFillSettings`](../) è dither.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+### Property Value
+
+`true` se dither; altrimenti, `false`.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradientFillSettings.FillType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseGradientFillSettings proprietà. Il tipo di riempimento"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.FillType property
+
+Il tipo di riempimento.
+
+```csharp
+public override FillType FillType { get; }
+```
+
+### Vedi anche
+
+* enum [FillType](../../filltype/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradientFillSettings.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene la modalità per questo gradiente. Determina Gradient Type  Solid/Noise 0/1"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientMode property
+
+Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; }
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.GradientName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta il nome del gradiente"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientName property
+
+Ottiene o imposta il nome del gradiente.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+### Property Value
+
+Il nome del gradiente.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/_index.md
@@ -1,0 +1,29 @@
+---
+title: "BaseGradientFillSettings.GradientType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta il tipo del gradiente"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientType property
+
+Ottiene o imposta il tipo del gradiente.
+
+```csharp
+public GradientType GradientType { get; set; }
+```
+
+### Property Value
+
+Il tipo del gradiente.
+
+### Vedi anche
+
+* enum [GradientType](../../gradienttype/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.HorizontalOffset"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta lo spostamento orizzontale in percentuale"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.HorizontalOffset property
+
+Ottiene o imposta lo spostamento orizzontale in percentuale.
+
+```csharp
+public double HorizontalOffset { get; set; }
+```
+
+### Property Value
+
+Lo spostamento orizzontale.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.Reverse"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta un valore che indica se questo BaseGradientFillSettings è invertito"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Reverse property
+
+Ottiene o imposta un valore che indica se questo [`BaseGradientFillSettings`](../) è invertito.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+### Property Value
+
+`true` se invertito; altrimenti, `false`.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/_index.md
@@ -1,0 +1,34 @@
+---
+title: "BaseGradientFillSettings.Scale"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta la scala"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Scale property
+
+Ottiene o imposta la scala.
+
+```csharp
+public int Scale { get; set; }
+```
+
+### Property Value
+
+La scala.
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | La scala deve essere nell'intervallo da 1 a 1000. |
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.TransparencyPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta i punti di trasparenza"
+type: docs
+weight: 140
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.TransparencyPoints property
+
+Ottiene o imposta i punti di trasparenza.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+I punti di trasparenza.
+
+### Vedi anche
+
+* interface [IGradientTransparencyPoint](../../igradienttransparencypoint/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.VerticalOffset"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradientFillSettings. Ottiene o imposta lo spostamento verticale in percentuale"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.VerticalOffset property
+
+Ottiene o imposta lo spostamento verticale in percentuale.
+
+```csharp
+public double VerticalOffset { get; set; }
+```
+
+### Property Value
+
+Lo spostamento verticale.
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ColorFillSettings.ColorFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore di ColorFillSettings. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/
+---
+{{< psd/tize >}}
+## ColorFillSettings constructor
+
+Il costruttore predefinito.
+
+```csharp
+public ColorFillSettings()
+```
+
+### Vedi anche
+
+* class [ColorFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "GradientColorPoint.Color"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientColorPoint. Ottiene o imposta il colore"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/
+---
+{{< psd/tize >}}
+## GradientColorPoint.Color property
+
+Ottiene o imposta il colore.
+
+```csharp
+[Obsolete]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+Il colore.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [GradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GradientColorPoint.ColorMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientColorPoint. Modalità per il colore da seguire"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/
+---
+{{< psd/tize >}}
+## GradientColorPoint.ColorMode property
+
+Modalità per il colore da seguire
+
+```csharp
+public short ColorMode { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GradientFillSettings.Gradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GradientFillSettings proprietà. Ottiene o imposta l'istanza di definizione del gradiente specifico Solid/Noise"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/
+---
+{{< psd/tize >}}
+## GradientFillSettings.Gradient property
+
+Ottiene o imposta l'istanza di definizione del gradiente specifico (Solido/Rumore).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+### Vedi anche
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientFillSettings.Interpolation"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GradientFillSettings proprietà. Ottiene o imposta Interpolation. Determina la fluidità quando Gradient Type  Solid. Intervallo di valori 04096"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/
+---
+{{< psd/tize >}}
+## GradientFillSettings.Interpolation property
+
+Ottiene o imposta l'interpolazione. Determina la fluidità, quando 'Gradient Type' = 'Solid'. Intervallo di valori: 0-4096.
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Vedi anche
+
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GradientFillSettings.InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GradientFillSettings proprietà. Ottiene o imposta il metodo di interpolazione per il gradiente"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## GradientFillSettings.InterpolationMethod property
+
+Ottiene o imposta il metodo di interpolazione per il gradiente.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Classe GradientMapSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.GradientMapSettings classe. Classe delle impostazioni di gradiente per il livello mappa gradiente. Contiene proprietà comuni per entrambi i tipi di gradiente Solido e Rumore."
+type: docs
+weight: 2080
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/
+---
+{{< psd/tize >}}
+## GradientMapSettings class
+
+Classe delle impostazioni di gradiente per il livello mappa gradiente. Contiene proprietà comuni per entrambi i tipi di gradiente (Solido e Rumore).
+
+```csharp
+public class GradientMapSettings
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [GradientMapSettings](gradientmapsettings/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/) { get; set; } | Ottiene o imposta un valore che indica se questo [`GradientFillSettings`](../gradientfillsettings/) è dither. |
+| [Gradient](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/) { get; set; } | Ottiene o imposta l'istanza di definizione del gradiente specifico (Solido/Rumore). |
+| [InterpolationMethod](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/) { get; set; } | Ottiene o imposta il metodo di interpolazione per il gradiente. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/) { get; set; } | Ottiene o imposta un valore che indica se questo [`GradientFillSettings`](../gradientfillsettings/) è invertito. |
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GradientMapSettings.Dither"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientMapSettings. Ottiene o imposta un valore che indica se questo GradientFillSettings è dither"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Dither property
+
+Ottiene o imposta un valore che indica se questo [`GradientFillSettings`](../../gradientfillsettings/) è dither.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+### Property Value
+
+`true` se dither; altrimenti, `false`.
+
+### Vedi anche
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/_index.md
@@ -1,0 +1,133 @@
+---
+title: "GradientMapSettings.Gradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientMapSettings. Ottiene o imposta l'istanza di definizione del gradiente specifico Solido/Rumore"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Gradient property
+
+Ottiene o imposta l'istanza di definizione del gradiente specifico (Solido/Rumore).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientMapSettings.GradientMapSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore di GradientMapSettings. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/
+---
+{{< psd/tize >}}
+## GradientMapSettings constructor
+
+Il costruttore predefinito.
+
+```csharp
+public GradientMapSettings()
+```
+
+### Vedi anche
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GradientMapSettings.InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientMapSettings. Ottiene o imposta il metodo di interpolazione per il gradiente"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## GradientMapSettings.InterpolationMethod property
+
+Ottiene o imposta il metodo di interpolazione per il gradiente.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GradientMapSettings.Reverse"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GradientMapSettings. Ottiene o imposta un valore che indica se questo GradientFillSettings è invertito"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Reverse property
+
+Ottiene o imposta un valore che indica se questo [`GradientFillSettings`](../../gradientfillsettings/) è invertito.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+### Property Value
+
+`true` se invertito; altrimenti, `false`.
+
+### Vedi anche
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IGradientFillSettings.Gradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IGradientFillSettings proprietà. Ottiene o imposta l'istanza di definizione del gradiente specifico Solid/Noise"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.Gradient property
+
+Ottiene o imposta l'istanza di definizione del gradiente specifico (Solido/Rumore).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IGradientFillSettings.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IGradientFillSettings proprietà. Ottiene la modalità del gradiente. Determina il tipo di gradiente Solid/Noise 0/1"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.GradientMode property
+
+Ottiene la modalità del gradiente. Determina 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; }
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "IGradientFillSettings.InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IGradientFillSettings proprietà. Ottiene o imposta il metodo di interpolazione per il gradiente"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.InterpolationMethod property
+
+Ottiene o imposta il metodo di interpolazione per il gradiente.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/_index.md
@@ -1,0 +1,84 @@
+---
+title: "Enum InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.InterpolationMethod enum. Valori fourCC impacchettati per il metodo di interpolazione del gradiente di Photoshop. Chiave del descrittore gradientsInterpolationMethod"
+type: docs
+weight: 2160
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## InterpolationMethod enumeration
+
+Valori fourCC impacchettati per il metodo di interpolazione del gradiente di Photoshop. Chiave del descrittore: "gradientsInterpolationMethod"
+
+```csharp
+public enum InterpolationMethod : uint
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Classic | `1197698163` | 'Gcls' — Classico (predefinito legacy quando la chiave è assente). |
+| Perceptual | `1348825699` | 'Perc' — Percepito. |
+| Linear | `1282306592` | 'Lnr ' — Lineare (nota lo spazio finale). |
+| Smooth | `1399680879` | 'Smoo' — Liscio. |
+| Stripes | `1195986291` | 'GIMs' — Strisce. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/_index.md
@@ -1,0 +1,28 @@
+---
+title: "IPatternFillSettings.Angle"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IPatternFillSettings. Ottiene o imposta l'angolo"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/
+---
+{{< psd/tize >}}
+## IPatternFillSettings.Angle property
+
+Ottiene o imposta l'angolo.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+L'angolo.
+
+### Vedi anche
+
+* interface [IPatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Classe NoiseGradientFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.FillSettings.NoiseGradientFillSettings. Classe di definizione del gradiente di rumore"
+type: docs
+weight: 2150
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings class
+
+Classe di definizione del gradiente di rumore.
+
+```csharp
+public class NoiseGradientFillSettings : BaseGradientFillSettings
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [NoiseGradientFillSettings](noisegradientfillsettings/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AlignWithLayer](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/) { get; set; } | Ottiene o imposta un valore che indica se [allinea con il livello]. |
+| [Angle](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/) { get; set; } | Ottiene o imposta l'angolo. |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/) { get; set; } | Ottiene o imposta il modello di colore - RGB/HSB/LAB (3/4/6). |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/) { get; set; } | Ottiene o imposta un valore che indica se questo [`BaseGradientFillSettings`](../basegradientfillsettings/) è dither. |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/) { get; set; } | Ottiene o imposta il conteggio di espansione ( = 2 per Photoshop 6.0). |
+| override [FillType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/) { get; } | Il tipo di riempimento. |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/) { get; } | Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/) { get; set; } | Ottiene o imposta il nome del gradiente. |
+| [GradientType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/) { get; set; } | Ottiene o imposta il tipo del gradiente. |
+| [HorizontalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/) { get; set; } | Ottiene o imposta lo spostamento orizzontale in percentuale. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/) { get; set; } | Ottiene o imposta il colore massimo di PixelDataFormat. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/) { get; set; } | Ottiene o imposta il colore minimo di PixelDataFormat. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/) { get; set; } | Ottiene o imposta un valore che indica se questo [`BaseGradientFillSettings`](../basegradientfillsettings/) è invertito. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/) { get; set; } | Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente di rumore |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/) { get; set; } | Ottiene o imposta il fattore di rugosità. |
+| [Scale](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/) { get; set; } | Ottiene o imposta la scala. |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/) { get; set; } | Ottiene o imposta il flag per mostrare la trasparenza. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/) { get; set; } | Ottiene o imposta il flag per l'uso del colore vettoriale. |
+| [VerticalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/) { get; set; } | Ottiene o imposta lo spostamento verticale in percentuale. |
+
+### Vedi anche
+
+* class [BaseGradientFillSettings](../basegradientfillsettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.ColorModel"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "NoiseGradientFillSettings proprietà. Ottiene o imposta il modello di colore RGB/HSB/LAB 3/4/6"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ColorModel property
+
+Ottiene o imposta il modello di colore - RGB/HSB/LAB (3/4/6).
+
+```csharp
+public NoiseColorModel ColorModel { get; set; }
+```
+
+### Vedi anche
+
+* enum [NoiseColorModel](../../../aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "NoiseGradientFillSettings.ExpansionCount"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "NoiseGradientFillSettings proprietà. Ottiene o imposta il conteggio di espansione   2 per Photoshop 6.0"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ExpansionCount property
+
+Ottiene o imposta il conteggio di espansione ( = 2 per Photoshop 6.0).
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello mappa gradiente.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Aggiungi un livello di regolazione mappa gradiente.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    GradientFillSettings gradientSettings = (GradientFillSettings)gradientMapLayer.GradientSettings;
+
+    AssertAreEqual(90.0, gradientSettings.Angle);
+    AssertAreEqual((short)4096, gradientSettings.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(true, gradientSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual(GradientType.Linear, gradientSettings.GradientType);
+    AssertAreEqual(100, gradientSettings.Scale);
+    AssertAreEqual(0.0, gradientSettings.HorizontalOffset);
+    AssertAreEqual(0.0, gradientSettings.VerticalOffset);
+    AssertAreEqual("Custom", gradientSettings.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.MaximumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradientFillSettings. Ottiene o imposta il colore massimo di PixelDataFormat"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.MaximumColor property
+
+Ottiene o imposta il colore massimo di PixelDataFormat.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.MinimumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "NoiseGradientFillSettings proprietà. Ottiene o imposta il colore minimo di PixelDataFormat"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.MinimumColor property
+
+Ottiene o imposta il colore minimo di PixelDataFormat.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.NoiseGradientFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore NoiseGradientFillSettings. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings constructor
+
+Il costruttore predefinito.
+
+```csharp
+public NoiseGradientFillSettings()
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.RndNumberSeed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "NoiseGradientFillSettings proprietà. Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente Noise"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.RndNumberSeed property
+
+Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente di rumore
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.Roughness"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "NoiseGradientFillSettings proprietà. Ottiene o imposta il fattore di rugosità"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.Roughness property
+
+Ottiene o imposta il fattore di rugosità.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.ShowTransparency"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradientFillSettings. Ottiene o imposta il flag per mostrare la trasparenza"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ShowTransparency property
+
+Ottiene o imposta il flag per mostrare la trasparenza.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.UseVectorColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradientFillSettings. Ottiene o imposta il flag per l'uso del colore vettoriale"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.UseVectorColor property
+
+Ottiene o imposta il flag per l'uso del colore vettoriale.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PatternFillSettings.Angle"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PatternFillSettings. Ottiene o imposta l'angolo"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/
+---
+{{< psd/tize >}}
+## PatternFillSettings.Angle property
+
+Ottiene o imposta l'angolo.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+L'angolo.
+
+### Vedi anche
+
+* class [PatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PatternFillSettings.PatternFillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore di PatternFillSettings. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/
+---
+{{< psd/tize >}}
+## PatternFillSettings constructor
+
+Il costruttore predefinito.
+
+```csharp
+public PatternFillSettings()
+```
+
+### Vedi anche
+
+* class [PatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Layers.Gradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Lo spazio dei nomi gestisce l'elaborazione del formato file Psd"
+type: docs
+weight: 280
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/
+---
+{{< psd/tize >}}
+Lo spazio dei nomi gestisce l'elaborazione del formato file Psd.
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [BaseGradient](./basegradient/) | Classe di definizione del gradiente di base. Contiene proprietà comuni per entrambi i tipi di gradiente (Solido e Rumore). |
+| [NoiseGradient](./noisegradient/) | Classe di definizione del gradiente di rumore. |
+| [SolidGradient](./solidgradient/) | Impostazioni dell'effetto di riempimento gradiente. |
+## Enumerazione
+
+| Enumerazione | Descrizione |
+| --- | --- |
+| [GradientKind](./gradientkind/) | Gradient type enum. |
+| [NoiseColorModel](./noisecolormodel/) | Modello colore Quando 'Gradient type' = 'Noise', possiamo assegnare 'Color Model' a RGB/SHB/LAB (3/4/6) |
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Classe BaseGradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.BaseGradient class. Classe di definizione del gradiente base. Contiene proprietà comuni per entrambi i tipi di gradiente Solido e Rumore"
+type: docs
+weight: 2190
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/
+---
+{{< psd/tize >}}
+## BaseGradient class
+
+Classe di definizione del gradiente di base. Contiene proprietà comuni per entrambi i tipi di gradiente (Solido e Rumore).
+
+```csharp
+public abstract class BaseGradient
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| abstract [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/) { get; } | Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Ottiene o imposta il nome del gradiente. |
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradient.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradient. Ottiene la modalità per questo gradiente. Determina il tipo di gradiente Solido/Rumore 0/1"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/
+---
+{{< psd/tize >}}
+## BaseGradient.GradientMode property
+
+Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1).
+
+```csharp
+public abstract GradientKind GradientMode { get; }
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../gradientkind/)
+* class [BaseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradient.GradientName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseGradient. Ottiene o imposta il nome del gradiente"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/
+---
+{{< psd/tize >}}
+## BaseGradient.GradientName property
+
+Ottiene o imposta il nome del gradiente.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+### Property Value
+
+Il nome del gradiente.
+
+### Vedi anche
+
+* class [BaseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Enum GradientKind"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.GradientKind enum. Enum tipo gradiente"
+type: docs
+weight: 2200
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/
+---
+{{< psd/tize >}}
+## GradientKind enumeration
+
+Gradient type enum.
+
+```csharp
+public enum GradientKind
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Solid | `0` | Tipo di gradiente solido |
+| Noise | `1` | Tipo di gradiente rumore |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Enum NoiseColorModel"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.NoiseColorModel enum. Modello di colore. Quando il tipo di gradiente è Rumore possiamo assegnare il modello di colore a RGB/SHB/LAB 3/4/6"
+type: docs
+weight: 2210
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/
+---
+{{< psd/tize >}}
+## NoiseColorModel enumeration
+
+Modello colore Quando 'Gradient type' = 'Noise', possiamo assegnare 'Color Model' a RGB/SHB/LAB (3/4/6)
+
+```csharp
+public enum NoiseColorModel : short
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| RGB | `3` | Modello di colore RGB. |
+| HSB | `4` | Modello di colore HSB. |
+| LAB | `6` | Modello di colore LAB. |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/_index.md
@@ -1,0 +1,153 @@
+---
+title: "Classe NoiseGradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.NoiseGradient class. Classe di definizione del gradiente di rumore"
+type: docs
+weight: 2220
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/
+---
+{{< psd/tize >}}
+## NoiseGradient class
+
+Classe di definizione del gradiente di rumore.
+
+```csharp
+public class NoiseGradient : BaseGradient
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [NoiseGradient](noisegradient/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/) { get; set; } | Ottiene o imposta il modello di colore - RGB/HSB/LAB (3/4/6). |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/) { get; set; } | Ottiene o imposta il conteggio di espansione ( = 2 per Photoshop 6.0). |
+| override [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/) { get; } | Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Ottiene o imposta il nome del gradiente. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/) { get; set; } | Ottiene o imposta il colore massimo di PixelDataFormat. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/) { get; set; } | Ottiene o imposta il colore minimo di PixelDataFormat. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/) { get; set; } | Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente di rumore |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/) { get; set; } | Ottiene o imposta il fattore di rugosità. |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/) { get; set; } | Ottiene o imposta il flag per mostrare la trasparenza. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/) { get; set; } | Ottiene o imposta il flag per l'uso del colore vettoriale. |
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseGradient](../basegradient/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.ColorModel"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il modello di colore RGB/HSB/LAB 3/4/6"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/
+---
+{{< psd/tize >}}
+## NoiseGradient.ColorModel property
+
+Ottiene o imposta il modello di colore - RGB/HSB/LAB (3/4/6).
+
+```csharp
+public NoiseColorModel ColorModel { get; set; }
+```
+
+### Vedi anche
+
+* enum [NoiseColorModel](../../noisecolormodel/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/_index.md
@@ -1,0 +1,66 @@
+---
+title: "NoiseGradient.ExpansionCount"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il conteggio di espansione   2 per Photoshop 6.0"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/
+---
+{{< psd/tize >}}
+## NoiseGradient.ExpansionCount property
+
+Ottiene o imposta il conteggio di espansione ( = 2 per Photoshop 6.0).
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello mappa gradiente.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Aggiungi un livello di regolazione mappa gradiente.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene la modalità per questo gradiente. Determina il tipo di gradiente Solido/Rumore 0/1"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/
+---
+{{< psd/tize >}}
+## NoiseGradient.GradientMode property
+
+Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1).
+
+```csharp
+public override GradientKind GradientMode { get; }
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../gradientkind/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.MaximumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il colore massimo di PixelDataFormat"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.MaximumColor property
+
+Ottiene o imposta il colore massimo di PixelDataFormat.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.MinimumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il colore Minimum di PixelDataFormat"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.MinimumColor property
+
+Ottiene o imposta il colore minimo di PixelDataFormat.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.NoiseGradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore NoiseGradient. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/
+---
+{{< psd/tize >}}
+## NoiseGradient constructor
+
+Il costruttore predefinito.
+
+```csharp
+public NoiseGradient()
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.RndNumberSeed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente di rumore"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/
+---
+{{< psd/tize >}}
+## NoiseGradient.RndNumberSeed property
+
+Ottiene o imposta il seme del numero casuale usato per generare i colori per il gradiente di rumore
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.Roughness"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il fattore di rugosità"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/
+---
+{{< psd/tize >}}
+## NoiseGradient.Roughness property
+
+Ottiene o imposta il fattore di rugosità.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.ShowTransparency"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il flag per mostrare la trasparenza"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/
+---
+{{< psd/tize >}}
+## NoiseGradient.ShowTransparency property
+
+Ottiene o imposta il flag per mostrare la trasparenza.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.UseVectorColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NoiseGradient. Ottiene o imposta il flag per l'uso del colore vettoriale"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.UseVectorColor property
+
+Ottiene o imposta il flag per l'uso del colore vettoriale.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Vedi anche
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/_index.md
@@ -1,0 +1,158 @@
+---
+title: "Classe SolidGradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.SolidGradient class. Impostazioni dell'effetto di riempimento del gradiente"
+type: docs
+weight: 2230
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/
+---
+{{< psd/tize >}}
+## SolidGradient class
+
+Impostazioni dell'effetto di riempimento gradiente.
+
+```csharp
+public class SolidGradient : BaseGradient
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [SolidGradient](solidgradient/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorPoints](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/) { get; set; } | Ottiene o imposta i punti di colore. |
+| override [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/) { get; } | Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Ottiene o imposta il nome del gradiente. |
+| [Interpolation](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/) { get; set; } | Ottiene o imposta l'interpolazione. Determina la fluidità, quando 'Gradient Type' = 'Solid'. Intervallo di valori: 0-4096. |
+| [TransparencyPoints](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/) { get; set; } | Ottiene o imposta i punti di trasparenza. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [AddColorPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/)() | Aggiunge il punto di colore. |
+| [AddTransparencyPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/)() | Aggiunge il punto di colore. |
+| [RemoveColorPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/)(IGradientColorPoint) | Rimuove il punto di colore. |
+| [RemoveTransparencyPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/)(IGradientTransparencyPoint) | Rimuove il punto di trasparenza. |
+| static [GenerateLfx2ResourceNodes](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/)() | Genera i nodi risorsa LFX2. |
+
+## Esempi
+
+Dimostra la lettura e la modifica delle impostazioni di gradiente rumore e solido negli effetti di riempimento del tratto.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Verifica le proprietà del gradiente Rumore
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Modifica le impostazioni del gradiente
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Verifica le proprietà comuni delle impostazioni di riempimento del gradiente
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseGradient](../basegradient/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.AddColorPoint"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo SolidGradient. Aggiunge il punto di colore"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/
+---
+{{< psd/tize >}}
+## SolidGradient.AddColorPoint method
+
+Aggiunge il punto di colore.
+
+```csharp
+public GradientColorPoint AddColorPoint()
+```
+
+### Valore di ritorno
+
+Punto di colore creato
+
+### Vedi anche
+
+* class [GradientColorPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.AddTransparencyPoint"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo SolidGradient. Aggiunge il punto di colore"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/
+---
+{{< psd/tize >}}
+## SolidGradient.AddTransparencyPoint method
+
+Aggiunge il punto di colore.
+
+```csharp
+public GradientTransparencyPoint AddTransparencyPoint()
+```
+
+### Valore di ritorno
+
+Punto di trasparenza creato
+
+### Vedi anche
+
+* class [GradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "SolidGradient.Color"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SolidGradient. Ottiene o imposta il colore"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/
+---
+{{< psd/tize >}}
+## SolidGradient.Color property
+
+Ottiene o imposta il colore.
+
+```csharp
+[Obsolete("Property is obsolete and will be removed in further release.")]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+Il colore.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/_index.md
@@ -1,0 +1,102 @@
+---
+title: "SolidGradient.ColorPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SolidGradient. Ottiene o imposta i punti colore"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/
+---
+{{< psd/tize >}}
+## SolidGradient.ColorPoints property
+
+Ottiene o imposta i punti di colore.
+
+```csharp
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+I punti di colore.
+
+## Esempi
+
+Il seguente esempio dimostra il supporto per Gradient FillLayer e le opzioni di modifica di IGradientFillSettings.
+
+```csharp
+[C#]
+
+string sourceFileName = "ComplexGradientFillLayer.psd";
+string outputFile = "ComplexGradientFillLayer_output.psd";
+var im = (PsdImage)Image.Load(sourceFileName);
+using (im)
+{
+    foreach (var layer in im.Layers)
+    {
+        if (layer is FillLayer)
+        {
+            var fillLayer = (FillLayer)layer;
+            if (fillLayer.FillSettings.FillType != FillType.Gradient)
+            {
+                throw new Exception("Wrong Fill Layer");
+            }
+            var settings = (GradientFillSettings)fillLayer.FillSettings;
+            var solidGradient = (SolidGradient)settings.Gradient;
+            if (
+             Math.Abs(settings.Angle - 45) > 0.25 ||
+             settings.Dither != true ||
+             settings.AlignWithLayer != false ||
+             settings.Reverse != false ||
+             Math.Abs(settings.HorizontalOffset - (-39)) > 0.25 ||
+             Math.Abs(settings.VerticalOffset - (-5)) > 0.25 ||
+             solidGradient.TransparencyPoints.Length != 3 ||
+             solidGradient.ColorPoints.Length != 2 ||
+             Math.Abs(100.0 - solidGradient.TransparencyPoints[0].Opacity) > 0.25 ||
+             solidGradient.TransparencyPoints[0].Location != 0 ||
+             solidGradient.TransparencyPoints[0].MedianPointLocation != 50 ||
+             solidGradient.ColorPoints[0].Color != Color.FromArgb(203, 64, 140) ||
+             solidGradient.ColorPoints[0].Location != 0 ||
+             solidGradient.ColorPoints[0].MedianPointLocation != 50)
+            {
+                throw new Exception("Gradient Fill was not read correctly");
+            }
+            settings.Angle = 0.0;
+            settings.Dither = false;
+            settings.AlignWithLayer = true;
+            settings.Reverse = true;
+            settings.HorizontalOffset = 25;
+            settings.VerticalOffset = -15;
+            var colorPoints = new List<IGradientColorPoint>(solidGradient.ColorPoints);
+            var transparencyPoints = new List<IGradientTransparencyPoint>(solidGradient.TransparencyPoints);
+            colorPoints.Add(new GradientColorPoint()
+            {
+                Color = Color.Violet,
+                Location = 4096,
+                MedianPointLocation = 75
+            });
+            colorPoints[1].Location = 3000;
+            transparencyPoints.Add(new GradientTransparencyPoint()
+            {
+                Opacity = 80.0,
+                Location = 4096,
+                MedianPointLocation = 25
+            });
+            transparencyPoints[2].Location = 3000;
+            solidGradient.ColorPoints = colorPoints.ToArray();
+            solidGradient.TransparencyPoints = transparencyPoints.ToArray();
+            fillLayer.Update();
+            im.Save(outputFile, new PsdOptions(im));
+            break;
+        }
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.GenerateLfx2ResourceNodes"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo SolidGradient. Genera i nodi risorsa LFX2"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/
+---
+{{< psd/tize >}}
+## SolidGradient.GenerateLfx2ResourceNodes method
+
+Genera i nodi risorsa LFX2.
+
+```csharp
+public static List<OSTypeStructure> GenerateLfx2ResourceNodes()
+```
+
+### Valore di ritorno
+
+Elenco generato di [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+
+### Vedi anche
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "SolidGradient.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SolidGradient. Ottiene la modalità per questo gradiente. Determina il tipo di gradiente Solid/Noise 0/1"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/
+---
+{{< psd/tize >}}
+## SolidGradient.GradientMode property
+
+Ottiene la modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' (0/1).
+
+```csharp
+public override GradientKind GradientMode { get; }
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../gradientkind/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "SolidGradient.Interpolation"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SolidGradient. Ottiene o imposta Interpolation. Determina la fluidità quando il tipo di gradiente è Solid. Intervallo di valori 04096"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/
+---
+{{< psd/tize >}}
+## SolidGradient.Interpolation property
+
+Ottiene o imposta l'interpolazione. Determina la fluidità, quando 'Gradient Type' = 'Solid'. Intervallo di valori: 0-4096.
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Vedi anche
+
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.RemoveColorPoint"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo SolidGradient. Rimuove il punto di colore"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/
+---
+{{< psd/tize >}}
+## SolidGradient.RemoveColorPoint method
+
+Rimuove il punto di colore.
+
+```csharp
+public void RemoveColorPoint(IGradientColorPoint point)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| punto | IGradientColorPoint | Il punto. |
+
+### Vedi anche
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.RemoveTransparencyPoint"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo SolidGradient. Rimuove il punto di trasparenza"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/
+---
+{{< psd/tize >}}
+## SolidGradient.RemoveTransparencyPoint method
+
+Rimuove il punto di trasparenza.
+
+```csharp
+public void RemoveTransparencyPoint(IGradientTransparencyPoint point)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| punto | IGradientTransparencyPoint | Il punto. |
+
+### Vedi anche
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/_index.md
@@ -1,0 +1,24 @@
+---
+title: "SolidGradient.SolidGradient"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore SolidGradient. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/
+---
+{{< psd/tize >}}
+## SolidGradient constructor
+
+Il costruttore predefinito.
+
+```csharp
+public SolidGradient()
+```
+
+### Vedi anche
+
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/_index.md
@@ -1,0 +1,102 @@
+---
+title: "SolidGradient.TransparencyPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SolidGradient. Ottiene o imposta i punti di trasparenza"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/
+---
+{{< psd/tize >}}
+## SolidGradient.TransparencyPoints property
+
+Ottiene o imposta i punti di trasparenza.
+
+```csharp
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+I punti di trasparenza.
+
+## Esempi
+
+Il seguente esempio dimostra il supporto per Gradient FillLayer e le opzioni di modifica di IGradientFillSettings.
+
+```csharp
+[C#]
+
+string sourceFileName = "ComplexGradientFillLayer.psd";
+string outputFile = "ComplexGradientFillLayer_output.psd";
+var im = (PsdImage)Image.Load(sourceFileName);
+using (im)
+{
+    foreach (var layer in im.Layers)
+    {
+        if (layer is FillLayer)
+        {
+            var fillLayer = (FillLayer)layer;
+            if (fillLayer.FillSettings.FillType != FillType.Gradient)
+            {
+                throw new Exception("Wrong Fill Layer");
+            }
+            var settings = (GradientFillSettings)fillLayer.FillSettings;
+            var solidGradient = (SolidGradient)settings.Gradient;
+            if (
+             Math.Abs(settings.Angle - 45) > 0.25 ||
+             settings.Dither != true ||
+             settings.AlignWithLayer != false ||
+             settings.Reverse != false ||
+             Math.Abs(settings.HorizontalOffset - (-39)) > 0.25 ||
+             Math.Abs(settings.VerticalOffset - (-5)) > 0.25 ||
+             solidGradient.TransparencyPoints.Length != 3 ||
+             solidGradient.ColorPoints.Length != 2 ||
+             Math.Abs(100.0 - solidGradient.TransparencyPoints[0].Opacity) > 0.25 ||
+             solidGradient.TransparencyPoints[0].Location != 0 ||
+             solidGradient.TransparencyPoints[0].MedianPointLocation != 50 ||
+             solidGradient.ColorPoints[0].Color != Color.FromArgb(203, 64, 140) ||
+             solidGradient.ColorPoints[0].Location != 0 ||
+             solidGradient.ColorPoints[0].MedianPointLocation != 50)
+            {
+                throw new Exception("Gradient Fill was not read correctly");
+            }
+            settings.Angle = 0.0;
+            settings.Dither = false;
+            settings.AlignWithLayer = true;
+            settings.Reverse = true;
+            settings.HorizontalOffset = 25;
+            settings.VerticalOffset = -15;
+            var colorPoints = new List<IGradientColorPoint>(solidGradient.ColorPoints);
+            var transparencyPoints = new List<IGradientTransparencyPoint>(solidGradient.TransparencyPoints);
+            colorPoints.Add(new GradientColorPoint()
+            {
+                Color = Color.Violet,
+                Location = 4096,
+                MedianPointLocation = 75
+            });
+            colorPoints[1].Location = 3000;
+            transparencyPoints.Add(new GradientTransparencyPoint()
+            {
+                Opacity = 80.0,
+                Location = 4096,
+                MedianPointLocation = 25
+            });
+            transparencyPoints[2].Location = 3000;
+            solidGradient.ColorPoints = colorPoints.ToArray();
+            solidGradient.TransparencyPoints = transparencyPoints.ToArray();
+            fillLayer.Update();
+            im.Save(outputFile, new PsdOptions(im));
+            break;
+        }
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/_index.md
@@ -1,0 +1,45 @@
+---
+title: "BlendingOptions.AreEffectsEnabled"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BlendingOptions. Ottiene o imposta la visibilità di tutti gli effetti di livello"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/
+---
+{{< psd/tize >}}
+## BlendingOptions.AreEffectsEnabled property
+
+Ottiene o imposta la visibilità di tutti gli effetti di livello.
+
+```csharp
+public bool AreEffectsEnabled { get; set; }
+```
+
+## Esempi
+
+Dimostra come abilitare o disabilitare gli effetti di livello usando la proprietà AreEffectsEnabled.
+
+```csharp
+[C#]
+
+string srcFile = "2485.psd";
+string outputOnFile = "on_2485.png";
+string outputOffFile = "off_2485.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Save(outputOnFile);
+
+    psdImage.Layers[1].BlendingOptions.AreEffectsEnabled = false;
+
+    psdImage.Save(outputOffFile);
+}
+```
+
+### Vedi anche
+
+* class [BlendingOptions](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ColorOverlayEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ColorOverlayEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## ColorOverlayEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [ColorOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "DropShadowEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo DropShadowEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 130
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## DropShadowEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [DropShadowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "GradientOverlayEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo GradientOverlayEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## GradientOverlayEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [GradientOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ILayerEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ILayerEffect. Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## ILayerEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+## Esempi
+
+Dimostra come ottenere i limiti di un livello con effetti e esportarli con la dimensione corretta.
+
+```csharp
+[C#]
+
+string srcFile = "1958.psd";
+string outputFile = "out_1958.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    var layer1 = psdImage.Layers[1];
+
+    var layerBoudns = layer1.Bounds;
+    foreach (var effect in layer1.BlendingOptions.Effects)
+    {
+        layerBoudns = Rectangle.Union(
+            layerBoudns,
+            effect.GetEffectBounds(layer1.Bounds, psdImage.GlobalAngle));
+    }
+
+    Rectangle boundsToExport = Rectangle.Empty; // The default value is to save only the layer with effects.
+                                                // boundsToExport = psdImage.Bounds; // Per salvare entro i limiti di PsdImage nella posizione originale del livello
+
+    layer1.Save(
+        outputFile,
+        new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha },
+        boundsToExport);
+
+    using (var imgStream = new FileStream(outputFile, FileMode.Open))
+    {
+        var loadedLayer = new Layer(imgStream);
+        if (loadedLayer.Size == layerBoudns.Size)
+        {
+            System.Console.WriteLine("The size is calculated correctly.");
+        }
+    }
+}
+```
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* interface [ILayerEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "InnerShadowEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo InnerShadowEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## InnerShadowEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [InnerShadowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Enum LayerEffectsTypes"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Enum Aspose.PSD.FileFormats.Psd.Layers.LayerEffects.LayerEffectsTypes. Effetti di fusione dei livelli"
+type: docs
+weight: 2360
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/
+---
+{{< psd/tize >}}
+## LayerEffectsTypes enumeration
+
+Effetti di fusione dei livelli.
+
+```csharp
+public enum LayerEffectsTypes
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| DropShadow | `0` | L'ombra proiettata. |
+| OuterGlow | `1` | Il bagliore esterno. |
+| PatternOverlay | `2` | La sovrapposizione a trama. |
+| GradientOverlay | `3` | La sovrapposizione a gradiente. |
+| ColorOverlay | `4` | La sovrapposizione colore. |
+| Satin | `5` | Il tipo di effetto satinato. |
+| InnerGlow | `6` | Il bagliore interno. |
+| InnerShadow | `7` | L'ombra interna. |
+| Stroke | `8` | Il contorno. |
+| BevelEmboss | `9` | Il rilievo a smusso. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà ILayerEffect.EffectType.
+
+```csharp
+[C#]
+
+string inputFile = "input.psd";
+string outputWithout = "outputWithout.png";
+string outputWith = "outputWith.png";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(inputFile, new LoadOptions()))
+{
+    psdImage.Save(outputWithout, new PngOptions());
+
+    Layer workLayer = psdImage.Layers[1];
+
+    DropShadowEffect dropShadowEffect = workLayer.BlendingOptions.AddDropShadow();
+    dropShadowEffect.Distance = 0;
+    dropShadowEffect.Size = 8;
+    dropShadowEffect.Opacity = 20;
+
+    foreach (ILayerEffect iEffect in workLayer.BlendingOptions.Effects)
+    {
+        if (iEffect.EffectType == LayerEffectsTypes.DropShadow)
+        {
+            // ha catturato
+            psdImage.Save(outputWith, new PngOptions());
+        }
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "OuterGlowEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo OuterGlowEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 140
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## OuterGlowEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [OuterGlowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "PatternOverlayEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PatternOverlayEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## PatternOverlayEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [PatternOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "StrokeEffect.GetEffectBounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo StrokeEffect. Calcola e ottiene i limiti dei pixel dell'effetto basati sui limiti dei pixel del livello di input"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## StrokeEffect.GetEffectBounds method
+
+Calcola e restituisce i limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| layerBounds | Rettangolo | I limiti dei pixel del livello. |
+| globalAngle | Int32 | L'angolo globale per calcolare l'angolo della luce globale. |
+
+### Valore di ritorno
+
+I limiti dei pixel di effetto basati sui limiti dei pixel del livello di input.
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [StrokeEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/_index.md
@@ -1,0 +1,142 @@
+---
+title: "Interfaccia IStrokeSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Interfaccia Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.IStrokeSettings. Impostazioni di tratto delle forme"
+type: docs
+weight: 3390
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/
+---
+{{< psd/tize >}}
+## IStrokeSettings interface
+
+Impostazioni di tratto delle forme.
+
+```csharp
+public interface IStrokeSettings
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Enabled](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/) { get; set; } | Il tratto è abilitato. |
+| [Fill](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/) { get; set; } | Ottiene o imposta le impostazioni di riempimento del tratto. |
+| [LineAlignment](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/) { get; set; } | Ottiene o imposta l'allineamento della linea dello stile di tratto. |
+| [LineCap](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/) { get; set; } | Tipo di estremità della linea del tratto. |
+| [LineDashSet](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/) { get; set; } | Ottiene o imposta l'array di tratti di linea. |
+| [LineJoin](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/) { get; set; } | Tipo di unione della linea del tratto. |
+| [Size](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/) { get; set; } | Larghezza della linea del tratto. |
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.Enabled"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Il tratto è abilitato"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Enabled property
+
+Il tratto è abilitato.
+
+```csharp
+public bool Enabled { get; set; }
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.Fill"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Ottiene o imposta le impostazioni di riempimento del tratto"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Fill property
+
+Ottiene o imposta le impostazioni di riempimento del tratto.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Vedi anche
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineAlignment"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Ottiene o imposta l'allineamento della linea dello stile del tratto"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineAlignment property
+
+Ottiene o imposta l'allineamento della linea dello stile di tratto.
+
+```csharp
+public StrokePosition LineAlignment { get; set; }
+```
+
+### Vedi anche
+
+* enum [StrokePosition](../../../aspose.psd.fileformats.psd.layers.layereffects/strokeposition/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineCap"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Tipo di cap della linea del tratto"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineCap property
+
+Tipo di estremità della linea del tratto.
+
+```csharp
+public LineCapType LineCap { get; set; }
+```
+
+### Vedi anche
+
+* enum [LineCapType](../../linecaptype/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.LineDashSet"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Ottiene o imposta l'array di tratti di linea"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineDashSet property
+
+Ottiene o imposta l'array di tratti di linea.
+
+```csharp
+public double[] LineDashSet { get; set; }
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineJoin"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Tipo di unione della linea del tratto"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineJoin property
+
+Tipo di unione della linea del tratto.
+
+```csharp
+public LineJoinType LineJoin { get; set; }
+```
+
+### Vedi anche
+
+* enum [LineJoinType](../../linejointype/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.Size"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IStrokeSettings. Larghezza della linea del tratto"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Size property
+
+Larghezza della linea del tratto.
+
+```csharp
+public double Size { get; set; }
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/_index.md
@@ -1,0 +1,126 @@
+---
+title: "Classe StrokeSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.StrokeSettings. Impostazioni di tratto delle forme"
+type: docs
+weight: 3420
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/
+---
+{{< psd/tize >}}
+## StrokeSettings class
+
+Impostazioni di tratto delle forme.
+
+```csharp
+public class StrokeSettings : IStrokeSettings
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [StrokeSettings](strokesettings/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Enabled](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/) { get; set; } | Ottiene o imposta se Stroke è abilitato. |
+| [Fill](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/) { get; set; } | Ottiene o imposta le impostazioni di riempimento del tratto. |
+| [LineAlignment](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/) { get; set; } | Ottiene o imposta l'allineamento della linea dello stile di tratto. |
+| [LineCap](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/) { get; set; } | Ottiene o imposta il tipo di capolinea di Stroke. |
+| [LineDashSet](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/) { get; set; } | Ottiene o imposta l'array di tratti di linea. |
+| [LineJoin](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/) { get; set; } | Ottiene o imposta il tipo di unione di linea di Stroke. |
+| [Size](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/) { get; set; } | Ottiene o imposta la larghezza della linea di Stroke. |
+
+## Esempi
+
+Il codice seguente dimostra il rendering di supporto di Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Verifica i dati modificati.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../istrokesettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.Enabled"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta se il Tratto è abilitato"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/
+---
+{{< psd/tize >}}
+## StrokeSettings.Enabled property
+
+Ottiene o imposta se Stroke è abilitato.
+
+```csharp
+public bool Enabled { get; set; }
+```
+
+### Vedi anche
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.Fill"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta le impostazioni di riempimento del Tratto"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/
+---
+{{< psd/tize >}}
+## StrokeSettings.Fill property
+
+Ottiene o imposta le impostazioni di riempimento del tratto.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Vedi anche
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineAlignment"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta l'allineamento della linea di stile del Tratto"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineAlignment property
+
+Ottiene o imposta l'allineamento della linea dello stile di tratto.
+
+```csharp
+public StrokePosition LineAlignment { get; set; }
+```
+
+### Vedi anche
+
+* enum [StrokePosition](../../../aspose.psd.fileformats.psd.layers.layereffects/strokeposition/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineCap"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta il tipo di estremità della linea del Tratto"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineCap property
+
+Ottiene o imposta il tipo di capolinea di Stroke.
+
+```csharp
+public LineCapType LineCap { get; set; }
+```
+
+### Vedi anche
+
+* enum [LineCapType](../../linecaptype/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.LineDashSet"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta l'array di tratti di linea"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineDashSet property
+
+Ottiene o imposta l'array di tratti di linea.
+
+```csharp
+public double[] LineDashSet { get; set; }
+```
+
+### Vedi anche
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineJoin"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta il tipo di giunzione della linea del Tratto"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineJoin property
+
+Ottiene o imposta il tipo di unione di linea di Stroke.
+
+```csharp
+public LineJoinType LineJoin { get; set; }
+```
+
+### Vedi anche
+
+* enum [LineJoinType](../../linejointype/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.Size"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StrokeSettings. Ottiene o imposta la larghezza della linea del Tratto"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/
+---
+{{< psd/tize >}}
+## StrokeSettings.Size property
+
+Ottiene o imposta la larghezza della linea di Stroke.
+
+```csharp
+public double Size { get; set; }
+```
+
+### Vedi anche
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.StrokeSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore StrokeSettings. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/
+---
+{{< psd/tize >}}
+## StrokeSettings constructor
+
+Il costruttore predefinito.
+
+```csharp
+public StrokeSettings()
+```
+
+### Vedi anche
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/_index.md
@@ -1,0 +1,101 @@
+---
+title: "Classe VscgResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.VscgResource. Risorsa dati di contenuto del tratto vettoriale"
+type: docs
+weight: 3430
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/
+---
+{{< psd/tize >}}
+## VscgResource class
+
+Risorsa dati di contenuto del tratto vettoriale.
+
+```csharp
+public class VscgResource : LayerResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [VscgResource](vscgresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/) { get; } | Ottiene o imposta l'array di elementi della struttura. **Warning:** I valori dell'array `Items` devono corrispondere alla proprietà `KeyForData`, che determina il tipo di impostazioni di riempimento memorizzate nelle strutture all'interno di `Items`. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| [KeyForData](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/) { get; } | Ottiene la chiave intera che definisce quale tipo di impostazioni di riempimento è memorizzato nella risorsa: * Color - 0x536f436f - SoCoResource.TypeToolKey * Gradient - 0x4764466c - GdFlResource.TypeToolKey * Pattern - 0x5074466c - PtFlResource.TypeToolKey Attenzione! Il valore della proprietà KeyForData dovrebbe corrispondere al tipo di impostazioni di riempimento memorizzate nelle strutture Items. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto di VscgResource.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeInternalFill_src.psd";
+string outputFile = "StrokeInternalFill_res.psd";
+
+void AreEqual(double expected, double current, double tolerance = 0.1)
+{
+    if (Math.Abs(expected - current) > tolerance)
+    {
+        throw new Exception(
+            $"Values is not equal.\nExpected:{expected}\nResult:{current}\nDifference:{expected - current}");
+    }
+}
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(89.8, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(219.6, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(34.2, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+
+    ((DoubleStructure)rgbColorStructure.Structures[0]).Value = 255d; // Red
+    ((DoubleStructure)rgbColorStructure.Structures[1]).Value = 0d; // Green
+    ((DoubleStructure)rgbColorStructure.Structures[2]).Value = 0d; // Blue
+
+    image.Save(outputFile);
+}
+
+// verifica delle modifiche
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(255, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+}
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/_index.md
@@ -1,0 +1,76 @@
+---
+title: "VscgResource.Items"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene o imposta l'array di elementi di struttura. Attenzione: i valori dell'array Items devono corrispondere alla proprietà KeyForData, che determina il tipo di impostazioni di riempimento memorizzate nelle strutture all'interno di Items"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/
+---
+{{< psd/tize >}}
+## VscgResource.Items property
+
+Ottiene o imposta l'array di elementi della struttura. **Warning:** I valori dell'array `Items` devono corrispondere alla proprietà `KeyForData`, che determina il tipo di impostazioni di riempimento memorizzate nelle strutture all'interno di `Items`.
+
+```csharp
+public OSTypeStructure[] Items { get; }
+```
+
+### Property Value
+
+L'array di elementi [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/).
+
+## Esempi
+
+Il codice seguente dimostra il supporto di VscgResource.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeInternalFill_src.psd";
+string outputFile = "StrokeInternalFill_res.psd";
+
+void AreEqual(double expected, double current, double tolerance = 0.1)
+{
+    if (Math.Abs(expected - current) > tolerance)
+    {
+        throw new Exception(
+            $"Values is not equal.\nExpected:{expected}\nResult:{current}\nDifference:{expected - current}");
+    }
+}
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(89.8, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(219.6, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(34.2, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+
+    ((DoubleStructure)rgbColorStructure.Structures[0]).Value = 255d; // Red
+    ((DoubleStructure)rgbColorStructure.Structures[1]).Value = 0d; // Green
+    ((DoubleStructure)rgbColorStructure.Structures[2]).Value = 0d; // Blue
+
+    image.Save(outputFile);
+}
+
+// verifica delle modifiche
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(255, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+}
+```
+
+### Vedi anche
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Key"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene la chiave della risorsa di livello"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/
+---
+{{< psd/tize >}}
+## VscgResource.Key property
+
+Ottiene la chiave della risorsa del livello.
+
+```csharp
+public override int Key { get; }
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.KeyForData"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene la chiave intera che definisce quale tipo di impostazioni di riempimento è memorizzato nella risorsa  Color  0x536f436f  SoCoResource.TypeToolKey  Gradient  0x4764466c  GdFlResource.TypeToolKey  Pattern  0x5074466c  PtFlResource.TypeToolKey. Attenzione: il valore della proprietà KeyForData dovrebbe corrispondere al tipo di impostazioni di riempimento memorizzate nelle strutture Items"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/
+---
+{{< psd/tize >}}
+## VscgResource.KeyForData property
+
+Ottiene la chiave intera che definisce quale tipo di impostazioni di riempimento è memorizzato nella risorsa: * Color - 0x536f436f - SoCoResource.TypeToolKey * Gradient - 0x4764466c - GdFlResource.TypeToolKey * Pattern - 0x5074466c - PtFlResource.TypeToolKey Attenzione! Il valore della proprietà KeyForData dovrebbe corrispondere al tipo di impostazioni di riempimento memorizzate nelle strutture Items.
+
+```csharp
+public int KeyForData { get; }
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene la lunghezza della risorsa di livello in byte"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/
+---
+{{< psd/tize >}}
+## VscgResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene la versione psd"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/
+---
+{{< psd/tize >}}
+## VscgResource.PsdVersion property
+
+Ottiene la versione psd.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "VscgResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo VscgResource. Salva la risorsa nel contenitore di stream specificato"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/
+---
+{{< psd/tize >}}
+## VscgResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Signature"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VscgResource. Ottiene la firma"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/
+---
+{{< psd/tize >}}
+## VscgResource.Signature property
+
+Ottiene la firma.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo VscgResource. La chiave di informazioni dello strumento di tipo"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/
+---
+{{< psd/tize >}}
+## VscgResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.VscgResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore VscgResource. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/
+---
+{{< psd/tize >}}
+## VscgResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public VscgResource()
+```
+
+### Vedi anche
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/_index.md
@@ -1,0 +1,109 @@
+---
+title: "VstkResource.FillSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VstkResource. Ottiene o imposta le impostazioni di riempimento del Tratto"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/
+---
+{{< psd/tize >}}
+## VstkResource.FillSettings property
+
+Ottiene o imposta le impostazioni di riempimento del tratto.
+
+```csharp
+public IFillSettings FillSettings { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il rendering di supporto di Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Verifica i dati modificati.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [VstkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/_index.md
@@ -1,0 +1,124 @@
+---
+title: "Classe NameStructure"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures.NameStructure. La chiave della struttura Name 0x6E616D65, che corrisponde a \"name\" in ASCII, è una struttura semplice usata per memorizzare una stringa Unicode o in stile Pascal che rappresenta il nome di un elemento, come un percorso di layer o una regolazione."
+type: docs
+weight: 3580
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/
+---
+{{< psd/tize >}}
+## NameStructure class
+
+La struttura Name (chiave: 0x6E616D65, che corrisponde a "name" in ASCII) è una struttura semplice usata per memorizzare una stringa Unicode o in stile Pascal che rappresenta il nome di un elemento, come un layer, un percorso o una regolazione.
+
+```csharp
+public sealed class NameStructure : OSTypeStructure
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [NameStructure](namestructure/)(ClassID) | Inizializza una nuova istanza della classe `NameStructure`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Key](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/) { get; } | Ottiene la chiave. |
+| [KeyName](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/keyname/) { get; set; } | Ottiene o imposta il nome della chiave. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/) { get; } | Ottiene la lunghezza in byte della [`OSTypeStructure`](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/). |
+| [Value](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/) { get; set; } | Ottiene o imposta il valore di una struttura Name. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| virtual [GetHeaderLength](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/getheaderlength/)() | Ottiene la lunghezza dell'intestazione. |
+| [Save](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/save/)(StreamContainer) | Salva la struttura nel contenitore di stream specificato. |
+| [SaveWithoutKeyName](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/savewithoutkeyname/)(StreamContainer) | Salva la struttura nel contenitore di stream specificato. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [StructureKey](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/) | La chiave della struttura Name. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto per NameStructure.
+
+```csharp
+[C#]
+
+string inputFile = "Mixer_ipad_Hand_W_crash.psd";
+string outputFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(inputFile, new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    //// Il file è stato caricato correttamente
+
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+
+    // Salva il file di prova senza modifiche
+    psdImage.Save(outputFile);
+
+    //// Il file dovrebbe essere aperto in PS senza errori
+}
+
+// Verifica che le strutture degli effetti di illuminazione siano salvate correttamente
+using (var psdImage = (PsdImage)Image.Load(
+           outputFile,
+           new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [OSTypeStructure](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.Key"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NameStructure. Ottiene la chiave"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/
+---
+{{< psd/tize >}}
+## NameStructure.Key property
+
+Ottiene la chiave.
+
+```csharp
+public override int Key { get; }
+```
+
+### Vedi anche
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NameStructure. Ottiene la lunghezza di OSTypeStructure in byte"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/
+---
+{{< psd/tize >}}
+## NameStructure.Length property
+
+Ottiene la lunghezza in byte del [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/).
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NameStructure.NameStructure"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore NameStructure. Inizializza una nuova istanza della classe NameStructure"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/
+---
+{{< psd/tize >}}
+## NameStructure constructor
+
+Inizializza una nuova istanza della classe [`NameStructure`](../).
+
+```csharp
+public NameStructure(ClassID keyName)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| keyName | ClassID | Il nome della chiave. |
+
+### Vedi anche
+
+* class [ClassID](../../../aspose.psd.fileformats.psd.layers.layerresources/classid/)
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.StructureKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo NameStructure. La chiave della struttura Name"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/
+---
+{{< psd/tize >}}
+## NameStructure.StructureKey field
+
+La chiave della struttura Name.
+
+```csharp
+public const int StructureKey;
+```
+
+### Vedi anche
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/_index.md
@@ -1,0 +1,95 @@
+---
+title: "NameStructure.Value"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà NameStructure. Ottiene o imposta il valore di una struttura Name"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/
+---
+{{< psd/tize >}}
+## NameStructure.Value property
+
+Ottiene o imposta il valore di una struttura Name.
+
+```csharp
+public string Value { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto per NameStructure.
+
+```csharp
+[C#]
+
+string inputFile = "Mixer_ipad_Hand_W_crash.psd";
+string outputFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(inputFile, new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    //// Il file è stato caricato correttamente
+
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+
+    // Salva il file di prova senza modifiche
+    psdImage.Save(outputFile);
+
+    //// Il file dovrebbe essere aperto in PS senza errori
+}
+
+// Verifica che le strutture degli effetti di illuminazione siano salvate correttamente
+using (var psdImage = (PsdImage)Image.Load(
+           outputFile,
+           new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Classe AbddResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.AbddResource. I dati delle informazioni dell'Artboard"
+type: docs
+weight: 2490
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/
+---
+{{< psd/tize >}}
+## AbddResource class
+
+I dati delle informazioni dell'Artboard.
+
+```csharp
+public sealed class AbddResource : BaseArtboardInfoResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [AbddResource](abddresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Ottiene o imposta gli elementi [`OSTypeStructure`](../ostypestructure/). |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "AbddResource.AbddResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore AbddResource. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/
+---
+{{< psd/tize >}}
+## AbddResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public AbddResource()
+```
+
+### Vedi anche
+
+* class [AbddResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "AbddResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo AbddResource. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/
+---
+{{< psd/tize >}}
+## AbddResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [AbddResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Classe ArtBResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ArtBResource. I dati informativi dell'Artboard per le Risorse"
+type: docs
+weight: 2520
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/
+---
+{{< psd/tize >}}
+## ArtBResource class
+
+I dati informativi dell'Artboard per [`Resources`](../../aspose.psd.fileformats.psd.layers/layer/resources/).
+
+```csharp
+public sealed class ArtBResource : BaseArtboardInfoResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [ArtBResource](artbresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ArtboardBackgroundType](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/) { get; set; } | Ottiene o imposta il [`ArtboardBackgroundType`](./artboardbackgroundtype/) |
+| [Color](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/) { get; set; } | Ottiene o imposta il [`Color`](./color/) |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Ottiene o imposta gli elementi [`OSTypeStructure`](../ostypestructure/). |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ArtBResource.ArtboardBackgroundType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtBResource. Ottiene o imposta l'ArtboardBackgroundType"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/
+---
+{{< psd/tize >}}
+## ArtBResource.ArtboardBackgroundType property
+
+Ottiene o imposta l'`ArtboardBackgroundType`
+
+```csharp
+public int ArtboardBackgroundType { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione di ArtboardLayer come immagini separate e tutte in un'unica immagine.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Vedi anche
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtBResource.ArtBResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore ArtBResource. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/
+---
+{{< psd/tize >}}
+## ArtBResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public ArtBResource()
+```
+
+### Vedi anche
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ArtBResource.Color"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtBResource. Ottiene o imposta il Color"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/
+---
+{{< psd/tize >}}
+## ArtBResource.Color property
+
+Ottiene o imposta il `Color`
+
+```csharp
+public Color Color { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione di ArtboardLayer come immagini separate e tutte in un'unica immagine.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtBResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo ArtBResource. La chiave di informazioni dello strumento di tipo"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ArtBResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Classe ArtDResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ArtDResource. I dati informativi dell'Artboard per GlobalLayerResources"
+type: docs
+weight: 2530
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/
+---
+{{< psd/tize >}}
+## ArtDResource class
+
+I dati delle informazioni dell'Artboard per [`GlobalLayerResources`](../../aspose.psd.fileformats.psd/psdimage/globallayerresources/).
+
+```csharp
+public sealed class ArtDResource : BaseArtboardInfoResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [ArtDResource](artdresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Ottiene o imposta gli elementi [`OSTypeStructure`](../ostypestructure/). |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtDResource.ArtDResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore ArtDResource. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/
+---
+{{< psd/tize >}}
+## ArtDResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public ArtDResource()
+```
+
+### Vedi anche
+
+* class [ArtDResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtDResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo ArtDResource. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ArtDResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [ArtDResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/_index.md
@@ -1,0 +1,82 @@
+---
+title: "Classe BaseArtboardInfoResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseArtboardInfoResource class. La risorsa dati delle informazioni della tavola da disegno"
+type: docs
+weight: 2540
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource class
+
+La risorsa dati delle informazioni della tavola da disegno.
+
+```csharp
+public abstract class BaseArtboardInfoResource : LayerResource
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Ottiene o imposta gli elementi [`OSTypeStructure`](../ostypestructure/). |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/_index.md
@@ -1,0 +1,66 @@
+---
+title: "BaseArtboardInfoResource.Items"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseArtboardInfoResource proprietà. Ottiene o imposta gli elementi OSTypeStructure"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Items property
+
+Ottiene o imposta gli elementi [`OSTypeStructure`](../../ostypestructure/).
+
+```csharp
+public OSTypeStructure[] Items { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [OSTypeStructure](../../ostypestructure/)
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/_index.md
@@ -1,0 +1,22 @@
+---
+title: "BaseArtboardInfoResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseArtboardInfoResource proprietà."
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Length property
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/_index.md
@@ -1,0 +1,22 @@
+---
+title: "BaseArtboardInfoResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseArtboardInfoResource proprietà."
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.PsdVersion property
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseArtboardInfoResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseArtboardInfoResource metodo. Salva la risorsa nel contenitore di flusso specificato"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/_index.md
@@ -1,0 +1,88 @@
+---
+title: "Classe BaseFxResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseFxResource. Risorsa di effetti di base"
+type: docs
+weight: 2550
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/
+---
+{{< psd/tize >}}
+## BaseFxResource class
+
+Risorsa di effetti di base
+
+```csharp
+public abstract class BaseFxResource : LayerResource
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Ottiene la versione del descrittore. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa multi-effetti.
+
+```csharp
+[C#]
+
+// L'immagine PSD contiene 2 effetti Drop Shadow 
+string sourceFile = "MultiExample.psd";
+string outputFile1 = "export1.png";
+string outputFile2 = "export2.png";
+string outputFile3 = "export3.png";
+
+using (PsdImage image = (PsdImage)Aspose.PSD.Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    // Renderizza l'immagine PSD con 2 effetti Drop Shadow.
+    image.Save(outputFile1, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    var blendingOptions = image.Layers[0].BlendingOptions;
+
+    // Aggiunge un terzo effetto Drop Shadow.
+    DropShadowEffect dropShadowEffect3 = blendingOptions.AddDropShadow();
+    dropShadowEffect3.Color = Color.Red;
+    dropShadowEffect3.Distance = 50;
+    dropShadowEffect3.Angle = 0;
+
+    // Renderizza l'immagine PSD con 3 effetti Drop Shadow.
+    image.Save(outputFile2, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // La risorsa imfx è usata se il livello contiene più effetti dello stesso tipo.
+    var imfx = (ImfxResource)image.Layers[0].Resources[0];
+
+    // Cancella tutti gli effetti.
+    blendingOptions.Effects = new ILayerEffect[0];
+
+    DropShadowEffect dropShadowEffect1 = blendingOptions.AddDropShadow();
+    dropShadowEffect1.Color = Color.Blue;
+    dropShadowEffect1.Distance = 10;
+
+    // Renderizza l'immagine PSD con 1 effetto Drop Shadow (gli altri sono stati eliminati).
+    image.Save(outputFile3, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // La risorsa lfx2 è usata se il livello non contiene più effetti dello stesso tipo.
+    var lfx2 = (Lfx2Resource)image.Layers[0].Resources[14];
+}
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseFxResource.DescriptorVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseFxResource. Ottiene la versione del descrittore"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/
+---
+{{< psd/tize >}}
+## BaseFxResource.DescriptorVersion property
+
+Ottiene la versione del descrittore.
+
+```csharp
+public int DescriptorVersion { get; }
+```
+
+### Property Value
+
+La versione del descrittore.
+
+### Vedi anche
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseFxResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseFxResource proprietà. Ottiene la lunghezza della risorsa di livello in byte"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/
+---
+{{< psd/tize >}}
+## BaseFxResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseFxResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseFxResource metodo. Salva la risorsa nel contenitore di stream specificato"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/
+---
+{{< psd/tize >}}
+## BaseFxResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseFxResource.Signature"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseFxResource. Ottiene la firma della risorsa di livello"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/
+---
+{{< psd/tize >}}
+## BaseFxResource.Signature property
+
+Ottiene la firma della risorsa di livello.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Vedi anche
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/_index.md
@@ -1,0 +1,93 @@
+---
+title: "Classe BaseLayerSectionResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseLayerSectionResource class. Classe base per le risorse di sezione di livello"
+type: docs
+weight: 2560
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource class
+
+Classe base per le risorse di sezione di livello
+
+```csharp
+public abstract class BaseLayerSectionResource : LayerResource
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BlendModeKey](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| [SectionType](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/) { get; set; } | Ottiene o imposta il tipo di sezione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+| [Subtype](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/) { get; set; } | Ottiene o imposta il sottotipo. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Esempi
+
+Il codice seguente dimostra la gerarchia delle classi delle risorse di sezione di livello.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/_index.md
@@ -1,0 +1,110 @@
+---
+title: "BaseLayerSectionResource.BlendModeKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "BaseLayerSectionResource proprietà. Ottiene o imposta la chiave della modalità di fusione"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.BlendModeKey property
+
+Ottiene o imposta la chiave della modalità di fusione.
+
+```csharp
+public BlendMode BlendModeKey { get; set; }
+```
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | BlendModeKey deve avere una lunghezza di 4 caratteri. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto di LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+Il codice seguente dimostra la gerarchia delle classi delle risorse di sezione di livello.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Vedi anche
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseLayerSectionResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseLayerSectionResource. Ottiene la lunghezza della risorsa del layer in byte"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseLayerSectionResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo BaseLayerSectionResource. Salva la risorsa nel contenitore di stream specificato"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/_index.md
@@ -1,0 +1,104 @@
+---
+title: "BaseLayerSectionResource.SectionType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseLayerSectionResource. Ottiene o imposta il tipo di sezione"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.SectionType property
+
+Ottiene o imposta il tipo di sezione.
+
+```csharp
+public LayerSectionType SectionType { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+Il codice seguente dimostra la gerarchia delle classi delle risorse di sezione di livello.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Vedi anche
+
+* enum [LayerSectionType](../../layersectiontype/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/_index.md
@@ -1,0 +1,104 @@
+---
+title: "BaseLayerSectionResource.Subtype"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà BaseLayerSectionResource. Ottiene o imposta il sottotipo"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Subtype property
+
+Ottiene o imposta il sottotipo.
+
+```csharp
+public LayerSectionSubtype Subtype { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+Il codice seguente dimostra la gerarchia delle classi delle risorse di sezione di livello.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Vedi anche
+
+* enum [LayerSectionSubtype](../../layersectionsubtype/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.ColorModel"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Modello di colore RGB/HSB/LAB RGBC/HSBl/LbCl"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/
+---
+{{< psd/tize >}}
+## GdFlResource.ColorModel property
+
+Modello di colore - RGB/HSB/LAB ("RGBC"/"HSBl"/"LbCl").
+
+```csharp
+public string ColorModel { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Modalità per questo gradiente. Determina il tipo di gradiente Solid/Noise CstS/ClNs"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/
+---
+{{< psd/tize >}}
+## GdFlResource.GradientMode property
+
+Modalità per questo gradiente. Determina 'Tipo di gradiente' = 'Solido/Rumore' = "CstS"/"ClNs".
+
+```csharp
+public string GradientMode { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GdFlResource.InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Ottiene o imposta il metodo di interpolazione per il gradiente"
+type: docs
+weight: 130
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/
+---
+{{< psd/tize >}}
+## GdFlResource.InterpolationMethod property
+
+Ottiene o imposta il metodo di interpolazione per il gradiente.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [InterpolationMethod](../../../aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GdFlResource.MaximumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Colore massimo di PixelDataFormat"
+type: docs
+weight: 150
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.MaximumColor property
+
+Colore massimo di PixelDataFormat.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GdFlResource.MinimumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Colore minimo di PixelDataFormat"
+type: docs
+weight: 160
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.MinimumColor property
+
+Colore minimo di PixelDataFormat.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.RndNumberSeed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Il seme del numero casuale usato per generare i colori per il gradiente Noise"
+type: docs
+weight: 180
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/
+---
+{{< psd/tize >}}
+## GdFlResource.RndNumberSeed property
+
+Il seme del numero casuale usato per generare i colori per il gradiente Noise.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.Roughness"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Fattore di rugosità"
+type: docs
+weight: 190
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/
+---
+{{< psd/tize >}}
+## GdFlResource.Roughness property
+
+Fattore di rugosità.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.ShowTransparency"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Flag per la visualizzazione della trasparenza"
+type: docs
+weight: 210
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/
+---
+{{< psd/tize >}}
+## GdFlResource.ShowTransparency property
+
+Flag per la visualizzazione della trasparenza.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.UseVectorColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà GdFlResource. Flag per l'uso del colore vettoriale"
+type: docs
+weight: 230
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.UseVectorColor property
+
+Flag per l'uso del colore vettoriale.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Vedi anche
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/_index.md
@@ -1,0 +1,118 @@
+---
+title: "Classe GrdmResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.GrdmResource. Classe GrdmResource. Contiene informazioni sul layer GradientMap."
+type: docs
+weight: 2770
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/
+---
+{{< psd/tize >}}
+## GrdmResource class
+
+Classe GrdmResource. Contiene informazioni sul layer Gradient-Map.
+
+```csharp
+public class GrdmResource : AdjustmentLayerResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [GrdmResource](grdmresource/)(int) | Inizializza una nuova istanza della classe `GrdmResource`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/) { get; set; } | Modello di colore. Quando 'Gradient type' = 'Noise', possiamo assegnare 'Color Model' a RGB/SHB/LAB (3/4/6). |
+| [ColorPoints](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/) { get; set; } | Ottiene o imposta i punti di colore. |
+| [Dither](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/) { get; set; } | Il gradiente è dithertizzato. |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/) { get; set; } | Conteggio di espansione ( = 2 per Photoshop 6.0). |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/) { get; set; } | La modalità per questo gradiente determina 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/) { get; set; } | Nome del gradiente: stringa Unicode, riempita. |
+| [Interpolation](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/) { get; set; } | Interpolazione. Determina la fluidità, quando 'Gradient Type' = 'Solid' (GradientMode = 0). |
+| [InterpolationMethod](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/) { get; set; } | Ottiene o imposta il metodo di interpolazione per il gradiente. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/) { get; set; } | Colore massimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB, ogni canale è a 16 bit. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/) { get; set; } | Colore minimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB, ogni canale è a 16 bit. |
+| override [PsdVersion](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/) { get; } | Ottiene la versione minima di PSD richiesta per questa risorsa. La versione 3 è necessaria quando il metodo di interpolazione è memorizzato esplicitamente. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/) { get; set; } | Il gradiente è invertito. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/) { get; set; } | Il seme del numero casuale usato per generare i colori per il gradiente Noise. |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/) { get; set; } | Fattore di rugosità Quando 'Gradient type' = 'Noise', possiamo assegnare 'Roughness' (0 - 2048). |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/) { get; set; } | Flag per mostrare la trasparenza Quando 'Gradient type' = 'Noise', possiamo assegnare 'Add transparency' a true. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+| [TransparencyPoints](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/) { get; set; } | Ottiene o imposta i punti di trasparenza. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/) { get; set; } | Flag per l'uso del colore vettoriale. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/)(StreamContainer, int) | Salva i dati della risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [AdjustmentLayerResource](../adjustmentlayerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ColorModel"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Modello di colore. Quando il tipo Gradient Noise possiamo assegnare il Modello di colore a RGB/SHB/LAB 3/4/6"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/
+---
+{{< psd/tize >}}
+## GrdmResource.ColorModel property
+
+Modello di colore. Quando 'Gradient type' = 'Noise', possiamo assegnare 'Color Model' a RGB/SHB/LAB (3/4/6).
+
+```csharp
+public short ColorModel { get; set; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/_index.md
@@ -1,0 +1,79 @@
+---
+title: "GrdmResource.ColorPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene o imposta i punti di colore"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/
+---
+{{< psd/tize >}}
+## GrdmResource.ColorPoints property
+
+Ottiene o imposta i punti di colore.
+
+```csharp
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+I punti di colore.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Dither"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Il gradiente è ditherato"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/
+---
+{{< psd/tize >}}
+## GrdmResource.Dither property
+
+Il gradiente è dithertizzato.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ExpansionCount"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Conteggio di espansione   2 per Photoshop 6.0"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/
+---
+{{< psd/tize >}}
+## GrdmResource.ExpansionCount property
+
+Conteggio di espansione ( = 2 per Photoshop 6.0).
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/_index.md
@@ -1,0 +1,75 @@
+---
+title: "GrdmResource.GradientMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Modalità per questo gradiente Determina il Tipo di Gradiente  Solid/Noise 0/1"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/
+---
+{{< psd/tize >}}
+## GrdmResource.GradientMode property
+
+La modalità per questo gradiente determina 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.GradientName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Nome della stringa Unicode del gradiente con riempimento"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/
+---
+{{< psd/tize >}}
+## GrdmResource.GradientName property
+
+Nome del gradiente: stringa Unicode, riempita.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GrdmResource.GrdmResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource costruttore. Inizializza una nuova istanza della classe GrdmResource"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/
+---
+{{< psd/tize >}}
+## GrdmResource constructor
+
+Inizializza una nuova istanza della classe [`GrdmResource`](../).
+
+```csharp
+public GrdmResource(int psdVersion = 1)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| psdVersion | Int32 | La versione psd della risorsa. |
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Interpolation"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Interpolazione. Determina la fluidità quando Gradient Type  Solid GradientMode  0"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/
+---
+{{< psd/tize >}}
+## GrdmResource.Interpolation property
+
+Interpolazione. Determina la fluidità, quando 'Gradient Type' = 'Solid' (GradientMode = 0).
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GrdmResource.InterpolationMethod"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene o imposta il metodo di interpolazione per il gradiente"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/
+---
+{{< psd/tize >}}
+## GrdmResource.InterpolationMethod property
+
+Ottiene o imposta il metodo di interpolazione per il gradiente.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto del rendering del gradiente con il metodo Smooth.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Leggi
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Modifica
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Verifica i dati salvati
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [InterpolationMethod](../../../aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Key"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene la chiave della risorsa di livello"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/
+---
+{{< psd/tize >}}
+## GrdmResource.Key property
+
+Ottiene la chiave della risorsa del livello.
+
+```csharp
+public override int Key { get; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene la lunghezza della risorsa di livello in byte"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/
+---
+{{< psd/tize >}}
+## GrdmResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GrdmResource.MaximumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Colore massimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB. Ogni canale è a 16 bit"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.MaximumColor property
+
+Colore massimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB, ogni canale è a 16 bit.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GrdmResource.MinimumColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Colore minimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB. Ogni canale è a 16 bit"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.MinimumColor property
+
+Colore minimo del formato PixelDataFormat.Rgba64Bpp. Il colore ha canali ARGB, ogni canale è a 16 bit.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene la versione PSD minima richiesta per questa risorsa. La versione 3 è necessaria quando il metodo di interpolazione è memorizzato esplicitamente"
+type: docs
+weight: 130
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/
+---
+{{< psd/tize >}}
+## GrdmResource.PsdVersion property
+
+Ottiene la versione minima di PSD richiesta per questa risorsa. La versione 3 è necessaria quando il metodo di interpolazione è memorizzato esplicitamente.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Reverse"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Indica se il gradiente è invertito"
+type: docs
+weight: 140
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/
+---
+{{< psd/tize >}}
+## GrdmResource.Reverse property
+
+Il gradiente è invertito.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.RndNumberSeed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Il seme del numero casuale usato per generare i colori per il gradiente Noise"
+type: docs
+weight: 150
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/
+---
+{{< psd/tize >}}
+## GrdmResource.RndNumberSeed property
+
+Il seme del numero casuale usato per generare i colori per il gradiente Noise.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Roughness"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Fattore di rugosità Quando il tipo di Gradiente è Noise possiamo assegnare Rugosità 0  2048"
+type: docs
+weight: 160
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/
+---
+{{< psd/tize >}}
+## GrdmResource.Roughness property
+
+Fattore di rugosità Quando 'Gradient type' = 'Noise', possiamo assegnare 'Roughness' (0 - 2048).
+
+```csharp
+public int Roughness { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa GrdmResource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controlla i valori attuali
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Colore rosso per il secondo punto di colore del gradiente
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controlla i valori modificati
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "GrdmResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource metodo. Salva i dati della risorsa nel contenitore di stream specificato"
+type: docs
+weight: 200
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/
+---
+{{< psd/tize >}}
+## GrdmResource.Save method
+
+Salva i dati della risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di flusso. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GrdmResource.SetPsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource metodo. Imposta la versione minima psd richiesta per la risorsa di livello. 0 indica nessuna restrizione"
+type: docs
+weight: 220
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/
+---
+{{< psd/tize >}}
+## GrdmResource.SetPsdVersion method
+
+Imposta la versione minima psd richiesta per la risorsa di livello. 0 indica nessuna restrizione.
+
+```csharp
+public void SetPsdVersion(ushort value)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| valore | UInt16 | Valore Psdversion |
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ShowTransparency"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Flag per mostrare la trasparenza Quando il tipo di Gradiente è Noise possiamo impostare Aggiungi trasparenza su true"
+type: docs
+weight: 170
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/
+---
+{{< psd/tize >}}
+## GrdmResource.ShowTransparency property
+
+Flag per mostrare la trasparenza Quando 'Gradient type' = 'Noise', possiamo assegnare 'Add transparency' a true.
+
+```csharp
+public short ShowTransparency { get; set; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Signature"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene la firma"
+type: docs
+weight: 180
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/
+---
+{{< psd/tize >}}
+## GrdmResource.Signature property
+
+Ottiene la firma.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/_index.md
@@ -1,0 +1,29 @@
+---
+title: "GrdmResource.TransparencyPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Ottiene o imposta i punti di trasparenza"
+type: docs
+weight: 180
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/
+---
+{{< psd/tize >}}
+## GrdmResource.TransparencyPoints property
+
+Ottiene o imposta i punti di trasparenza.
+
+```csharp
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+I punti di trasparenza.
+
+### Vedi anche
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource campo. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 210
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/
+---
+{{< psd/tize >}}
+## GrdmResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.UseVectorColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "GrdmResource proprietà. Flag per l'uso del colore vettoriale"
+type: docs
+weight: 190
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.UseVectorColor property
+
+Flag per l'uso del colore vettoriale.
+
+```csharp
+public short UseVectorColor { get; set; }
+```
+
+### Vedi anche
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Classe IfxsResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IfxsResource class. Risorsa Ifxs per il gruppo di effetti di livello"
+type: docs
+weight: 2840
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/
+---
+{{< psd/tize >}}
+## IfxsResource class
+
+Risorsa Ifxs (risorsa di effetti di gruppo di livello)
+
+```csharp
+public sealed class IfxsResource : BaseFxResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [IfxsResource](ifxsresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Ottiene la versione del descrittore. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto di IfxsResource.
+
+```csharp
+[C#]
+
+string sourceFile = "example.psd";
+string outputFile = "export.psd";
+
+var loadOptions = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+{
+    // L'esempio ha 2 gruppi di livelli con effetti
+    // Gruppo di livello con un effetto
+    LayerGroup layerGroupOne = (LayerGroup)psdImage.Layers[2];
+
+    // Gruppo di livello con molti effetti
+    LayerGroup layerGroupMany = (LayerGroup)psdImage.Layers[5];
+
+    // Ottieni il numero di effetti e verifica la loro quantità
+    int effectCountOne = layerGroupOne.BlendingOptions.Effects.Length;
+    int effectCountMany = layerGroupMany.BlendingOptions.Effects.Length;
+
+    // Un effetto nel gruppo di livello è nella risorsa 'IfxsResource'
+    IfxsResource ifxsResource = (IfxsResource)layerGroupOne.Resources[0];
+
+    // Due o più effetti in un gruppo di livello sono nella risorsa 'ImfxResource'
+    ImfxResource imfxResource = (ImfxResource)layerGroupMany.Resources[0];
+
+    // Aggiungi una terza ombra a un gruppo di livello con effetti multipli
+    layerGroupMany.BlendingOptions.AddDropShadow();
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Vedi anche
+
+* class [BaseFxResource](../basefxresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IfxsResource.IfxsResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IfxsResource costruttore. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/
+---
+{{< psd/tize >}}
+## IfxsResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public IfxsResource()
+```
+
+### Vedi anche
+
+* class [IfxsResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/_index.md
@@ -1,0 +1,65 @@
+---
+title: "IfxsResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IfxsResource campo. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/
+---
+{{< psd/tize >}}
+## IfxsResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di IfxsResource.
+
+```csharp
+[C#]
+
+string sourceFile = "example.psd";
+string outputFile = "export.psd";
+
+var loadOptions = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+{
+    // L'esempio ha 2 gruppi di livelli con effetti
+    // Gruppo di livello con un effetto
+    LayerGroup layerGroupOne = (LayerGroup)psdImage.Layers[2];
+
+    // Gruppo di livello con molti effetti
+    LayerGroup layerGroupMany = (LayerGroup)psdImage.Layers[5];
+
+    // Ottieni il numero di effetti e verifica la loro quantità
+    int effectCountOne = layerGroupOne.BlendingOptions.Effects.Length;
+    int effectCountMany = layerGroupMany.BlendingOptions.Effects.Length;
+
+    // Un effetto nel gruppo di livello è nella risorsa 'IfxsResource'
+    IfxsResource ifxsResource = (IfxsResource)layerGroupOne.Resources[0];
+
+    // Due o più effetti in un gruppo di livello sono nella risorsa 'ImfxResource'
+    ImfxResource imfxResource = (ImfxResource)layerGroupMany.Resources[0];
+
+    // Aggiungi una terza ombra a un gruppo di livello con effetti multipli
+    layerGroupMany.BlendingOptions.AddDropShadow();
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Vedi anche
+
+* class [IfxsResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Classe ImfxResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ImfxResource class. Risorsa Imfx per risorsa multi-effetti"
+type: docs
+weight: 2850
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/
+---
+{{< psd/tize >}}
+## ImfxResource class
+
+Risorsa Imfx (risorsa multi-effetti)
+
+```csharp
+public sealed class ImfxResource : BaseFxResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [ImfxResource](imfxresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Ottiene la versione del descrittore. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della risorsa multi-effetti.
+
+```csharp
+[C#]
+
+// L'immagine PSD contiene 2 effetti Drop Shadow 
+string sourceFile = "MultiExample.psd";
+string outputFile1 = "export1.png";
+string outputFile2 = "export2.png";
+string outputFile3 = "export3.png";
+
+using (PsdImage image = (PsdImage)Aspose.PSD.Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    // Renderizza l'immagine PSD con 2 effetti Drop Shadow.
+    image.Save(outputFile1, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    var blendingOptions = image.Layers[0].BlendingOptions;
+
+    // Aggiunge un terzo effetto Drop Shadow.
+    DropShadowEffect dropShadowEffect3 = blendingOptions.AddDropShadow();
+    dropShadowEffect3.Color = Color.Red;
+    dropShadowEffect3.Distance = 50;
+    dropShadowEffect3.Angle = 0;
+
+    // Renderizza l'immagine PSD con 3 effetti Drop Shadow.
+    image.Save(outputFile2, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // La risorsa imfx è usata se il livello contiene più effetti dello stesso tipo.
+    var imfx = (ImfxResource)image.Layers[0].Resources[0];
+
+    // Cancella tutti gli effetti.
+    blendingOptions.Effects = new ILayerEffect[0];
+
+    DropShadowEffect dropShadowEffect1 = blendingOptions.AddDropShadow();
+    dropShadowEffect1.Color = Color.Blue;
+    dropShadowEffect1.Distance = 10;
+
+    // Renderizza l'immagine PSD con 1 effetto Drop Shadow (gli altri sono stati eliminati).
+    image.Save(outputFile3, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // La risorsa lfx2 è usata se il livello non contiene più effetti dello stesso tipo.
+    var lfx2 = (Lfx2Resource)image.Layers[0].Resources[14];
+}
+```
+
+### Vedi anche
+
+* class [BaseFxResource](../basefxresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ImfxResource.ImfxResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ImfxResource costruttore. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/
+---
+{{< psd/tize >}}
+## ImfxResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public ImfxResource()
+```
+
+### Vedi anche
+
+* class [ImfxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ImfxResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "ImfxResource campo. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ImfxResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [ImfxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/_index.md
@@ -1,0 +1,145 @@
+---
+title: "Interfaccia IPath"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Interfaccia Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IPath. L'interfaccia descrive l'insieme di percorsi presenti in un livello Shape."
+type: docs
+weight: 2800
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/
+---
+{{< psd/tize >}}
+## IPath interface
+
+L'interfaccia descrive l'insieme di percorsi presenti in un livello Shape.
+
+```csharp
+public interface IPath
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [IsDisabled](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/) { get; set; } | Il percorso è disabilitato. |
+| [IsInverted](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/) { get; set; } | Il percorso è invertito. |
+| [IsNotLinked](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/) { get; set; } | Il percorso non è collegato. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/)() | Ottiene l'array di forme in un percorso. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/)(IPathShape[]) | Imposta l'array di forme in un percorso. |
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPath.GetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IPath method. Ottiene un array di forme in un percorso"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/
+---
+{{< psd/tize >}}
+## IPath.GetItems method
+
+Ottiene l'array di forme in un percorso.
+
+```csharp
+public IPathShape[] GetItems()
+```
+
+### Valore di ritorno
+
+Array di IPathShape.
+
+### Vedi anche
+
+* interface [IPathShape](../../ipathshape/)
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsDisabled"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IPath. Il percorso è disabilitato"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/
+---
+{{< psd/tize >}}
+## IPath.IsDisabled property
+
+Il percorso è disabilitato.
+
+```csharp
+public bool IsDisabled { get; set; }
+```
+
+### Vedi anche
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsInverted"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IPath. Il percorso è invertito"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/
+---
+{{< psd/tize >}}
+## IPath.IsInverted property
+
+Il percorso è invertito.
+
+```csharp
+public bool IsInverted { get; set; }
+```
+
+### Vedi anche
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsNotLinked"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "IPath property. Il percorso non è collegato"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/
+---
+{{< psd/tize >}}
+## IPath.IsNotLinked property
+
+Il percorso non è collegato.
+
+```csharp
+public bool IsNotLinked { get; set; }
+```
+
+### Vedi anche
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPath.SetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo IPath. Imposta l'array di forme in un percorso"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/
+---
+{{< psd/tize >}}
+## IPath.SetItems method
+
+Imposta l'array di forme in un percorso.
+
+```csharp
+public void SetItems(IPathShape[] shapes)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| forme | IPathShape[] | Array di IPathShape. |
+
+### Vedi anche
+
+* interface [IPathShape](../../ipathshape/)
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/_index.md
@@ -1,0 +1,144 @@
+---
+title: "Interfaccia IPathShape"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Interfaccia Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IPathShape. La forma dai nodi della curva di Bézier"
+type: docs
+weight: 2810
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/
+---
+{{< psd/tize >}}
+## IPathShape interface
+
+La forma dai nodi della curva di Bézier.
+
+```csharp
+public interface IPathShape
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [IsClosed](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/) { get; set; } | Ottiene o imposta la proprietà che determina se la forma è chiusa. |
+| [PathOperations](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/) { get; set; } | Le operazioni per la combinazione delle forme di percorso (operazioni booleane). |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/)() | Ottiene l'array dei nodi Bézier. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/)(BezierKnotRecord[]) | Assegna un array di nodi Bexier. |
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPathShape.GetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo IPathShape. Ottiene un array di nodi Bezier"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/
+---
+{{< psd/tize >}}
+## IPathShape.GetItems method
+
+Ottiene l'array dei nodi Bézier.
+
+```csharp
+public BezierKnotRecord[] GetItems()
+```
+
+### Valore di ritorno
+
+Array di BezierKnotRecord.
+
+### Vedi anche
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPathShape.IsClosed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IPathShape. Ottiene o imposta la proprietà che determina se la Forma è chiusa"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/
+---
+{{< psd/tize >}}
+## IPathShape.IsClosed property
+
+Ottiene o imposta la proprietà che determina se la forma è chiusa.
+
+```csharp
+public bool IsClosed { get; set; }
+```
+
+### Vedi anche
+
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IPathShape.PathOperations"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IPathShape. Le operazioni per le forme di percorso che combinano operazioni booleane"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/
+---
+{{< psd/tize >}}
+## IPathShape.PathOperations property
+
+Le operazioni per la combinazione delle forme di percorso (operazioni booleane).
+
+```csharp
+public PathOperations PathOperations { get; set; }
+```
+
+### Vedi anche
+
+* enum [PathOperations](../../../aspose.psd.fileformats.core.vectorpaths/pathoperations/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPathShape.SetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo IPathShape. Assegna un array di nodi Bezier"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/
+---
+{{< psd/tize >}}
+## IPathShape.SetItems method
+
+Assegna un array di nodi Bexier.
+
+```csharp
+public void SetItems(BezierKnotRecord[] bezierPoints)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| bezierPoints | BezierKnotRecord[] | Array di nodi bezier |
+
+### Vedi anche
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/_index.md
@@ -1,0 +1,130 @@
+---
+title: "Interfaccia IStrokeSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Interfaccia Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IStrokeSettings. Impostazioni di contorno delle forme"
+type: docs
+weight: 2670
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/
+---
+{{< psd/tize >}}
+## IStrokeSettings interface
+
+Impostazioni di tratto delle forme.
+
+```csharp
+public interface IStrokeSettings
+```
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BlendMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/
+---
+## Lfx2Resource.BlendMode property
+
+Ottiene la modalità di fusione.
+
+```csharp
+public BlendMode BlendMode { get; }
+```
+
+### Property Value
+
+La modalità di fusione.
+
+### Vedi anche
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode)
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Data"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/
+---
+## Lfx2Resource.Data property
+
+Ottiene o imposta i dati.
+
+```csharp
+public byte[] Data { get; set; }
+```
+
+### Property Value
+
+I dati.
+
+### Vedi anche
+
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/_index.md
@@ -1,0 +1,28 @@
+---
+title: "EffectColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/
+---
+## Lfx2Resource.EffectColor property
+
+Ottiene il colore dell'effetto.
+
+```csharp
+public Color EffectColor { get; }
+```
+
+### Property Value
+
+Il colore dell'effetto.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color)
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Opacity"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/
+---
+## Lfx2Resource.Opacity property
+
+Ottiene l'opacità.
+
+```csharp
+public double Opacity { get; }
+```
+
+### Property Value
+
+L'opacità.
+
+### Vedi anche
+
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/_index.md
@@ -1,0 +1,56 @@
+---
+title: "Lfx2Resource test"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 2570
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/
+---
+## Lfx2Resource class
+
+Risorsa Lfx2 (risorsa effetti)
+
+```csharp
+public sealed class Lfx2Resource : LayerResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [Lfx2Resource](lfx2resource)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BlendMode](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode) { get; } | Ottiene la modalità di fusione. |
+| [Data](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data) { get; set; } | Ottiene o imposta i dati. |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/descriptorversion) { get; } | Ottiene la versione del descrittore. |
+| [EffectColor](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor) { get; } | Ottiene il colore dell'effetto. |
+| override [Key](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/key) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/length) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity) { get; } | Ottiene l'opacità. |
+| override [PsdVersion](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/psdversion) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| override [Signature](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/signature) { get; } | Ottiene la firma della risorsa di livello. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/save)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Altri membri
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](typetoolkey) | La chiave delle informazioni dello strumento di tipo. |
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources)
+* assembly [Aspose.PSD](../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/_index.md
@@ -1,0 +1,116 @@
+---
+title: "Classe LmskResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LmskResource. La risorsa LMsk"
+type: docs
+weight: 3020
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/
+---
+{{< psd/tize >}}
+## LmskResource class
+
+La risorsa LMsk.
+
+```csharp
+public class LmskResource : LayerResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [LmskResource](lmskresource/)() | Inizializza una nuova istanza della classe `LmskResource`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [ColorComponent1](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/) { get; set; } | Ottiene il componente colore 1. |
+| [ColorComponent2](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/) { get; set; } | Ottiene il componente colore 2. |
+| [ColorComponent3](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/) { get; set; } | Ottiene il componente colore 3. |
+| [ColorComponent4](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/) { get; set; } | Ottiene il componente colore 4. |
+| [ColorSpace](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/) { get; set; } | Ottiene lo spazio colore. |
+| [Flag](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/) { get; } | Ottiene il flag. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/) { get; set; } | Ottiene l'opacità. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Osservazioni
+
+Questa risorsa contiene l'ID dello spazio colore, che si riferisce a un tipo specifico di spazio colore, e 4 componenti colore. A seconda dell'ID, i componenti colore hanno significati diversi. Se il tipo di spazio colore non richiede quattro valori, i componenti extra sono indefiniti e sempre scritti come zero. Componenti colore per tipo di spazio colore: RGB - i primi tre componenti sono rosso, verde e blu. HSB - i primi tre componenti sono tonalità, saturazione e luminosità. CMYK - i quattro componenti sono ciano, magenta, giallo e nero. Lab - i primi tre componenti sono luminosità, crominanza a e crominanza b. Grayscale - il primo componente è il valore di grigio, da 0...10000.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent1"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene il componente colore 1"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent1 property
+
+Ottiene il componente colore 1.
+
+```csharp
+public ushort ColorComponent1 { get; set; }
+```
+
+### Property Value
+
+Il componente colore 1.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent2"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource property. Ottiene il componente colore 2"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent2 property
+
+Ottiene il componente colore 2.
+
+```csharp
+public ushort ColorComponent2 { get; set; }
+```
+
+### Property Value
+
+Il componente colore 2.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent3"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource property. Ottiene il componente colore 3"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent3 property
+
+Ottiene il componente colore 3.
+
+```csharp
+public ushort ColorComponent3 { get; set; }
+```
+
+### Property Value
+
+Il componente colore 3.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent4"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource property. Ottiene il componente colore 4"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent4 property
+
+Ottiene il componente colore 4.
+
+```csharp
+public ushort ColorComponent4 { get; set; }
+```
+
+### Property Value
+
+Il componente colore 4.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/_index.md
@@ -1,0 +1,82 @@
+---
+title: "LmskResource.ColorSpace"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene lo spazio colore"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/
+---
+{{< psd/tize >}}
+## LmskResource.ColorSpace property
+
+Ottiene lo spazio colore.
+
+```csharp
+public ColorSpace ColorSpace { get; set; }
+```
+
+### Property Value
+
+Lo spazio colore.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* enum [ColorSpace](../../../aspose.psd.fileformats.psd.resources.enums/colorspace/)
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.Flag"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene il flag"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/
+---
+{{< psd/tize >}}
+## LmskResource.Flag property
+
+Ottiene il flag.
+
+```csharp
+public byte Flag { get; }
+```
+
+### Property Value
+
+Il flag.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Key"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene la chiave della risorsa di livello"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/
+---
+{{< psd/tize >}}
+## LmskResource.Key property
+
+Ottiene la chiave della risorsa del livello.
+
+```csharp
+public override int Key { get; }
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene la lunghezza della risorsa di livello in byte"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/
+---
+{{< psd/tize >}}
+## LmskResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.LmskResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource constructor. Inizializza una nuova istanza della classe LmskResource"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/
+---
+{{< psd/tize >}}
+## LmskResource constructor
+
+Inizializza una nuova istanza della classe [`LmskResource`](../).
+
+```csharp
+public LmskResource()
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.Opacity"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LmskResource. Ottiene l'opacità"
+type: docs
+weight: 90
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/
+---
+{{< psd/tize >}}
+## LmskResource.Opacity property
+
+Ottiene l'opacità.
+
+```csharp
+public short Opacity { get; set; }
+```
+
+### Property Value
+
+L'opacità.
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource property. Ottiene la versione psd"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/
+---
+{{< psd/tize >}}
+## LmskResource.PsdVersion property
+
+Ottiene la versione psd.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LmskResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource method. Salva la risorsa nel contenitore di stream specificato"
+type: docs
+weight: 100
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/
+---
+{{< psd/tize >}}
+## LmskResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Signature"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LmskResource property. Ottiene la firma"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/
+---
+{{< psd/tize >}}
+## LmskResource.Signature property
+
+Ottiene la firma.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo LmskResource. La chiave di informazioni dello strumento di tipo"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LmskResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Classe LrXxResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LrXxResource. La risorsa lrXX"
+type: docs
+weight: 3100
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/
+---
+{{< psd/tize >}}
+## LrXxResource class
+
+La risorsa lrXX.
+
+```csharp
+public abstract class LrXxResource : LayerResource
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| [Layers](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/) { get; set; } | Ottiene o imposta i livelli. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/) { get; } | Ottiene la lunghezza della risorsa per la versione dell'intestazione PSD dell'immagine. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/)(StreamContainer, int) | Salva il record del livello. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Key"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource proprietà. Ottiene la chiave della risorsa di livello"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/
+---
+{{< psd/tize >}}
+## LrXxResource.Key property
+
+Ottiene la chiave della risorsa del livello.
+
+```csharp
+public override int Key { get; }
+```
+
+### Vedi anche
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/_index.md
@@ -1,0 +1,29 @@
+---
+title: "LrXxResource.Layers"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource proprietà. Ottiene o imposta i livelli"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/
+---
+{{< psd/tize >}}
+## LrXxResource.Layers property
+
+Ottiene o imposta i livelli.
+
+```csharp
+public Layer[] Layers { get; set; }
+```
+
+### Property Value
+
+I livelli.
+
+### Vedi anche
+
+* class [Layer](../../../aspose.psd.fileformats.psd.layers/layer/)
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource proprietà. Ottiene la lunghezza della risorsa per la versione dell'intestazione PSD dell'immagine"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/
+---
+{{< psd/tize >}}
+## LrXxResource.Length property
+
+Ottiene la lunghezza della risorsa per la versione dell'intestazione PSD dell'immagine.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.LrXxResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource costruttore. Inizializza una nuova istanza della classe LrXxResource"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/
+---
+{{< psd/tize >}}
+## LrXxResource constructor
+
+Inizializza una nuova istanza della classe [`LrXxResource`](../).
+
+```csharp
+public LrXxResource()
+```
+
+### Vedi anche
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource proprietà. Ottiene la versione PSD"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/
+---
+{{< psd/tize >}}
+## LrXxResource.PsdVersion property
+
+Ottiene la versione psd.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/_index.md
@@ -1,0 +1,36 @@
+---
+title: "LrXxResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource metodo. Salva il record del livello"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/
+---
+{{< psd/tize >}}
+## LrXxResource.Save method
+
+Salva il record del livello.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di flusso. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| NotImplementedException | Il salvataggio dei canali a XX bit non è implementato |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Signature"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LrXxResource proprietà. Ottiene la firma"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/
+---
+{{< psd/tize >}}
+## LrXxResource.Signature property
+
+Ottiene la firma.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Vedi anche
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/_index.md
@@ -1,0 +1,86 @@
+---
+title: "Classe LsdkResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LsdkResource. La risorsa del livello lsdk risorsa della sezione di livello annidata"
+type: docs
+weight: 3110
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/
+---
+{{< psd/tize >}}
+## LsdkResource class
+
+La risorsa del livello lsdk (risorsa della sezione di livello annidata).
+
+```csharp
+public class LsdkResource : BaseLayerSectionResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [LsdkResource](lsdkresource/)() | Inizializza una nuova istanza della classe `LsdkResource`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BlendModeKey](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/) { get; } | Ottiene la lunghezza della risorsa del livello in byte. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| [SectionType](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/) { get; set; } | Ottiene o imposta il tipo di sezione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+| [Subtype](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/) { get; set; } | Ottiene o imposta il sottotipo. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto di LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controlla dopo il salvataggio
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+### Vedi anche
+
+* class [BaseLayerSectionResource](../baselayersectionresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "LsdkResource.BlendModeKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LsdkResource proprietà. Ottiene o imposta la chiave della modalità di fusione"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/
+---
+{{< psd/tize >}}
+## LsdkResource.BlendModeKey property
+
+Ottiene o imposta la chiave della modalità di fusione.
+
+```csharp
+public BlendMode BlendModeKey { get; set; }
+```
+
+### Eccezioni
+
+| eccezione | condizione |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | BlendModeKey deve avere una lunghezza di 4 caratteri. |
+
+### Vedi anche
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LsdkResource. Ottiene la lunghezza della risorsa di livello in byte"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/
+---
+{{< psd/tize >}}
+## LsdkResource.Length property
+
+Ottiene la lunghezza della risorsa del livello in byte.
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.LsdkResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore LsdkResource. Inizializza una nuova istanza della classe LsdkResource"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/
+---
+{{< psd/tize >}}
+## LsdkResource constructor
+
+Inizializza una nuova istanza della classe [`LsdkResource`](../).
+
+```csharp
+public LsdkResource()
+```
+
+### Vedi anche
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LsdkResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "LsdkResource metodo. Salva la risorsa nel contenitore di flusso specificato"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/
+---
+{{< psd/tize >}}
+## LsdkResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "LsdkResource.SectionType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LsdkResource. Ottiene o imposta il tipo di sezione"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/
+---
+{{< psd/tize >}}
+## LsdkResource.SectionType property
+
+Ottiene o imposta il tipo di sezione.
+
+```csharp
+public LayerSectionType SectionType { get; set; }
+```
+
+### Vedi anche
+
+* enum [LayerSectionType](../../layersectiontype/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "LsdkResource.Subtype"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LsdkResource. Ottiene o imposta il sottotipo"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/
+---
+{{< psd/tize >}}
+## LsdkResource.Subtype property
+
+Ottiene o imposta il sottotipo.
+
+```csharp
+public LayerSectionSubtype Subtype { get; set; }
+```
+
+### Vedi anche
+
+* enum [LayerSectionSubtype](../../layersectionsubtype/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo LsdkResource. La chiave delle informazioni dello strumento di tipo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LsdkResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Classe LyvrResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LyvrResource class. La risorsa che rappresenta la versione Photoshop del livello"
+type: docs
+weight: 3150
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/
+---
+{{< psd/tize >}}
+## LyvrResource class
+
+La risorsa che rappresenta la versione Photoshop del livello.
+
+```csharp
+public sealed class LyvrResource : LayerResource
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [LyvrResource](lyvrresource/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Ottiene la chiave della risorsa del livello. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Ottiene la versione minima di psd richiesta per la risorsa del livello. 0 indica nessuna restrizione. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Ottiene la firma. |
+| [Version](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/) { get; set; } | Ottiene o imposta la versione Photoshop del livello. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/)(StreamContainer, int) | Salva la risorsa nel contenitore di stream specificato. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Restituisce una stringa che rappresenta questa istanza. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/) | La chiave delle informazioni dello strumento di tipo. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/_index.md
@@ -1,0 +1,22 @@
+---
+title: "LyvrResource.Length"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LyvrResource."
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/
+---
+{{< psd/tize >}}
+## LyvrResource.Length property
+
+```csharp
+public override int Length { get; }
+```
+
+### Vedi anche
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LyvrResource.LyvrResource"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore LyvrResource. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/
+---
+{{< psd/tize >}}
+## LyvrResource constructor
+
+Il costruttore predefinito.
+
+```csharp
+public LyvrResource()
+```
+
+### Vedi anche
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/_index.md
@@ -1,0 +1,22 @@
+---
+title: "LyvrResource.PsdVersion"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LyvrResource."
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/
+---
+{{< psd/tize >}}
+## LyvrResource.PsdVersion property
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Vedi anche
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LyvrResource.Save"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo LyvrResource. Salva la risorsa nel contenitore di stream specificato"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/
+---
+{{< psd/tize >}}
+## LyvrResource.Save method
+
+Salva la risorsa nel contenitore di stream specificato.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| streamContainer | StreamContainer | Il contenitore di stream in cui salvare. |
+| psdVersion | Int32 | La versione PSD. |
+
+### Vedi anche
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LyvrResource.TypeToolKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo LyvrResource. La chiave delle informazioni sul tipo di strumento"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LyvrResource.TypeToolKey field
+
+La chiave delle informazioni dello strumento di tipo.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Vedi anche
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/_index.md
@@ -1,0 +1,65 @@
+---
+title: "LyvrResource.Version"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà LyvrResource. Ottiene o imposta la versione Photoshop del Layer"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/
+---
+{{< psd/tize >}}
+## LyvrResource.Version property
+
+Ottiene o imposta la versione Photoshop del livello.
+
+```csharp
+public int Version { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto delle risorse Artboard.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/_index.md
@@ -1,0 +1,154 @@
+---
+title: "Classe PathShape"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.PathShape. La figura dai nodi della curva di Bézier"
+type: docs
+weight: 3210
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/
+---
+{{< psd/tize >}}
+## PathShape class
+
+La figura dai nodi della curva di Bézier.
+
+```csharp
+public class PathShape : IPathShape
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [PathShape](pathshape/#constructor)() | Inizializza una nuova istanza della classe `PathShape`. |
+| [PathShape](pathshape/#constructor_1)(LengthRecord, BezierKnotRecord[]) | Inizializza una nuova istanza della classe `PathShape`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [IsClosed](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/) { get; set; } | Ottiene o imposta un valore che indica se questa istanza è chiusa. |
+| [PathOperations](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/) { get; set; } | Ottiene o imposta le operazioni di percorso (operazioni booleane). |
+| [ShapeIndex](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/) { get; set; } | Ottiene o imposta l'indice della forma di percorso corrente nel livello. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/)() | Ottiene l'array dei nodi Bézier. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/)(BezierKnotRecord[]) | Assegna l'array dei nodi Bézier. |
+| [ToVectorPathRecords](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/)() | Crea i record [`VectorPathRecord`](../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/) basati su questa istanza. |
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* interface [IPathShape](../ipathshape/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.GetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PathShape. Ottiene un array di nodi Bezier"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/
+---
+{{< psd/tize >}}
+## PathShape.GetItems method
+
+Ottiene l'array dei nodi Bézier.
+
+```csharp
+public BezierKnotRecord[] GetItems()
+```
+
+### Valore di ritorno
+
+Array di BezierKnotRecord
+
+### Vedi anche
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PathShape.IsClosed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PathShape. Ottiene o imposta un valore che indica se questa istanza è chiusa"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/
+---
+{{< psd/tize >}}
+## PathShape.IsClosed property
+
+Ottiene o imposta un valore che indica se questa istanza è chiusa.
+
+```csharp
+public bool IsClosed { get; set; }
+```
+
+### Property Value
+
+`true` se questa istanza è chiusa; altrimenti, `false`.
+
+### Vedi anche
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/_index.md
@@ -1,0 +1,25 @@
+---
+title: "PathShape.PathOperations"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PathShape. Ottiene o imposta le operazioni booleane delle operazioni di percorso"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/
+---
+{{< psd/tize >}}
+## PathShape.PathOperations property
+
+Ottiene o imposta le operazioni di percorso (operazioni booleane).
+
+```csharp
+public PathOperations PathOperations { get; set; }
+```
+
+### Vedi anche
+
+* enum [PathOperations](../../../aspose.psd.fileformats.core.vectorpaths/pathoperations/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PathShape.PathShape"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore PathShape. Inizializza una nuova istanza della classe PathShape"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/
+---
+{{< psd/tize >}}
+## PathShape() {#constructor}
+
+Inizializza una nuova istanza della classe [`PathShape`](../).
+
+```csharp
+public PathShape()
+```
+
+### Vedi anche
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## PathShape(LengthRecord, BezierKnotRecord[]) {#constructor_1}
+
+Inizializza una nuova istanza della classe [`PathShape`](../).
+
+```csharp
+public PathShape(LengthRecord lengthRecord, BezierKnotRecord[] bezierKnotRecords)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| lengthRecord | LengthRecord | Il record di lunghezza. |
+| bezierKnotRecords | BezierKnotRecord[] | I record dei nodi Bezier. |
+
+### Vedi anche
+
+* class [LengthRecord](../../../aspose.psd.fileformats.core.vectorpaths/lengthrecord/)
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.SetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PathShape. Assegna un array di nodi Bezier"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/
+---
+{{< psd/tize >}}
+## PathShape.SetItems method
+
+Assegna l'array dei nodi Bézier.
+
+```csharp
+public void SetItems(BezierKnotRecord[] bezierPoints)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| bezierPoints | BezierKnotRecord[] | Array di nodi bezier |
+
+### Vedi anche
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PathShape.ShapeIndex"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PathShape. Ottiene o imposta l'indice della forma di percorso corrente nel livello"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/
+---
+{{< psd/tize >}}
+## PathShape.ShapeIndex property
+
+Ottiene o imposta l'indice della forma di percorso corrente nel livello.
+
+```csharp
+public ushort ShapeIndex { get; set; }
+```
+
+### Vedi anche
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.ToVectorPathRecords"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PathShape. Crea i record VectorPathRecord basati su questa istanza"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/
+---
+{{< psd/tize >}}
+## PathShape.ToVectorPathRecords method
+
+Crea i record [`VectorPathRecord`](../../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/) basati su questa istanza.
+
+```csharp
+public IEnumerable<VectorPathRecord> ToVectorPathRecords()
+```
+
+### Valore di ritorno
+
+Restituisce un [`LengthRecord`](../../../aspose.psd.fileformats.core.vectorpaths/lengthrecord/) e un [`BezierKnotRecord`](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/) per ogni punto in questa istanza.
+
+### Vedi anche
+
+* class [VectorPathRecord](../../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PtFlResource.Angle"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "PtFlResource property. Ottiene o imposta l'angolo"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/
+---
+{{< psd/tize >}}
+## PtFlResource.Angle property
+
+Ottiene o imposta l'angolo.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+L'angolo.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà Angle in PtFlResource.
+
+```csharp
+[C#]
+
+string sourceFile = "PatternFillLayerWide_0.psd";
+string outputFile = "PatternFillLayerWide_0_output.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    FillLayer fillLayer = (FillLayer)image.Layers[1];
+    PatternFillSettings fillSettings = (PatternFillSettings)fillLayer.FillSettings;
+    fillSettings.Angle = 70;
+    fillLayer.Update();
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (PsdImage image = (PsdImage)Image.Load(outputFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    FillLayer fillLayer = (FillLayer)image.Layers[1];
+    PatternFillSettings fillSettings = (PatternFillSettings)fillLayer.FillSettings;
+
+    Assert.AreEqual(70, fillSettings.Angle);
+}
+```
+
+### Vedi anche
+
+* class [PtFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/_index.md
@@ -1,0 +1,154 @@
+---
+title: "Classe VectorPath"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.LayerResources.VectorPath. La classe che contiene percorsi vettoriali"
+type: docs
+weight: 3730
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/
+---
+{{< psd/tize >}}
+## VectorPath class
+
+La classe che contiene percorsi vettoriali.
+
+```csharp
+public class VectorPath : IPath
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [VectorPath](vectorpath/)() | Inizializza una nuova istanza della classe `VectorPath`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [IsDisabled](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/) { get; set; } | Ottiene o imposta un valore che indica se questa istanza è disabilitata. |
+| [IsFillStartsWithAllPixels](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/) { get; set; } | Ottiene o imposta un valore che indica se il riempimento inizia con tutti i pixel. |
+| [IsInverted](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/) { get; set; } | Ottiene o imposta un valore che indica se questa istanza è invertita. |
+| [IsNotLinked](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/) { get; set; } | Ottiene o imposta un valore che indica se questa istanza non è collegata. |
+| [Version](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/) { get; set; } | Ottiene o imposta la versione. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/)() | Ottiene l'array di forme in un percorso. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/)(IPathShape[]) | Imposta l'array di forme in un percorso. |
+
+## Esempi
+
+Il codice seguente dimostra gli oggetti percorso dalle risorse vsms o vmsk per ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Rimuovi una forma
+    shapes.RemoveAt(1);
+
+    // Salva i dati modificati nella risorsa
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Verifica i valori modificati nel file salvato
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Il file salvato dovrebbe contenere 1 forma
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Vedi anche
+
+* interface [IPath](../ipath/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "VectorPath.FillColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta il colore di riempimento del percorso vettoriale"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/
+---
+{{< psd/tize >}}
+## VectorPath.FillColor property
+
+Ottiene o imposta il colore di riempimento del percorso vettoriale.
+
+```csharp
+public Color FillColor { get; set; }
+```
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "VectorPath.GetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo VectorPath. Ottiene un array di forme in un percorso"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/
+---
+{{< psd/tize >}}
+## VectorPath.GetItems method
+
+Ottiene l'array di forme in un percorso.
+
+```csharp
+public IPathShape[] GetItems()
+```
+
+### Valore di ritorno
+
+Array di IPathShape.
+
+### Vedi anche
+
+* interface [IPathShape](../../ipathshape/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsDisabled"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta un valore che indica se questa istanza è disabilitata"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/
+---
+{{< psd/tize >}}
+## VectorPath.IsDisabled property
+
+Ottiene o imposta un valore che indica se questa istanza è disabilitata.
+
+```csharp
+public bool IsDisabled { get; set; }
+```
+
+### Property Value
+
+`true` se questa istanza è disabilitata; altrimenti, `false`.
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsFillStartsWithAllPixels"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta un valore che indica se il riempimento inizia con tutti i pixel"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/
+---
+{{< psd/tize >}}
+## VectorPath.IsFillStartsWithAllPixels property
+
+Ottiene o imposta un valore che indica se il riempimento inizia con tutti i pixel.
+
+```csharp
+public bool IsFillStartsWithAllPixels { get; set; }
+```
+
+### Property Value
+
+Il riempimento inizia con tutti i pixel.
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsInverted"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta un valore che indica se questa istanza è invertita"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/
+---
+{{< psd/tize >}}
+## VectorPath.IsInverted property
+
+Ottiene o imposta un valore che indica se questa istanza è invertita.
+
+```csharp
+public bool IsInverted { get; set; }
+```
+
+### Property Value
+
+`true` se questa istanza è invertita; altrimenti, `false`.
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsNotLinked"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta un valore che indica se questa istanza non è collegata"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/
+---
+{{< psd/tize >}}
+## VectorPath.IsNotLinked property
+
+Ottiene o imposta un valore che indica se questa istanza non è collegata.
+
+```csharp
+public bool IsNotLinked { get; set; }
+```
+
+### Property Value
+
+`true` se questa istanza non è collegata; altrimenti, `false`.
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "VectorPath.SetItems"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo VectorPath. Imposta un array di Shape in un Path"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/
+---
+{{< psd/tize >}}
+## VectorPath.SetItems method
+
+Imposta l'array di forme in un percorso.
+
+```csharp
+public void SetItems(IPathShape[] shapes)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| forme | IPathShape[] | Array di IPathShape. |
+
+### Vedi anche
+
+* interface [IPathShape](../../ipathshape/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VectorPath.VectorPath"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore VectorPath. Inizializza una nuova istanza della classe VectorPath"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/
+---
+{{< psd/tize >}}
+## VectorPath constructor
+
+Inizializza una nuova istanza della classe [`VectorPath`](../).
+
+```csharp
+public VectorPath()
+```
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.Version"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà VectorPath. Ottiene o imposta la versione"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/
+---
+{{< psd/tize >}}
+## VectorPath.Version property
+
+Ottiene o imposta la versione.
+
+```csharp
+public int Version { get; set; }
+```
+
+### Property Value
+
+La versione.
+
+### Vedi anche
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/_index.md
@@ -1,0 +1,106 @@
+---
+title: "Classe SharpenSmartFilter"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.SmartFilters.SharpenSmartFilter classe. Il filtro intelligente Sharpen"
+type: docs
+weight: 3870
+url: /it/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter class
+
+Il filtro intelligente Sharpen.
+
+```csharp
+public sealed class SharpenSmartFilter : SmartFilter
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [SharpenSmartFilter](sharpensmartfilter/#constructor)() | Inizializza una nuova istanza della classe `SharpenSmartFilter`. |
+| [SharpenSmartFilter](sharpensmartfilter/#constructor_1)(DescriptorStructure) | Inizializza una nuova istanza della classe `SharpenSmartFilter`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BlendMode](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/blendmode/) { get; set; } | Ottiene o imposta la modalità di fusione. |
+| override [FilterId](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/) { get; } | Ottiene l'identificatore del tipo di filtro intelligente. |
+| [IsEnabled](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/isenabled/) { get; set; } | Ottiene o imposta lo stato abilitato del filtro intelligente. |
+| override [Name](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/) { get; } | Ottiene il nome del filtro intelligente. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/opacity/) { get; set; } | Ottiene o imposta il valore di opacità del filtro intelligente. |
+| [SourceDescriptor](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/sourcedescriptor/) { get; } | La struttura del descrittore di origine con i dati del filtro intelligente. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [Apply](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/apply/)(RasterImage) | Applica il filtro corrente all'immagine di input [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ApplyToMask](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/applytomask/)(Layer) | Applica il filtro corrente ai dati della maschera di input [`Layer`](../../aspose.psd.fileformats.psd.layers/layer/). |
+| [Clone](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/clone/)() | Crea la clonazione membro per membro dell'istanza corrente del tipo. |
+
+## Campi
+
+| Nome | Descrizione |
+| --- | --- |
+| const [FilterType](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/) | L'identificatore del filtro intelligente corrente. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto di SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // modifica filtri intelligenti
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controlla i valori del filtro
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // aggiorna i valori del filtro
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // aggiungi nuovi elementi filtro
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // applica le modifiche
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SmartFilter](../smartfilter/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.FilterId"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SharpenSmartFilter. Ottiene l'identificatore del tipo di filtro intelligente"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.FilterId property
+
+Ottiene l'identificatore del tipo di filtro intelligente.
+
+```csharp
+public override int FilterId { get; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // modifica filtri intelligenti
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controlla i valori del filtro
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // aggiorna i valori del filtro
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // aggiungi nuovi elementi filtro
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // applica le modifiche
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.FilterType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Campo SharpenSmartFilter. L'identificatore del filtro intelligente corrente"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.FilterType field
+
+L'identificatore del filtro intelligente corrente.
+
+```csharp
+public const int FilterType;
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // modifica filtri intelligenti
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controlla i valori del filtro
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // aggiorna i valori del filtro
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // aggiungi nuovi elementi filtro
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // applica le modifiche
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.Name"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SharpenSmartFilter. Ottiene il nome del filtro intelligente"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.Name property
+
+Ottiene il nome del filtro intelligente.
+
+```csharp
+public override string Name { get; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // modifica filtri intelligenti
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controlla i valori del filtro
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // aggiorna i valori del filtro
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // aggiungi nuovi elementi filtro
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // applica le modifiche
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/_index.md
@@ -1,0 +1,95 @@
+---
+title: "SharpenSmartFilter.SharpenSmartFilter"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore SharpenSmartFilter. Inizializza una nuova istanza della classe SharpenSmartFilter"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter() {#constructor}
+
+Inizializza una nuova istanza della classe [`SharpenSmartFilter`](../).
+
+```csharp
+public SharpenSmartFilter()
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto di SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // modifica filtri intelligenti
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controlla i valori del filtro
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // aggiorna i valori del filtro
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // aggiungi nuovi elementi filtro
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // applica le modifiche
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## SharpenSmartFilter(DescriptorStructure) {#constructor_1}
+
+Inizializza una nuova istanza della classe [`SharpenSmartFilter`](../).
+
+```csharp
+public SharpenSmartFilter(DescriptorStructure sourceDescriptor)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| sourceDescriptor | DescriptorStructure | La struttura del descrittore con le informazioni del filtro intelligente. |
+
+### Vedi anche
+
+* class [DescriptorStructure](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/descriptorstructure/)
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SmartObjectLayer.SmartObjectLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore SmartObjectLayer. Inizializza una nuova istanza della classe SmartObjectLayer"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/
+---
+{{< psd/tize >}}
+## SmartObjectLayer constructor
+
+Inizializza una nuova istanza della classe [`SmartObjectLayer`](../).
+
+```csharp
+public SmartObjectLayer(Stream stream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| flusso | Flusso | Il flusso di elementi |
+
+### Vedi anche
+
+* class [SmartObjectLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartObjects](../../../aspose.psd.fileformats.psd.layers.smartobjects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/_index.md
@@ -1,0 +1,108 @@
+---
+title: "SmartObjectLayer.WarpSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà SmartObjectLayer. Ottiene o imposta i parametri Warp che sono stati impostati o ottenuti dalla risorsa predefinita"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/
+---
+{{< psd/tize >}}
+## SmartObjectLayer.WarpSettings property
+
+Ottiene o imposta i parametri Warp che sono stati impostati o ottenuti dalla risorsa (predefinita)
+
+```csharp
+public WarpSettings WarpSettings { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* class [WarpSettings](../../../aspose.psd.fileformats.psd.layers.warp/warpsettings/)
+* class [SmartObjectLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartObjects](../../../aspose.psd.fileformats.psd.layers.smartobjects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Layers.Warp"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Lo spazio dei nomi contiene API per manipolare i dati dei livelli di testo"
+type: docs
+weight: 370
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/
+---
+{{< psd/tize >}}
+Lo spazio dei nomi contiene API per manipolare i dati dei livelli di testo
+
+## Classi
+
+| Classe | Descrizione |
+| --- | --- |
+| [WarpSettings](./warpsettings/) | Parametri del livello con warp |
+## Enumerazione
+
+| Enumerazione | Descrizione |
+| --- | --- |
+| [RenderQuality](./renderquality/) | Descrive la qualità di rendering di Warp. |
+| [WarpRotates](./warprotates/) | Tipi di rotazione warp |
+| [WarpStyles](./warpstyles/) | Tipi di stili warp supportati |
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/renderquality/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/renderquality/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Enum RenderQuality"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.RenderQuality enum. Descrive la qualità di rendering del Warp"
+type: docs
+weight: 3990
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/renderquality/
+---
+{{< psd/tize >}}
+## RenderQuality enumeration
+
+Descrive la qualità di rendering di Warp.
+
+```csharp
+public enum RenderQuality
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Turbo | `4` | L'opzione più veloce, ma la qualità ne risente. |
+| VeryFast | `18` | Se ti serve veloce, può essere adatto per piccole curvature. |
+| Fast | `35` | Consente di rendere il rendering più veloce con una piccola perdita di qualità. |
+| Normal | `60` | Valore consigliato per la maggior parte delle curvature |
+| Good | `130` | Qualità superiore a quella standard, velocità più lenta. Consigliato per distorsioni marcate. |
+| Excellent | `260` | L'opzione più lenta. Consigliata per distorsioni marcate e alte risoluzioni. |
+
+## Esempi
+
+Il codice seguente dimostra la proprietà WarpSettings.RenderQuality per configurare la deformazione warp.
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+RenderQuality[] qualityValues = { RenderQuality.Turbo, RenderQuality.Fast, RenderQuality.Normal, RenderQuality.Excellent };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Ottiene WarpSettings dal livello Smart
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Imposta la dimensione dell'area di elaborazione del warp
+        warpSettings.RenderQuality = qualityValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + qualityValues[i].ToString() + ".png";
+        outputFiles.Add(outputFile);
+
+        // Non dovrebbe esserci alcun errore qui
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warprotates/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warprotates/_index.md
@@ -1,0 +1,113 @@
+---
+title: "Enum WarpRotates"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpRotates enum. Tipi di rotazione della deformazione"
+type: docs
+weight: 4000
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warprotates/
+---
+{{< psd/tize >}}
+## WarpRotates enumeration
+
+Tipi di rotazione warp
+
+```csharp
+public enum WarpRotates
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Horizontal | `0` | Direzione di deformazione orizzontale |
+| Vertical | `1` | Direzione di deformazione verticale |
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/_index.md
@@ -1,0 +1,127 @@
+---
+title: "Classe WarpSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpSettings. Parametri del livello con warp"
+type: docs
+weight: 4010
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/
+---
+{{< psd/tize >}}
+## WarpSettings class
+
+Parametri del livello con warp
+
+```csharp
+public class WarpSettings
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [WarpSettings](warpsettings/#constructor_1)(PlacedResource) | Inizializza una nuova istanza della classe `WarpSettings`. |
+| [WarpSettings](warpsettings/#constructor)(OSTypeStructure[], Rectangle) | Inizializza una nuova istanza della classe `WarpSettings`. |
+| [WarpSettings](warpsettings/#constructor_2)(PointF[], Rectangle) | Inizializza una nuova istanza della classe `WarpSettings`. |
+| [WarpSettings](warpsettings/#constructor_3)(PointF[], Rectangle, WarpStyles) | Inizializza una nuova istanza della classe `WarpSettings`. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Bounds](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/) { get; } | Ottiene o imposta i limiti dell'immagine warp |
+| [GridSize](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/) { get; set; } | Ottiene o imposta la dimensione della griglia warp. Il valore predefinito è 1. |
+| [MeshPoints](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/) { get; set; } | Punti mesh di Photoshop |
+| [RenderQuality](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/) { get; set; } | Ottiene o imposta il valore della qualità di rendering warp - tra velocità e qualità |
+| [Rotate](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/) { get; set; } | Ottiene o imposta il valore di rotazione |
+| [Style](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/style/) { get; set; } | Ottiene o imposta lo stile del warp |
+| [Value](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/value/) { get; set; } | Ottiene o imposta il valore del warp |
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/_index.md
@@ -1,0 +1,25 @@
+---
+title: "WarpSettings.Bounds"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta i limiti dell'immagine deformata"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/
+---
+{{< psd/tize >}}
+## WarpSettings.Bounds property
+
+Ottiene o imposta i limiti dell'immagine warp
+
+```csharp
+public Rectangle Bounds { get; }
+```
+
+### Vedi anche
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/_index.md
@@ -1,0 +1,55 @@
+---
+title: "WarpSettings.GridSize"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta la dimensione della griglia di deformazione. Il valore predefinito è 1"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/
+---
+{{< psd/tize >}}
+## WarpSettings.GridSize property
+
+Ottiene o imposta la dimensione della griglia warp. Il valore predefinito è 1.
+
+```csharp
+public Size GridSize { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà WarpSettings.GridSize.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Ottieni le impostazioni di deformazione
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Imposta nuova dimensione
+    // Per Photoshop il valore può essere compreso tra 1 e 50 e non è possibile salvare correttamente il file PSD.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Imposta valore valido
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Esegui il rendering del file di esempio con griglia x3
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Vedi anche
+
+* struct [Size](../../../aspose.psd/size/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/_index.md
@@ -1,0 +1,25 @@
+---
+title: "WarpSettings.MeshPoints"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Punti mesh di Photoshop"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/
+---
+{{< psd/tize >}}
+## WarpSettings.MeshPoints property
+
+Punti mesh di Photoshop
+
+```csharp
+public PointF[] MeshPoints { get; set; }
+```
+
+### Vedi anche
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/_index.md
@@ -1,0 +1,58 @@
+---
+title: "WarpSettings.ProcessingArea"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta il valore della dimensione dell'area di elaborazione. Il valore predefinito è 10. L'intervallo è 240"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/
+---
+{{< psd/tize >}}
+## WarpSettings.ProcessingArea property
+
+Ottiene o imposta il valore della dimensione dell'area di elaborazione. Il valore predefinito è 10. L'intervallo è [2;40]
+
+```csharp
+public int ProcessingArea { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra la proprietà WarpSettings.ProcessingArea per configurare la deformazione
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+int[] areaValues = { 5, 10, 25, 40 };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Ottiene WarpSettings dal livello Smart
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Imposta la dimensione dell'area di elaborazione del warp
+        warpSettings.ProcessingArea = areaValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + areaValues[i] + ".png";
+        outputFiles.Add(outputFile);
+
+        // Non dovrebbe esserci alcun errore qui
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Vedi anche
+
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/_index.md
@@ -1,0 +1,59 @@
+---
+title: "WarpSettings.RenderQuality"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta il valore della qualità di rendering della deformazione tra velocità e qualità"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/
+---
+{{< psd/tize >}}
+## WarpSettings.RenderQuality property
+
+Ottiene o imposta il valore della qualità di rendering warp - tra velocità e qualità
+
+```csharp
+public RenderQuality RenderQuality { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra la proprietà WarpSettings.RenderQuality per configurare la deformazione warp.
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+RenderQuality[] qualityValues = { RenderQuality.Turbo, RenderQuality.Fast, RenderQuality.Normal, RenderQuality.Excellent };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Ottiene WarpSettings dal livello Smart
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Imposta la dimensione dell'area di elaborazione del warp
+        warpSettings.RenderQuality = qualityValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + qualityValues[i].ToString() + ".png";
+        outputFiles.Add(outputFile);
+
+        // Non dovrebbe esserci alcun errore qui
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Vedi anche
+
+* enum [RenderQuality](../../renderquality/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/_index.md
@@ -1,0 +1,108 @@
+---
+title: "WarpSettings.Rotate"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta il valore di rotazione"
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/
+---
+{{< psd/tize >}}
+## WarpSettings.Rotate property
+
+Ottiene o imposta il valore di rotazione
+
+```csharp
+public WarpRotates Rotate { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* enum [WarpRotates](../../warprotates/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/_index.md
@@ -1,0 +1,108 @@
+---
+title: "WarpSettings.Style"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta lo stile della deformazione"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/
+---
+{{< psd/tize >}}
+## WarpSettings.Style property
+
+Ottiene o imposta lo stile del warp
+
+```csharp
+public WarpStyles Style { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* enum [WarpStyles](../../warpstyles/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/_index.md
@@ -1,0 +1,24 @@
+---
+title: "WarpSettings.Value"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà WarpSettings. Ottiene o imposta il valore della deformazione"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/
+---
+{{< psd/tize >}}
+## WarpSettings.Value property
+
+Ottiene o imposta il valore del warp
+
+```csharp
+public double Value { get; set; }
+```
+
+### Vedi anche
+
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/_index.md
@@ -1,0 +1,160 @@
+---
+title: "WarpSettings.WarpSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore WarpSettings. Inizializza una nuova istanza della classe WarpSettings"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/
+---
+{{< psd/tize >}}
+## WarpSettings(PointF[], Rectangle) {#constructor_2}
+
+Inizializza una nuova istanza della classe [`WarpSettings`](../).
+
+```csharp
+public WarpSettings(PointF[] meshPoints, Rectangle bounds)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| meshPoints | PointF[] | I punti della mesh della deformazione |
+| bounds | Rettangolo | I limiti dell'immagine di deformazione |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà WarpSettings.GridSize.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Ottieni le impostazioni di deformazione
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Imposta nuova dimensione
+    // Per Photoshop il valore può essere compreso tra 1 e 50 e non è possibile salvare correttamente il file PSD.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Imposta valore valido
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Esegui il rendering del file di esempio con griglia x3
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Vedi anche
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(PointF[], Rectangle, WarpStyles) {#constructor_3}
+
+Inizializza una nuova istanza della classe [`WarpSettings`](../).
+
+```csharp
+public WarpSettings(PointF[] meshPoints, Rectangle bounds, WarpStyles style)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| meshPoints | PointF[] | I punti della mesh della deformazione |
+| bounds | Rettangolo | I limiti dell'immagine di deformazione |
+| stile | WarpStyles | Lo stile della deformazione |
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà WarpSettings.GridSize.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Ottieni le impostazioni di deformazione
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Imposta nuova dimensione
+    // Per Photoshop il valore può essere compreso tra 1 e 50 e non è possibile salvare correttamente il file PSD.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Imposta valore valido
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Esegui il rendering del file di esempio con griglia x3
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Vedi anche
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* enum [WarpStyles](../../warpstyles/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(OSTypeStructure[], Rectangle) {#constructor}
+
+Inizializza una nuova istanza della classe [`WarpSettings`](../).
+
+```csharp
+public WarpSettings(OSTypeStructure[] warpItems, Rectangle bounds)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| warpItems | OSTypeStructure[] | Elementi PS con impostazioni di deformazione |
+| bounds | Rettangolo | I limiti dell'immagine di deformazione |
+
+### Vedi anche
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(PlacedResource) {#constructor_1}
+
+Inizializza una nuova istanza della classe [`WarpSettings`](../).
+
+```csharp
+public WarpSettings(PlacedResource placedResource)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| placedResource | PlacedResource | La risorsa con impostazioni di deformazione |
+
+### Vedi anche
+
+* class [PlacedResource](../../../aspose.psd.fileformats.psd.layers.layerresources/placedresource/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/_index.md
@@ -1,0 +1,125 @@
+---
+title: "Enum WarpStyles"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpStyles enum. Tipi di stili di warp supportati"
+type: docs
+weight: 4020
+url: /it/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/
+---
+{{< psd/tize >}}
+## WarpStyles enumeration
+
+Tipi di stili warp supportati
+
+```csharp
+public enum WarpStyles
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| None | `0` | Lo stile è impostato quando il livello non ha deformazione. |
+| Custom | `1` | Stile con movimento arbitrario dei punti |
+| Arc | `2` | Stile ad arco del warp |
+| ArcUpper | `3` | Stile ad arco superiore del warp |
+| ArcLower | `4` | Stile ad arco inferiore del warp |
+| Arch | `5` | Stile a volta del warp |
+| Bulge | `6` | Stile a rigonfiamento del warp |
+| Flag | `7` | Stile a bandiera del warp |
+| Fish | `8` | Stile a pesce del warp |
+| Rise | `9` | Stile di sollevamento del warp |
+| Wave | `10` | Stile Wave del warp |
+| Twist | `11` | Tipo Twist del warp |
+| Squeeze | `12` | Tipo Squeeze del warp |
+| Inflate | `13` | Tipo Inflate del warp |
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/_index.md
@@ -1,0 +1,211 @@
+---
+title: "Classe ArtboardLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.ArtboardLayer. La classe del layer artboard"
+type: docs
+weight: 1990
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/
+---
+{{< psd/tize >}}
+## ArtboardLayer class
+
+La classe del layer artboard.
+
+```csharp
+public sealed class ArtboardLayer : LayerGroup
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Ottiene o imposta un valore che indica se regolare automaticamente la tavolozza. |
+| override [BackgroundColor](../../aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/) { get; set; } | Ottiene o imposta il colore di sfondo del layer artboard. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Ottiene il conteggio dei bit per pixel dell'immagine. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Ottiene o imposta la fusione dell'elemento ritagliato. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Ottiene le opzioni di fusione. |
+| override [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layergroup/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Ottiene la firma della modalità di fusione. |
+| override [Bottom](../../aspose.psd.fileformats.psd.layers/artboardlayer/bottom/) { get; set; } |  |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Ottiene i limiti dell'immagine. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Ottiene o imposta le informazioni del canale. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Ottiene il conteggio dei canali del livello. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Ottiene o imposta il ritaglio del livello. 0 = base, 1 = non-base. |
+| [Container](../../aspose.psd/image/container/) { get; } | Ottiene il contenitore [`Image`](../../aspose.psd/image/). |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Ottiene il flusso di dati dell'oggetto. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Ottiene o imposta il nome visualizzato del livello. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Ottiene un valore che indica se questa istanza è stata eliminata. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Ottiene la lunghezza delle informazioni aggiuntive del livello in byte. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Ottiene un valore del formato file |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Ottiene o imposta il riempitore del livello. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Ottiene o imposta l'opacità del riempimento. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Ottiene o imposta i flag del livello. bit 0 = trasparenza protetta; bit 1 = visibile; bit 2 = obsoleto; bit 3 = 1 per Photoshop 5.0 e versioni successive, indica se il bit 4 contiene informazioni utili; bit 4 = dati pixel irrilevanti per l'aspetto del documento. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Ottiene un valore che indica se questa istanza ha alfa. |
+| override [HasBackgroundColor](../../aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/) { get; } | Ottiene o imposta un valore che indica se `ArtboardLayer` ha il colore di sfondo. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Ottiene un valore che indica se l'immagine ha un colore trasparente. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/artboardlayer/height/) { get; } |  |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Ottiene o imposta la risoluzione orizzontale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Ottiene l'opacità di questa immagine. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Ottiene o imposta il monitor di interruzione. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Restituisce un valore che indica se i dati dell'immagine sono attualmente memorizzati nella cache. |
+| [IsOpen](../../aspose.psd.fileformats.psd.layers/layergroup/isopen/) { get; set; } | Ottiene o imposta se la cartella è aperta; se impostato su `true` il gruppo sarà nello stato aperto all'avvio, altrimenti sarà minimizzato. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Restituisce un valore che indica se il caricamento dei dati grezzi è disponibile. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Ottiene o imposta un valore che indica se il livello è visibile |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Restituisce un valore che indica se questa istanza è visibile nel gruppo (se il livello non è in un gruppo significa gruppo radice). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Ottiene o imposta i dati degli intervalli di fusione del livello. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Ottiene o imposta la data e l'ora di creazione del livello. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Ottiene o imposta il blocco del livello. Nota che se il flag LayerFlags.TransparencyProtected è impostato verrà sovrascritto dal flag di blocco del livello. Per restituire il flag LayerFlags.TransparencyProtected è necessario applicarlo all'opzione del livello layer.Flags &#x7C;= LayerFlags.TransparencyProtected |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Ottiene o imposta i dati della maschera del livello. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Restituisce le opzioni del livello. |
+| [Layers](../../aspose.psd.fileformats.psd.layers/layergroup/layers/) { get; } | Ottiene i layer nel gruppo di layer |
+| override [Left](../../aspose.psd.fileformats.psd.layers/artboardlayer/left/) { get; set; } |  |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Restituisce la lunghezza complessiva del livello in byte. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Ottiene o imposta il nome del livello. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Ottiene o imposta l'opacità del livello. 0 = trasparente, 255 = opaco. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Ottiene o imposta la tavolozza dei colori. La tavolozza dei colori non viene utilizzata quando i pixel sono rappresentati direttamente. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Ottiene o imposta un valore che indica se i componenti dell'immagine devono essere premoltiplicati. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore personalizzato |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Restituisce il formato dei dati grezzi. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Restituisce le impostazioni attuali dei dati grezzi. Nota che quando si usano queste impostazioni i dati vengono caricati senza conversione. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Ottiene o imposta l'indice di fallback da utilizzare quando l'indice della tavolozza è fuori dai limiti |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore indicizzato |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Restituisce la dimensione della riga grezza in byte. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Ottiene o imposta le risorse del livello. |
+| override [Right](../../aspose.psd.fileformats.psd.layers/artboardlayer/right/) { get; set; } |  |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Ottiene o imposta l'evidenziazione del colore del foglio decorativo nell'elenco dei livelli. |
+| [Size](../../aspose.psd/image/size/) { get; } | Ottiene le dimensioni dell'immagine. |
+| override [Top](../../aspose.psd.fileformats.psd.layers/artboardlayer/top/) { get; set; } |  |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Ottiene il colore trasparente dell'immagine. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Ottiene o imposta un valore che indica se aggiornare i metadati XMP. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Ottiene un valore che indica se la palette dell'immagine è utilizzata. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Ottiene o imposta un valore che indica se utilizzare il caricamento di dati grezzi quando è disponibile. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Ottiene o imposta la risoluzione verticale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| override [Width](../../aspose.psd.fileformats.psd.layers/artboardlayer/width/) { get; } |  |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Ottiene o imposta i metadati XMP. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| [AddLayer](../../aspose.psd.fileformats.psd.layers/layergroup/addlayer/)(Layer) | Aggiunge il layer al gruppo di layer. |
+| [AddLayerGroup](../../aspose.psd.fileformats.psd.layers/layergroup/addlayergroup/)(string, int) | Aggiunge il gruppo di layer. |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Aggiunge la maschera al livello corrente. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Regola la luminosità dell'immagine. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Contrasto dell'immagine |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Correzione gamma di un'immagine. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Correzione gamma di un'immagine. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Applica la maschera di livello al livello, quindi elimina la maschera. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarizzazione di un'immagine con soglia predefinita |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarizzazione di un'immagine con sogliatura di Otsu |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Memorizza nella cache i dati e garantisce che non vengano effettuati ulteriori caricamenti di dati dal [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/) sottostante. |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Determina se l'immagine può essere salvata nel formato file specificato rappresentato dalle opzioni di salvataggio fornite. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Ritaglio dell'immagine. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Ritaglia l'immagine con spostamenti. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Elimina l'istanza corrente. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Esegue il dithering sull'immagine corrente. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Esegue il dithering sull'immagine corrente. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Disegna l'immagine sul livello. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtra il rettangolo specificato. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Ottiene un pixel immagine a 32-bit ARGB. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Ottiene l'array predefinito di pixel ARGB a 32-bit. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Ottiene le opzioni predefinite. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Ottiene l'array predefinito di pixel usando il caricatore di pixel parziali. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Ottiene l'array predefinito di dati grezzi. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Ottiene l'array predefinito di dati grezzi usando il caricatore di pixel parziali. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Restituisce un codice hash per questa istanza. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Ottiene la data e l'ora dell'ultima modifica dell'immagine di risorsa. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Ottiene le opzioni basate sulle impostazioni del file originale. Questo può essere utile per mantenere inalterata la profondità di bit e altri parametri dell'immagine originale. Ad esempio, se carichiamo un'immagine PNG in bianco e nero a 1 bit per pixel e poi la salviamo usando il metodo [`Save`](../../aspose.psd/datastreamsupporter/save/), verrà generata un'immagine PNG di output a 8 bit per pixel. Per evitarlo e salvare l'immagine PNG a 1 bit per pixel, utilizza questo metodo per ottenere le opzioni di salvataggio corrispondenti e passale al metodo [`Save`](../../aspose.psd/image/save/) come secondo parametro. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Ottiene un pixel immagine. Avviso sulle prestazioni: evita di utilizzare questo metodo per iterare su tutti i pixel dell'immagine poiché può causare notevoli problemi di prestazioni. Per una manipolazione dei pixel più efficiente, utilizza il metodo `LoadArgb32Pixels` per recuperare l'intero array di pixel simultaneamente. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Ottiene l'angolo di inclinazione. Questo metodo è applicabile ai documenti di testo scansionati, per determinare l'angolo di inclinazione durante la scansione. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Trasformazione di un'immagine nella sua rappresentazione in scala di grigi |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Carica pixel ARGB a 32-bit. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Carica pixel ARGB a 64-bit. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Carica pixel in formato CMYK. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Carica pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare in modo più efficace il metodo [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/). |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Carica parzialmente pixel ARGB a 32-bit per pacchetti. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Carica pixel parzialmente per pacchetti. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Carica pixel. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| virtual [MergeLayerTo](../../aspose.psd.fileformats.psd.layers/layer/mergelayerto/)(Layer) | Unisce il livello al livello specificato |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Ridimensiona l'immagine. Viene utilizzato il NearestNeighbourResample predefinito. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Ridimensiona l'immagine. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Ridimensiona l'immagine. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Ridimensiona l'altezza proporzionalmente. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Ridimensiona la larghezza proporzionalmente. Viene utilizzato il NearestNeighbourResample predefinito. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Ruota l'immagine attorno al centro. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Ruota l'immagine attorno al centro. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Ruota, capovolge o ruota e capovolge l'immagine. |
+| [Save](../../aspose.psd/image/save/)() | Salva i dati dell'immagine nello stream sottostante. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Salva i dati dell'oggetto nello stream specificato. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Salva i dati dell'oggetto nella posizione file specificata. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Salva i dati dell'oggetto nella posizione file specificata. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Salva i pixel ARGB a 32 bit. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Salva i pixel. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo più efficace [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/). |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Salva i pixel. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Salva i dati grezzi. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Imposta un pixel ARGB a 32 bit dell'immagine per la posizione specificata. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Imposta la tavolozza dell'immagine. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Imposta un pixel dell'immagine per la posizione specificata. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Imposta la risoluzione per questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Crea una copia superficiale del Layer corrente. Si prega di [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) per spiegazione. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converte l'immagine raster in bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione di ArtboardLayer come immagini separate e tutte in un'unica immagine.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Vedi anche
+
+* class [LayerGroup](../layergroup/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ArtboardLayer.BackgroundColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer. Ottiene o imposta il colore di sfondo dell'artboard"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/
+---
+{{< psd/tize >}}
+## ArtboardLayer.BackgroundColor property
+
+Ottiene o imposta il colore di sfondo del layer artboard.
+
+```csharp
+public override Color BackgroundColor { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto per l'esportazione di ArtboardLayer come immagini separate e tutte in un'unica immagine.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Bottom"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Bottom property
+
+```csharp
+public override int Bottom { get; set; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtboardLayer.HasBackgroundColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer. Ottiene o imposta un valore che indica se ArtboardLayer ha il colore di sfondo"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/
+---
+{{< psd/tize >}}
+## ArtboardLayer.HasBackgroundColor property
+
+Ottiene o imposta un valore che indica se [`ArtboardLayer`](../) ha il colore di sfondo.
+
+```csharp
+public override bool HasBackgroundColor { get; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Height"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Height property
+
+```csharp
+public override int Height { get; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Left"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Left property
+
+```csharp
+public override int Left { get; set; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Right"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Right property
+
+```csharp
+public override int Right { get; set; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Top"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 70
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Top property
+
+```csharp
+public override int Top { get; set; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Width"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ArtboardLayer."
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Width property
+
+```csharp
+public override int Width { get; }
+```
+
+### Vedi anche
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "IGradientColorPoint.Color"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IGradientColorPoint. Ottiene o imposta il colore."
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/
+---
+{{< psd/tize >}}
+## IGradientColorPoint.Color property
+
+Ottiene o imposta il colore.
+
+```csharp
+[Obsolete]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+Il colore.
+
+### Vedi anche
+
+* struct [Color](../../../aspose.psd/color/)
+* interface [IGradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/_index.md
@@ -1,0 +1,115 @@
+---
+title: "Interfaccia IShapeLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Interfaccia Aspose.PSD.FileFormats.Psd.Layers.IShapeLayer. Descrive le proprietà del livello Shape"
+type: docs
+weight: 2260
+url: /it/net/aspose.psd.fileformats.psd.layers/ishapelayer/
+---
+{{< psd/tize >}}
+## IShapeLayer interface
+
+Descrive le proprietà del livello Shape.
+
+```csharp
+public interface IShapeLayer
+```
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [Fill](../../aspose.psd.fileformats.psd.layers/ishapelayer/fill/) { get; set; } | Impostazioni di riempimento utilizzate per riempire l'area interna delle forme. |
+| [Path](../../aspose.psd.fileformats.psd.layers/ishapelayer/path/) { get; } | L'insieme di Path presenti in un livello Shape. |
+| [Stroke](../../aspose.psd.fileformats.psd.layers/ishapelayer/stroke/) { get; set; } | Impostazioni di tratto delle forme. |
+
+## Esempi
+
+Il codice seguente dimostra il rendering di supporto di Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Verifica i dati modificati.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Fill"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IShapeLayer. Impostazioni di riempimento usate per riempire l'area interna delle forme."
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/
+---
+{{< psd/tize >}}
+## IShapeLayer.Fill property
+
+Impostazioni di riempimento utilizzate per riempire l'area interna delle forme.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Vedi anche
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Path"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IShapeLayer. L'insieme di percorsi presenti in un livello Shape."
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/
+---
+{{< psd/tize >}}
+## IShapeLayer.Path property
+
+L'insieme di Path presenti in un livello Shape.
+
+```csharp
+public IPath Path { get; }
+```
+
+### Vedi anche
+
+* interface [IPath](../../../aspose.psd.fileformats.psd.layers.layerresources/ipath/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Stroke"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà IShapeLayer. Impostazioni di contorno delle forme."
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/
+---
+{{< psd/tize >}}
+## IShapeLayer.Stroke property
+
+Impostazioni di tratto delle forme.
+
+```csharp
+public IStrokeSettings Stroke { get; set; }
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Layer.ApplyLayerMask"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Layer. Applica la maschera del livello al livello e poi elimina la maschera"
+type: docs
+weight: 350
+url: /it/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/
+---
+{{< psd/tize >}}
+## Layer.ApplyLayerMask method
+
+Applica la maschera di livello al livello, quindi elimina la maschera.
+
+```csharp
+public void ApplyLayerMask()
+```
+
+## Esempi
+
+Il codice seguente dimostra la funzionalità di applicare la maschera al livello.
+
+```csharp
+[C#]
+
+var sourceFile = "example.psd";
+var outFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    psdImage.Layers[1].ApplyLayerMask();
+
+    psdImage.Save(outFile, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+```
+
+### Vedi anche
+
+* class [Layer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Layer.BlendClippedElements"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà Layer. Ottiene o imposta la fusione dell'elemento ritagliato"
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/
+---
+{{< psd/tize >}}
+## Layer.BlendClippedElements property
+
+Ottiene o imposta la fusione dell'elemento ritagliato.
+
+```csharp
+public bool BlendClippedElements { get; set; }
+```
+
+### Property Value
+
+La fusione dell'elemento ritagliato.
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà BlendClippedElements.
+
+```csharp
+[C#]
+
+string sourceFile = "example_source.psd";
+string outputPsd = "example_output.psd";
+string outputPng = "example_output.png";
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    image.Layers[1].BlendClippedElements = false;
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [Layer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/layer/equals/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/layer/equals/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Equals"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 350
+url: /it/net/aspose.psd.fileformats.psd.layers/layer/equals/
+---
+## Layer.Equals method
+
+Determina se l'Object specificato è uguale a questa istanza.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | Object | L'Object da confrontare con questa istanza. |
+
+## Valore di ritorno
+
+`true` se l'Object specificato è uguale a questa istanza; altrimenti, `false`.
+
+### Vedi anche
+
+* class [Layer](../../layer)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../layer)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/_index.md
@@ -1,0 +1,219 @@
+---
+title: "Classe ShapeLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.FileFormats.Psd.Layers.ShapeLayer. Livello Shape. Incapsula la logica di lavoro con il livello Shape e le risorse correlate"
+type: docs
+weight: 3820
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/
+---
+{{< psd/tize >}}
+## ShapeLayer class
+
+Livello Shape. Incapsula la logica di lavoro con il livello Shape e le risorse correlate.
+
+```csharp
+public class ShapeLayer : Layer, IShapeLayer
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [ShapeLayer](shapelayer/)() | Inizializza una nuova istanza della classe `ShapeLayer`. Tutte le risorse sono create nello stato predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Ottiene o imposta un valore che indica se regolare automaticamente la tavolozza. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Ottiene o imposta un valore per il colore di sfondo. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Ottiene il conteggio dei bit per pixel dell'immagine. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Ottiene o imposta la fusione dell'elemento ritagliato. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Ottiene le opzioni di fusione. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Ottiene o imposta la chiave della modalità di fusione. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Ottiene la firma della modalità di fusione. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Ottiene o imposta la posizione del livello inferiore. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Ottiene i limiti dell'immagine. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Ottiene o imposta le informazioni del canale. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Ottiene il conteggio dei canali del livello. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Ottiene o imposta il ritaglio del livello. 0 = base, 1 = non-base. |
+| [Container](../../aspose.psd/image/container/) { get; } | Ottiene il contenitore [`Image`](../../aspose.psd/image/). |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Ottiene il flusso di dati dell'oggetto. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Ottiene o imposta il nome visualizzato del livello. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Ottiene un valore che indica se questa istanza è stata eliminata. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Ottiene la lunghezza delle informazioni aggiuntive del livello in byte. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Ottiene un valore del formato file |
+| [Fill](../../aspose.psd.fileformats.psd.layers/shapelayer/fill/) { get; set; } | Ottiene o imposta le impostazioni di riempimento per l'area interna delle forme nel livello Shape. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Ottiene o imposta il riempitore del livello. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Ottiene o imposta l'opacità del riempimento. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Ottiene o imposta i flag del livello. bit 0 = trasparenza protetta; bit 1 = visibile; bit 2 = obsoleto; bit 3 = 1 per Photoshop 5.0 e versioni successive, indica se il bit 4 contiene informazioni utili; bit 4 = dati pixel irrilevanti per l'aspetto del documento. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Ottiene un valore che indica se questa istanza ha alfa. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Ottiene o imposta un valore che indica se l'immagine ha un colore di sfondo. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Ottiene un valore che indica se l'immagine ha un colore trasparente. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Ottiene l'altezza dell'immagine. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Ottiene o imposta la risoluzione orizzontale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Ottiene l'opacità di questa immagine. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Ottiene o imposta il monitor di interruzione. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Restituisce un valore che indica se i dati dell'immagine sono attualmente memorizzati nella cache. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Restituisce un valore che indica se il caricamento dei dati grezzi è disponibile. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Ottiene o imposta un valore che indica se il livello è visibile |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Restituisce un valore che indica se questa istanza è visibile nel gruppo (se il livello non è in un gruppo significa gruppo radice). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Ottiene o imposta i dati degli intervalli di fusione del livello. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Ottiene o imposta la data e l'ora di creazione del livello. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Ottiene o imposta il blocco del livello. Nota che se il flag LayerFlags.TransparencyProtected è impostato verrà sovrascritto dal flag di blocco del livello. Per restituire il flag LayerFlags.TransparencyProtected è necessario applicarlo all'opzione del livello layer.Flags &#x7C;= LayerFlags.TransparencyProtected |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Ottiene o imposta i dati della maschera del livello. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Restituisce le opzioni del livello. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Ottiene o imposta la posizione sinistra del livello. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Restituisce la lunghezza complessiva del livello in byte. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Ottiene o imposta il nome del livello. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Ottiene o imposta l'opacità del livello. 0 = trasparente, 255 = opaco. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Ottiene o imposta la tavolozza dei colori. La tavolozza dei colori non viene utilizzata quando i pixel sono rappresentati direttamente. |
+| [Path](../../aspose.psd.fileformats.psd.layers/shapelayer/path/) { get; } | Restituisce l'insieme di Paths che sono presenti in un livello Shape. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Ottiene o imposta un valore che indica se i componenti dell'immagine devono essere premoltiplicati. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore personalizzato |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Restituisce il formato dei dati grezzi. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Restituisce le impostazioni attuali dei dati grezzi. Nota che quando si usano queste impostazioni i dati vengono caricati senza conversione. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Ottiene o imposta l'indice di fallback da utilizzare quando l'indice della tavolozza è fuori dai limiti |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Ottiene o imposta il convertitore di colore indicizzato |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Restituisce la dimensione della riga grezza in byte. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Ottiene o imposta le risorse del livello. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Ottiene o imposta la posizione destra del livello. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Ottiene o imposta l'evidenziazione del colore del foglio decorativo nell'elenco dei livelli. |
+| [Size](../../aspose.psd/image/size/) { get; } | Ottiene le dimensioni dell'immagine. |
+| [Stroke](../../aspose.psd.fileformats.psd.layers/shapelayer/stroke/) { get; set; } | Ottiene o imposta le impostazioni del tratto delle forme. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Ottiene o imposta la posizione del livello superiore. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Ottiene il colore trasparente dell'immagine. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Ottiene o imposta un valore che indica se aggiornare i metadati XMP. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Ottiene un valore che indica se la palette dell'immagine è utilizzata. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Ottiene o imposta un valore che indica se utilizzare il caricamento di dati grezzi quando è disponibile. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Ottiene o imposta la risoluzione verticale, in pixel per pollice, di questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Ottiene la larghezza dell'immagine. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Ottiene o imposta i metadati XMP. |
+
+## Metodi
+
+| Nome | Descrizione |
+| --- | --- |
+| static [CreateInstance](../../aspose.psd.fileformats.psd.layers/shapelayer/createinstance/)() | Crea una nuova istanza della classe `ShapeLayer`. |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Aggiunge la maschera al livello corrente. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Regola la luminosità dell'immagine. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Contrasto dell'immagine |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Correzione gamma di un'immagine. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Correzione gamma di un'immagine. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Applica la maschera di livello al livello, quindi elimina la maschera. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarizzazione di un'immagine usando l'algoritmo di sogliatura adattiva di Bradley con sogliatura dell'immagine integrale |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarizzazione di un'immagine con soglia predefinita |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarizzazione di un'immagine con sogliatura di Otsu |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Memorizza nella cache i dati e garantisce che non vengano effettuati ulteriori caricamenti di dati dal [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/) sottostante. |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Determina se l'immagine può essere salvata nel formato file specificato rappresentato dalle opzioni di salvataggio fornite. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Ritaglio dell'immagine. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Ritaglia l'immagine con spostamenti. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Elimina l'istanza corrente. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Esegue il dithering sull'immagine corrente. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Esegue il dithering sull'immagine corrente. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Disegna l'immagine sul livello. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtra il rettangolo specificato. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Ottiene un pixel immagine a 32-bit ARGB. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Ottiene l'array predefinito di pixel ARGB a 32-bit. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Ottiene le opzioni predefinite. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Ottiene l'array predefinito di pixel usando il caricatore di pixel parziali. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Ottiene l'array predefinito di dati grezzi. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Ottiene l'array predefinito di dati grezzi usando il caricatore di pixel parziali. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Restituisce un codice hash per questa istanza. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Ottiene la data e l'ora dell'ultima modifica dell'immagine di risorsa. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Ottiene le opzioni basate sulle impostazioni del file originale. Questo può essere utile per mantenere inalterata la profondità di bit e altri parametri dell'immagine originale. Ad esempio, se carichiamo un'immagine PNG in bianco e nero a 1 bit per pixel e poi la salviamo usando il metodo [`Save`](../../aspose.psd/datastreamsupporter/save/), verrà generata un'immagine PNG di output a 8 bit per pixel. Per evitarlo e salvare l'immagine PNG a 1 bit per pixel, utilizza questo metodo per ottenere le opzioni di salvataggio corrispondenti e passale al metodo [`Save`](../../aspose.psd/image/save/) come secondo parametro. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Ottiene un pixel immagine. Avviso sulle prestazioni: evita di utilizzare questo metodo per iterare su tutti i pixel dell'immagine poiché può causare notevoli problemi di prestazioni. Per una manipolazione dei pixel più efficiente, utilizza il metodo `LoadArgb32Pixels` per recuperare l'intero array di pixel simultaneamente. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Ottiene l'angolo di inclinazione. Questo metodo è applicabile ai documenti di testo scansionati, per determinare l'angolo di inclinazione durante la scansione. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Trasformazione di un'immagine nella sua rappresentazione in scala di grigi |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Carica pixel ARGB a 32-bit. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Carica pixel ARGB a 64-bit. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Carica pixel in formato CMYK. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Carica pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare in modo più efficace il metodo [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/). |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Carica parzialmente pixel ARGB a 32-bit per pacchetti. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Carica pixel parzialmente per pacchetti. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Carica pixel. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Carica dati grezzi. |
+| virtual [MergeLayerTo](../../aspose.psd.fileformats.psd.layers/layer/mergelayerto/)(Layer) | Unisce il livello al livello specificato |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normalizza l'angolo. Questo metodo è applicabile ai documenti di testo scansionati per eliminare la scansione inclinata. Questo metodo utilizza i metodi [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) e [`Rotate`](../../aspose.psd/rasterimage/rotate/). |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Legge l'intera riga di scansione tramite l'indice di riga di scansione specificato. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Sostituisce un colore con un altro con differenza consentita e preserva il valore alfa originale per mantenere bordi morbidi. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Sostituisce tutti i colori non trasparenti con un nuovo colore e preserva il valore alfa originale per mantenere bordi morbidi. Nota: se lo usi su immagini senza trasparenza, tutti i colori saranno sostituiti con uno solo. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Ridimensiona l'immagine. Viene utilizzato il NearestNeighbourResample predefinito. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Ridimensiona l'immagine. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Ridimensiona l'immagine. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Ridimensiona l'altezza proporzionalmente. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Ridimensiona l'altezza proporzionalmente. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Ridimensiona la larghezza proporzionalmente. Viene utilizzato il NearestNeighbourResample predefinito. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Ridimensiona la larghezza proporzionalmente. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Ruota l'immagine attorno al centro. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Ruota l'immagine attorno al centro. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Ruota, capovolge o ruota e capovolge l'immagine. |
+| [Save](../../aspose.psd/image/save/)() | Salva i dati dell'immagine nello stream sottostante. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Salva i dati dell'oggetto nello stream specificato. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Salva i dati dell'oggetto nella posizione file specificata. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Salva i dati dell'oggetto nella posizione file specificata. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Salva i dati dell'immagine nello stream specificato nel formato file specificato secondo le opzioni di salvataggio. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Salva i dati dell'oggetto nella posizione file specificata nel formato file specificato secondo le opzioni di salvataggio. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Salva i pixel ARGB a 32 bit. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Salva i pixel. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo più efficace [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/). |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Salva i pixel. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Salva i dati grezzi. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Imposta un pixel ARGB a 32 bit dell'immagine per la posizione specificata. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Imposta la tavolozza dell'immagine. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Imposta un pixel dell'immagine per la posizione specificata. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Imposta la risoluzione per questo [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Crea una copia superficiale del Layer corrente. Si prega di [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) per spiegazione. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converte l'immagine raster in bitmap. |
+| [Update](../../aspose.psd.fileformats.psd.layers/shapelayer/update/)() | Aggiorna le risorse dalle proprietà del layer Shape. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Scrive l'intera riga di scansione all'indice di riga di scansione specificato. |
+
+## Esempi
+
+Il codice seguente mostra il supporto per il layer ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Il file di origine contiene 2 figure. Rimuovi la seconda.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Vedi anche
+
+* class [Layer](../layer/)
+* interface [IShapeLayer](../ishapelayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/_index.md
@@ -1,0 +1,57 @@
+---
+title: "ShapeLayer.CreateInstance"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ShapeLayer. Crea una nuova istanza della classe ShapeLayer"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/
+---
+{{< psd/tize >}}
+## ShapeLayer.CreateInstance method
+
+Crea una nuova istanza della classe [`ShapeLayer`](../).
+
+```csharp
+public static ShapeLayer CreateInstance()
+```
+
+### Valore di ritorno
+
+Restituisce la nuova istanza della classe [`ShapeLayer`](../).
+
+## Esempi
+
+Il codice seguente mostra il supporto per il layer ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Il file di origine contiene 2 figure. Rimuovi la seconda.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Vedi anche
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/_index.md
@@ -1,0 +1,70 @@
+---
+title: "ShapeLayer.Fill"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ShapeLayer. Ottiene o imposta le impostazioni di riempimento per l'area interna delle forme nel livello Shape."
+type: docs
+weight: 30
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/
+---
+{{< psd/tize >}}
+## ShapeLayer.Fill property
+
+Ottiene o imposta le impostazioni di riempimento per l'area interna delle forme nel livello Shape.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra la proprietà Fill di ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeInternalSolid.psd";
+string outFile = "ShapeInternalSolid.psd.out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+           srcFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.Red;
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(
+           outFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+
+    AssertAreEqual(Color.Red, fillSettings.Color);
+
+    image.Save(outFile);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/path/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/path/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ShapeLayer.Path"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ShapeLayer. Ottiene l'insieme di percorsi presenti in un livello Shape."
+type: docs
+weight: 40
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/path/
+---
+{{< psd/tize >}}
+## ShapeLayer.Path property
+
+Restituisce l'insieme di Paths che sono presenti in un livello Shape.
+
+```csharp
+public IPath Path { get; }
+```
+
+## Esempi
+
+Il codice seguente mostra il supporto per il layer ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Il file di origine contiene 2 figure. Rimuovi la seconda.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Vedi anche
+
+* interface [IPath](../../../aspose.psd.fileformats.psd.layers.layerresources/ipath/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ShapeLayer.ShapeLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore ShapeLayer. Inizializza una nuova istanza della classe ShapeLayer. Tutte le risorse sono create nello stato predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/
+---
+{{< psd/tize >}}
+## ShapeLayer constructor
+
+Inizializza una nuova istanza della classe [`ShapeLayer`](../). Tutte le risorse sono create nello stato predefinito.
+
+```csharp
+public ShapeLayer()
+```
+
+## Esempi
+
+Il codice seguente mostra il supporto per il layer ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Il file di origine contiene 2 figure. Rimuovi la seconda.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Vedi anche
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/_index.md
@@ -1,0 +1,109 @@
+---
+title: "ShapeLayer.Stroke"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà ShapeLayer. Ottiene o imposta le impostazioni di Stroke delle forme"
+type: docs
+weight: 50
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/
+---
+{{< psd/tize >}}
+## ShapeLayer.Stroke property
+
+Ottiene o imposta le impostazioni del tratto delle forme.
+
+```csharp
+public IStrokeSettings Stroke { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il rendering di supporto di Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Verifica i dati modificati.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* interface [IStrokeSettings](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/update/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/shapelayer/update/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ShapeLayer.Update"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo ShapeLayer. Aggiorna le risorse dalle proprietà del livello Shape."
+type: docs
+weight: 60
+url: /it/net/aspose.psd.fileformats.psd.layers/shapelayer/update/
+---
+{{< psd/tize >}}
+## ShapeLayer.Update method
+
+Aggiorna le risorse dalle proprietà del layer Shape.
+
+```csharp
+public void Update()
+```
+
+## Esempi
+
+Il codice seguente mostra il supporto per il layer ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Il file di origine contiene 2 figure. Rimuovi la seconda.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Vedi anche
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/_index.md
@@ -1,0 +1,108 @@
+---
+title: "TextLayer.WarpSettings"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà TextLayer. Ottiene o imposta i parametri Warp che sono stati impostati o ottenuti dalla risorsa predefinita"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/
+---
+{{< psd/tize >}}
+## TextLayer.WarpSettings property
+
+Ottiene o imposta i parametri Warp che sono stati impostati o ottenuti dalla risorsa (predefinita)
+
+```csharp
+public WarpSettings WarpSettings { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra come manipolare WarpSettings per eseguire la trasformazione di warp su SmartObjectLayer e TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Vedi anche
+
+* class [WarpSettings](../../../aspose.psd.fileformats.psd.layers.warp/warpsettings/)
+* class [TextLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd.resources.enums/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.resources.enums/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Resources.Enums"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Lo spazio dei nomi gestisce le enumerazioni delle risorse Psd"
+type: docs
+weight: 390
+url: /it/net/aspose.psd.fileformats.psd.resources.enums/
+---
+{{< psd/tize >}}
+Lo spazio dei nomi gestisce le enumerazioni delle risorse Psd.
+
+## Enumerazione
+
+| Enumerazione | Descrizione |
+| --- | --- |
+| [ColorSpace](./colorspace/) | I tipi di spazio colore. |
+
+

--- a/italian/net/aspose.psd.fileformats.psd.resources.enums/colorspace/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd.resources.enums/colorspace/_index.md
@@ -1,0 +1,86 @@
+---
+title: "Enum ColorSpace"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.FileFormats.Psd.Resources.Enums.ColorSpace enum. I tipi di spazio colore"
+type: docs
+weight: 4160
+url: /it/net/aspose.psd.fileformats.psd.resources.enums/colorspace/
+---
+{{< psd/tize >}}
+## ColorSpace enumeration
+
+I tipi di spazio colore.
+
+```csharp
+public enum ColorSpace : ushort
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| RGB | `0` | Lo spazio colore RGB. |
+| HSB | `1` | Lo spazio colore HSB. |
+| CMYK | `2` | Lo spazio colore CMYK. |
+| Lab | `7` | Lo spazio colore Lab. |
+| GrayScale | `8` | Lo spazio colore GrayScale. |
+
+## Esempi
+
+Il codice seguente dimostra come modificare le Opzioni di visualizzazione della Maschera di livello su immagini a 16 bit modificando le proprietà di LmskResource.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Carica immagine a 16 bit.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Trova LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Verifica le proprietà di LmskResource.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Modifica le proprietà di LmskResource.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Salva l'immagine.
+    image.Save(outputPsd);
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd.Resources.Enums](../../aspose.psd.fileformats.psd.resources.enums/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/leadingmode/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/leadingmode/_index.md
@@ -1,0 +1,29 @@
+---
+title: "LeadingMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: 
+type: docs
+weight: 3440
+url: /it/net/aspose.psd.fileformats.psd/leadingmode/
+---
+## LeadingMode enumeration
+
+Modalità di interlinea di Photoshop (distanza tra le righe)
+
+```csharp
+public enum LeadingMode
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| Auto | `0` | Modalità di interlinea automatica |
+| Manual | `1` | Modalità di interlinea manuale |
+
+### Vedi anche
+
+* namespace [Aspose.PSD.FileFormats.Psd](../../aspose.psd.fileformats.psd)
+* assembly [Aspose.PSD](../../)
+
+<!-- NON MODIFICARE: generato da xmldocmd per Aspose.PSD.dll -->

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PsdImage.AddGradientMapAdjustmentLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Aggiunge un livello di regolazione GradientMap"
+type: docs
+weight: 360
+url: /it/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddGradientMapAdjustmentLayer method
+
+Aggiunge un livello di regolazione GradientMap.
+
+```csharp
+public GradientMapLayer AddGradientMapAdjustmentLayer()
+```
+
+### Valore di ritorno
+
+Istanza GradientMap.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello mappa gradiente.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Aggiungi un livello di regolazione mappa gradiente.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [GradientMapLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/_index.md
@@ -1,0 +1,66 @@
+---
+title: "PsdImage.AddPosterizeAdjustmentLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Aggiunge Posterize Adjustment layer"
+type: docs
+weight: 430
+url: /it/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddPosterizeAdjustmentLayer method
+
+Aggiunge Posterize Adjustment layer.
+
+```csharp
+public PosterizeLayer AddPosterizeAdjustmentLayer()
+```
+
+### Valore di ritorno
+
+Istanza PosterizeLayer.
+
+## Esempi
+
+Il codice seguente dimostra la possibilità di aggiungere PosterizeAdjustmentLayer tramite PsdImage.
+
+```csharp
+[C#]
+
+string srcFile = "zendeya.psd";
+string outFile = "zendeya.psd.out.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    psdImage.AddPosterizeAdjustmentLayer();
+    psdImage.Save(outFile);
+}
+
+// Verifica le modifiche salvate
+using (PsdImage image = (PsdImage)Image.Load(
+           outFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    AssertAreEqual(2, image.Layers.Length);
+
+    PosterizeLayer posterizeLayer = (PosterizeLayer)image.Layers[1];
+
+    AssertAreEqual(true, posterizeLayer is PosterizeLayer);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [PosterizeLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/posterizelayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/_index.md
@@ -1,0 +1,124 @@
+---
+title: "PsdImage.AddSelectiveColorAdjustmentLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Aggiunge il selective color adjustment layer"
+type: docs
+weight: 450
+url: /it/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddSelectiveColorAdjustmentLayer method
+
+Aggiunge il selective color adjustment layer.
+
+```csharp
+public SelectiveColorLayer AddSelectiveColorAdjustmentLayer()
+```
+
+### Valore di ritorno
+
+Il selective color adjustment layer creato.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione SelectiveColorLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Selective Color dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Ottieni il livello di regolazione Selective Color.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Modifica i parametri dei livelli.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Selective color sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Aggiungi il livello di regolazione Selective Color.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [SelectiveColorLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/_index.md
@@ -1,0 +1,139 @@
+---
+title: "PsdImage.AddShapeLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Aggiungi un livello Shape vuoto. Senza percorsi. Dovrebbero essere aggiunti al livello shape prima del salvataggio"
+type: docs
+weight: 460
+url: /it/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddShapeLayer method
+
+Aggiungi un livello Shape vuoto. Senza percorsi. Dovrebbero essere aggiunti al livello shape prima del salvataggio.
+
+```csharp
+public ShapeLayer AddShapeLayer()
+```
+
+### Valore di ritorno
+
+Istanza ShapeLayer.
+
+## Esempi
+
+Il codice seguente dimostra come aggiungere ShapeLayer.
+
+```csharp
+[C#]
+
+string outputFile = "AddShapeLayer_output.psd";
+
+const int ImgToPsdRatio = 256 * 65535;
+
+using (PsdImage newPsd = new PsdImage(600, 400))
+{
+    ShapeLayer layer = newPsd.AddShapeLayer();
+
+    var newShape = GenerateNewShape(newPsd.Size);
+    List<IPathShape> newShapes = new List<IPathShape>();
+    newShapes.Add(newShape);
+    layer.Path.SetItems(newShapes.ToArray());
+
+    layer.Update();
+
+    newPsd.Save(outputFile);
+}
+
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    AssertAreEqual(2, image.Layers.Length);
+
+    ShapeLayer shapeLayer = image.Layers[1] as ShapeLayer;
+    ColorFillSettings internalFill = shapeLayer.Fill as ColorFillSettings;
+    IStrokeSettings strokeSettings = shapeLayer.Stroke;
+    ColorFillSettings strokeFill = shapeLayer.Stroke.Fill as ColorFillSettings;
+
+    AssertAreEqual(1, shapeLayer.Path.GetItems().Length); // 1 Shape
+    AssertAreEqual(3, shapeLayer.Path.GetItems()[0].GetItems().Length); // 3 knots in a shape
+
+    AssertAreEqual(-16127182, internalFill.Color.ToArgb()); // ff09eb32
+
+    AssertAreEqual(7.41, strokeSettings.Size);
+    AssertAreEqual(false, strokeSettings.Enabled);
+    AssertAreEqual(StrokePosition.Center, strokeSettings.LineAlignment);
+    AssertAreEqual(LineCapType.ButtCap, strokeSettings.LineCap);
+    AssertAreEqual(LineJoinType.MiterJoin, strokeSettings.LineJoin);
+    AssertAreEqual(-16777216, strokeFill.Color.ToArgb()); // ff000000
+}
+
+PathShape GenerateNewShape(Size imageSize)
+{
+    var newShape = new PathShape();
+
+    PointF point1 = new PointF(20, 100);
+    PointF point2 = new PointF(200, 100);
+    PointF point3 = new PointF(300, 10);
+
+    BezierKnotRecord[] bezierKnots = new BezierKnotRecord[]
+    {
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point1, imageSize),
+                          PointFToResourcePoint(point1, imageSize),
+                          PointFToResourcePoint(point1, imageSize),
+                      }
+         },
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point2, imageSize),
+                          PointFToResourcePoint(point2, imageSize),
+                          PointFToResourcePoint(point2, imageSize),
+                      }
+         },
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point3, imageSize),
+                          PointFToResourcePoint(point3, imageSize),
+                          PointFToResourcePoint(point3, imageSize),
+                      }
+         },
+    };
+
+    newShape.SetItems(bezierKnots);
+
+    return newShape;
+}
+
+Point PointFToResourcePoint(PointF point, Size imageSize)
+{
+    return new Point(
+        (int)Math.Round(point.Y * (ImgToPsdRatio / imageSize.Height)),
+        (int)Math.Round(point.X * (ImgToPsdRatio / imageSize.Width)));
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* class [ShapeLayer](../../../aspose.psd.fileformats.psd.layers/shapelayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PsdImage.AddThresholdAdjustmentLayer"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Aggiunge il Threshold adjustment layer"
+type: docs
+weight: 480
+url: /it/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddThresholdAdjustmentLayer method
+
+Aggiunge il Threshold adjustment layer.
+
+```csharp
+public ThresholdLayer AddThresholdAdjustmentLayer()
+```
+
+### Valore di ritorno
+
+Il Threshold adjustment layer creato.
+
+## Esempi
+
+Il codice seguente dimostra il supporto del livello di regolazione ThresholdLayer.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Ottieni, verifica e modifica il livello di regolazione Threshold dall'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Ottieni il livello di regolazione Threshold.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Verifica i parametri dei livelli.
+            AssertAreEqual(level, (short)115);
+
+            // Imposta i parametri dei livelli.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Aggiungi e imposta il livello di regolazione Threshold sull'immagine.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Aggiungi livello di regolazione Threshold.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Imposta i parametri dei livelli.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [ThresholdLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/setresolution/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/setresolution/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PsdImage.SetResolution"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PsdImage. Imposta la risoluzione per questa PsdImage"
+type: docs
+weight: 680
+url: /it/net/aspose.psd.fileformats.psd/psdimage/setresolution/
+---
+{{< psd/tize >}}
+## PsdImage.SetResolution method
+
+Imposta la risoluzione per questa [`PsdImage`](../).
+
+```csharp
+public override void SetResolution(double dpiX, double dpiY)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| dpiX | Double | La risoluzione orizzontale, in punti per pollice, del [`RasterImage`](../../../aspose.psd/rasterimage/). |
+| dpiY | Double | La risoluzione verticale, in punti per pollice, del [`RasterImage`](../../../aspose.psd/rasterimage/). |
+
+### Vedi anche
+
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.fileformats.psd/psdimage/timeline/_index.md
+++ b/italian/net/aspose.psd.fileformats.psd/psdimage/timeline/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PsdImage.Timeline"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PsdImage. Ottiene la Timeline di questo PsdImage"
+type: docs
+weight: 250
+url: /it/net/aspose.psd.fileformats.psd/psdimage/timeline/
+---
+{{< psd/tize >}}
+## PsdImage.Timeline property
+
+Ottiene la `Timeline` di questo [`PsdImage`](../).
+
+```csharp
+public Timeline Timeline { get; }
+```
+
+## Esempi
+
+Il codice seguente dimostra un nuovo approccio per lavorare con la Timeline.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Aggiungi un altro fotogramma
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Vedi anche
+
+* class [Timeline](../../../aspose.psd.fileformats.psd.layers.animation/timeline/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/pngloadoptions/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/pngloadoptions/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Classe PngLoadOptions"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Aspose.PSD.ImageLoadOptions.PngLoadOptions class. Le opzioni di caricamento png"
+type: docs
+weight: 5240
+url: /it/net/aspose.psd.imageloadoptions/pngloadoptions/
+---
+{{< psd/tize >}}
+## PngLoadOptions class
+
+Le opzioni di caricamento png.
+
+```csharp
+[Obsolete("Should be replaced with base \"LoadOptions\" class because it contains ony one obsolete \"StrictMode\" property.")]
+public class PngLoadOptions : LoadOptions
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [PngLoadOptions](pngloadoptions/)() | Il costruttore predefinito. |
+
+## Proprietà
+
+| Nome | Descrizione |
+| --- | --- |
+| [BufferSizeHint](../../aspose.psd/loadoptions/buffersizehint/) { get; set; } | Ottiene o imposta il suggerimento della dimensione del buffer, definito come dimensione massima consentita per tutti i buffer interni. |
+| [DataBackgroundColor](../../aspose.psd/loadoptions/databackgroundcolor/) { get; set; } | Ottiene o imposta lo sfondo dell'[`Image`](../../aspose.psd/image/) [`Color`](../../aspose.psd/color/). |
+| [DataRecoveryMode](../../aspose.psd/loadoptions/datarecoverymode/) { get; set; } | Ottiene o imposta la modalità di recupero dati. |
+| [ProgressEventHandler](../../aspose.psd/loadoptions/progresseventhandler/) { get; set; } | Ottiene o imposta il gestore dell'evento di avanzamento. |
+| [StrictMode](../../aspose.psd.imageloadoptions/pngloadoptions/strictmode/) { get; set; } | Ottiene o imposta un valore che indica se è attiva la [modalità rigorosa]. |
+| [UseIccProfileConversion](../../aspose.psd/loadoptions/useiccprofileconversion/) { get; set; } | Ottiene o imposta un valore che indica se deve essere applicata la conversione del profilo ICC. |
+
+### Vedi anche
+
+* class [LoadOptions](../../aspose.psd/loadoptions/)
+* namespace [Aspose.PSD.ImageLoadOptions](../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PngLoadOptions.PngLoadOptions"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore PngLoadOptions. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/
+---
+{{< psd/tize >}}
+## PngLoadOptions constructor
+
+Il costruttore predefinito.
+
+```csharp
+public PngLoadOptions()
+```
+
+### Vedi anche
+
+* class [PngLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PngLoadOptions.StrictMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PngLoadOptions. Ottiene o imposta un valore che indica se la modalità rigorosa è attiva"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/
+---
+{{< psd/tize >}}
+## PngLoadOptions.StrictMode property
+
+Ottiene o imposta un valore che indica se è attiva la [modalità rigorosa].
+
+```csharp
+[Obsolete("This redundant property should be replaced with an expression: \"LoadOptions.DataRecoveryMode == DataRecoveryMode.ConsistentRecover\".")]
+public bool StrictMode { get; set; }
+```
+
+### Property Value
+
+`true` se [modalità rigorosa]; altrimenti, `false`.
+
+### Vedi anche
+
+* class [PngLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PsdLoadOptions.AllowNonChangedLayerRepaint"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PsdLoadOptions. Ottiene o imposta se conservare i pixel originali del livello durante il rendering se il livello non è stato modificato"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/
+---
+{{< psd/tize >}}
+## PsdLoadOptions.AllowNonChangedLayerRepaint property
+
+Ottiene o imposta se conservare i pixel originali del livello durante il rendering se il livello non è stato modificato.
+
+```csharp
+public bool AllowNonChangedLayerRepaint { get; set; }
+```
+
+### Property Value
+
+`true` per mantenere i pixel originali dei livelli non modificati; altrimenti, `false`.
+
+## Esempi
+
+Il codice seguente dimostra il nuovo comportamento che impedisce il ridisegno automatico dei livelli prima delle modifiche.
+
+```csharp
+[C#]
+
+string srcFile = "psdnet2400.psd";
+string output1 = "unchanged-2400.png";
+string output2 = "updated-2400.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile,
+new PsdLoadOptions() { AllowNonChangedLayerRepaint = false /* The new default behaviour */ }))
+{
+    psdImage.Save(output1, new PngOptions());
+
+    ((TextLayer)psdImage.Layers[1]).TextData.UpdateLayerData();
+
+    psdImage.Save(output2, new PngOptions());
+}
+```
+
+### Vedi anche
+
+* class [PsdLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/_index.md
@@ -1,0 +1,79 @@
+---
+title: "PsdLoadOptions.ReadOnlyType"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PsdLoadOptions. Ottiene o imposta la modalità di sola lettura utilizzata durante il caricamento di un'immagine PSD"
+type: docs
+weight: 80
+url: /it/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/
+---
+{{< psd/tize >}}
+## PsdLoadOptions.ReadOnlyType property
+
+Ottiene o imposta la modalità di sola lettura utilizzata durante il caricamento di un'immagine PSD.
+
+```csharp
+public ReadOnlyMode ReadOnlyType { get; set; }
+```
+
+### Property Value
+
+Uno dei valori di [`ReadOnlyMode`](../readonlymode/):
+
+* !:ReadOnlyMode.None – No restrictions. Image content can be modified.
+* !:ReadOnlyMode.Default – The image is fully read-only.
+* !:ReadOnlyMode.MetadataEdit – Only metadata can be edited (such as [`ImageResources`](../../../aspose.psd.fileformats.psd/psdimage/imageresources/)), while image pixel content remains read-only.
+
+## Esempi
+
+Dimostra la modifica e il salvataggio dei metadati PSD utilizzando ReadOnlyMode.MetadataEdit.
+
+```csharp
+[C#]
+
+string sourceFile = "psdnet2382.psd";
+string outputFile = "output.psd";
+
+string testMetadata = "Updated metadata text";
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(sourceFile,
+    new PsdLoadOptions() { ReadOnlyType = ReadOnlyMode.MetadataEdit })) // Sets the of ReadOnlyMode to true
+{
+    AssertAreNotEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+
+    // Modifica i metadati in ReadOnlyMode
+    psdImage.XmpData.Meta.AdobeXmpToolkit = testMetadata;
+
+    // Salva i metadati modificati in ReadOnlyMode
+    psdImage.Save(outputFile);
+}
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(outputFile)) // Sets the of ReadOnlyMode to true
+{
+    AssertAreEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects should be equal, but they don't.");
+    }
+}
+
+void AssertAreNotEqual(object obj1, object obj2)
+{
+    if (object.Equals(obj1, obj2))
+    {
+        throw new Exception("Objects should not be equal, but they are equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* enum [ReadOnlyMode](../../readonlymode/)
+* class [PsdLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageloadoptions/readonlymode/_index.md
+++ b/italian/net/aspose.psd.imageloadoptions/readonlymode/_index.md
@@ -1,0 +1,77 @@
+---
+title: "Enum ReadOnlyMode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Enum Aspose.PSD.ImageLoadOptions.ReadOnlyMode. Specifica le modalità di sola lettura disponibili durante il caricamento di un'immagine PSD"
+type: docs
+weight: 5260
+url: /it/net/aspose.psd.imageloadoptions/readonlymode/
+---
+{{< psd/tize >}}
+## ReadOnlyMode enumeration
+
+Specifica le modalità di sola lettura disponibili durante il caricamento di un'immagine PSD.
+
+```csharp
+public enum ReadOnlyMode
+```
+
+### Valori
+
+| Nome | Valore | Descrizione |
+| --- | --- | --- |
+| None | `0` | Non vengono applicate restrizioni di sola lettura. L'immagine può essere modificata completamente. |
+| Default | `1` | Modalità predefinita. L'immagine è completamente di sola lettura e non può essere modificata. |
+| MetadataEdit | `2` | Consente la modifica dei metadati dell'immagine mantenendo il contenuto dell'immagine in sola lettura. |
+
+## Esempi
+
+Dimostra la modifica e il salvataggio dei metadati PSD utilizzando ReadOnlyMode.MetadataEdit.
+
+```csharp
+[C#]
+
+string sourceFile = "psdnet2382.psd";
+string outputFile = "output.psd";
+
+string testMetadata = "Updated metadata text";
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(sourceFile,
+    new PsdLoadOptions() { ReadOnlyType = ReadOnlyMode.MetadataEdit })) // Sets the of ReadOnlyMode to true
+{
+    AssertAreNotEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+
+    // Modifica i metadati in ReadOnlyMode
+    psdImage.XmpData.Meta.AdobeXmpToolkit = testMetadata;
+
+    // Salva i metadati modificati in ReadOnlyMode
+    psdImage.Save(outputFile);
+}
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(outputFile)) // Sets the of ReadOnlyMode to true
+{
+    AssertAreEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects should be equal, but they don't.");
+    }
+}
+
+void AssertAreNotEqual(object obj1, object obj2)
+{
+    if (object.Equals(obj1, obj2))
+    {
+        throw new Exception("Objects should not be equal, but they are equal.");
+    }
+}
+```
+
+### Vedi anche
+
+* namespace [Aspose.PSD.ImageLoadOptions](../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/_index.md
+++ b/italian/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/_index.md
@@ -1,0 +1,29 @@
+---
+title: "JpegOptions.DefaultMemoryAllocationLimit"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà JpegOptions. Ottiene o imposta il limite predefinito di allocazione della memoria"
+type: docs
+weight: 70
+url: /it/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/
+---
+{{< psd/tize >}}
+## JpegOptions.DefaultMemoryAllocationLimit property
+
+Ottiene o imposta il limite predefinito di allocazione della memoria.
+
+```csharp
+[Obsolete("Use Aspose.PSD.Image.BufferSizeHint, Aspose.PSD.ImageOptionsBase.BufferSizeHint or Aspose.PSD.LoadOptions.BufferSizeHint instead.")]
+public int DefaultMemoryAllocationLimit { get; set; }
+```
+
+### Property Value
+
+Il limite predefinito di allocazione della memoria.
+
+### Vedi anche
+
+* class [JpegOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/_index.md
+++ b/italian/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PsdOptions.BackgroundContents"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PsdOptions. Ottiene o imposta il colore di sfondo. Può essere visto sotto gli oggetti trasparenti"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/
+---
+{{< psd/tize >}}
+## PsdOptions.BackgroundContents property
+
+Ottiene o imposta il colore di sfondo. Può essere visto sotto gli oggetti trasparenti.
+
+```csharp
+public RawColor BackgroundContents { get; set; }
+```
+
+## Esempi
+
+Il codice seguente dimostra il supporto della proprietà BackgroundContents in PsdOptions.
+
+```csharp
+[C#]
+
+// La semitrasparenza è elaborata in modo errato nell'anteprima del file psd.
+// BackgroundContents assegnato a White. Le aree trasparenti dovrebbero avere colore bianco.
+
+string sourceFile = "frog_nosymb.psd";
+string outputFile = "frog_nosymb_backgroundcontents_output.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    RawColor backgroundColor = new RawColor(PixelDataFormat.Rgb32Bpp);
+    int argbValue = 255 << 24 | 255 << 16 | 255 << 8 | 255;
+    backgroundColor.SetAsInt(argbValue); // White
+
+    PsdOptions psdOptions = new PsdOptions(psdImage)
+    {
+        ColorMode = ColorModes.Rgb,
+        CompressionMethod = CompressionMethod.RLE,
+        ChannelsCount = 4,
+        BackgroundContents = backgroundColor,
+    };
+
+    psdImage.Save(outputFile, psdOptions);
+}
+```
+
+### Vedi anche
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [PsdOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageoptions/psdoptions/updatemetadata/_index.md
+++ b/italian/net/aspose.psd.imageoptions/psdoptions/updatemetadata/_index.md
@@ -1,0 +1,55 @@
+---
+title: "PsdOptions.UpdateMetadata"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà PsdOptions. Ottiene o imposta un valore che indica se aggiornare i metadati. Se il valore è true i metadati saranno aggiornati durante il salvataggio di un'immagine"
+type: docs
+weight: 110
+url: /it/net/aspose.psd.imageoptions/psdoptions/updatemetadata/
+---
+{{< psd/tize >}}
+## PsdOptions.UpdateMetadata property
+
+Ottiene o imposta un valore che indica se [aggiornare i metadati]. Se il valore è true, i metadati saranno aggiornati durante il salvataggio di un'immagine.
+
+```csharp
+public bool UpdateMetadata { get; set; }
+```
+
+### Property Value
+
+`true` se [aggiornare i metadati]; altrimenti, `false`.
+
+## Esempi
+
+Il codice seguente dimostra l'uso dell'opzione UpdateMetadata per aggiornare il valore CreatorTool nei dati xmp.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Se vuoi che lo strumento creatore cambi, assicurati che la proprietà "UpdateMetadata" sia impostata su true. È impostata su true per impostazione predefinita.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Salvataggio dell'immagine. 
+    image.Save(path, psdOptions);
+
+    // Verifica dello strumento creatore nel codice.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Qui verranno aggiornate le informazioni sullo strumento creatore.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Vedi anche
+
+* class [PsdOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/_index.md
+++ b/italian/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/_index.md
@@ -1,0 +1,29 @@
+---
+title: "TiffOptions.DefaultMemoryAllocationLimit"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà TiffOptions. Ottiene o imposta il limite predefinito di allocazione della memoria."
+type: docs
+weight: 120
+url: /it/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/
+---
+{{< psd/tize >}}
+## TiffOptions.DefaultMemoryAllocationLimit property
+
+Ottiene o imposta il limite predefinito di allocazione della memoria.
+
+```csharp
+[Obsolete("Use Aspose.PSD.Image.BufferSizeHint, Aspose.PSD.ImageOptionsBase.BufferSizeHint or Aspose.PSD.LoadOptions.BufferSizeHint instead.")]
+public int DefaultMemoryAllocationLimit { get; set; }
+```
+
+### Property Value
+
+Il limite predefinito di allocazione della memoria.
+
+### Vedi anche
+
+* class [TiffOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/_index.md
+++ b/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XmpBasicPackage.ContainsKey"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo XmpBasicPackage. Determina se la chiave specificata contiene la chiave"
+type: docs
+weight: 40
+url: /it/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/
+---
+{{< psd/tize >}}
+## XmpBasicPackage.ContainsKey method
+
+Determina se la chiave specificata contiene la chiave.
+
+```csharp
+public override bool ContainsKey(string key)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| chiave | Stringa | La chiave da verificare. |
+
+### Valore di ritorno
+
+Restituisce true se la chiave specificata contiene la chiave.
+
+## Esempi
+
+Il codice seguente dimostra l'uso dell'opzione UpdateMetadata per aggiornare il valore CreatorTool nei dati xmp.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Se vuoi che lo strumento creatore cambi, assicurati che la proprietà "UpdateMetadata" sia impostata su true. È impostata su true per impostazione predefinita.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Salvataggio dell'immagine. 
+    image.Save(path, psdOptions);
+
+    // Verifica dello strumento creatore nel codice.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Qui verranno aggiornate le informazioni sullo strumento creatore.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Vedi anche
+
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/_index.md
+++ b/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/_index.md
@@ -1,0 +1,63 @@
+---
+title: "XmpBasicPackage.Item"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà XmpBasicPackage. Ottiene o imposta l'Object con la chiave specificata"
+type: docs
+weight: 20
+url: /it/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/
+---
+{{< psd/tize >}}
+## XmpBasicPackage indexer
+
+Ottiene o imposta l'Object con la chiave specificata.
+
+```csharp
+public override object this[string key] { get; set; }
+```
+
+| Parametro | Descrizione |
+| --- | --- |
+| chiave | La chiave che identifica il valore. |
+
+### Valore di ritorno
+
+Restituisce l'Object con la chiave specificata.
+
+### Property Value
+
+L'Object.
+
+## Esempi
+
+Il codice seguente dimostra l'uso dell'opzione UpdateMetadata per aggiornare il valore CreatorTool nei dati xmp.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Se vuoi che lo strumento creatore cambi, assicurati che la proprietà "UpdateMetadata" sia impostata su true. È impostata su true per impostazione predefinita.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Salvataggio dell'immagine. 
+    image.Save(path, psdOptions);
+
+    // Verifica dello strumento creatore nel codice.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Qui verranno aggiornate le informazioni sullo strumento creatore.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Vedi anche
+
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/_index.md
+++ b/italian/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/_index.md
@@ -1,0 +1,57 @@
+---
+title: "XmpBasicPackage.SetValue"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo XmpBasicPackage. Imposta il valore"
+type: docs
+weight: 120
+url: /it/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/
+---
+{{< psd/tize >}}
+## XmpBasicPackage.SetValue method
+
+Imposta il valore.
+
+```csharp
+public override void SetValue(string key, IXmlValue value)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| chiave | Stringa | La rappresentazione stringa della chiave identificata con il valore aggiunto. |
+| valore | IXmlValue | Il valore a cui aggiungere. |
+
+## Esempi
+
+Il codice seguente dimostra l'uso dell'opzione UpdateMetadata per aggiornare il valore CreatorTool nei dati xmp.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Se vuoi che lo strumento creatore cambi, assicurati che la proprietà "UpdateMetadata" sia impostata su true. È impostata su true per impostazione predefinita.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Salvataggio dell'immagine. 
+    image.Save(path, psdOptions);
+
+    // Verifica dello strumento creatore nel codice.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Qui verranno aggiornate le informazioni sullo strumento creatore.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Vedi anche
+
+* interface [IXmlValue](../../../aspose.psd.xmp/ixmlvalue/)
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/cmykcolor/fromparams/_index.md
+++ b/italian/net/aspose.psd/cmykcolor/fromparams/_index.md
@@ -1,0 +1,36 @@
+---
+title: "CmykColor.FromParams"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo CmykColor. Crea una struttura CmykColor da valori cyan, magenta, yellow e black a 32‑bit. Questo metodo è deprecato. Si prega di utilizzare FromComponents più efficace."
+type: docs
+weight: 20
+url: /it/net/aspose.psd/cmykcolor/fromparams/
+---
+{{< psd/tize >}}
+## CmykColor.FromParams method
+
+Crea una struttura [`CmykColor`](../) da valori cyan, magenta, yellow e black a 32‑bit. Questo metodo è deprecato. Si prega di utilizzare [`FromComponents`](../../cmykcolorhelper/fromcomponents/) più efficace.
+
+```csharp
+[Obsolete]
+public static CmykColor FromParams(int cyan, int magenta, int yellow, int black)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| ciano | Int32 | Il componente ciano. I valori validi sono da 0 a 255. |
+| magenta | Int32 | Il componente magenta. I valori validi sono da 0 a 255. |
+| giallo | Int32 | Il componente giallo. I valori validi sono da 0 a 255. |
+| nero | Int32 | Il componente nero. I valori validi sono da 0 a 255. |
+
+### Valore di ritorno
+
+Il [`CmykColor`](../).
+
+### Vedi anche
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/cmykcolor/toargb32/_index.md
+++ b/italian/net/aspose.psd/cmykcolor/toargb32/_index.md
@@ -1,0 +1,33 @@
+---
+title: "CmykColor.ToArgb32"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo CmykColor. La conversione da CMYKColor a colore ARGB a 32 bit usando conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di usare un ToArgb32 più efficace"
+type: docs
+weight: 110
+url: /it/net/aspose.psd/cmykcolor/toargb32/
+---
+{{< psd/tize >}}
+## CmykColor.ToArgb32 method
+
+La conversione da CMYKColor a colore ARGB a 32 bit usando conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di usare un [`ToArgb32`](../../cmykcolorhelper/toargb32/) più efficace.
+
+```csharp
+[Obsolete]
+public static int[] ToArgb32(CmykColor[] cmykPixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | I pixel di tipo CMYKColor in formato CMYK. |
+
+### Valore di ritorno
+
+L'array del colore ARGB a 32 bit.
+
+### Vedi anche
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/cmykcolor/tocmyk/_index.md
+++ b/italian/net/aspose.psd/cmykcolor/tocmyk/_index.md
@@ -1,0 +1,58 @@
+---
+title: "CmykColor.ToCmyk"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo CmykColor. La conversione da colore ARGB a 32 bit a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace ToCmyk"
+type: docs
+weight: 120
+url: /it/net/aspose.psd/cmykcolor/tocmyk/
+---
+{{< psd/tize >}}
+## ToCmyk(int[]) {#tocmyk_1}
+
+La conversione da colore ARGB a 32 bit a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmyk(int[] argbPixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| argbPixels | Int32[] | I pixel del formato ARGB a 32 bit. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor[].
+
+### Vedi anche
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmyk(int) {#tocmyk}
+
+La conversione da ARGB a 32 bit a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmyk(int argbPixel)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| argbPixel | Int32 | Il pixel del formato ARGB a 32 bit. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor.
+
+### Vedi anche
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/cmykcolor/tocolor/_index.md
+++ b/italian/net/aspose.psd/cmykcolor/tocolor/_index.md
@@ -1,0 +1,60 @@
+---
+title: "CmykColor.ToColor"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo CmykColor. La conversione da CMYKColor a Color usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace ToArgb"
+type: docs
+weight: 130
+url: /it/net/aspose.psd/cmykcolor/tocolor/
+---
+{{< psd/tize >}}
+## ToColor(CmykColor[]) {#tocolor_1}
+
+La conversione da CMYKColor a Color usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgb`](../../cmykcolorhelper/toargb/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColor(CmykColor[] cmykPixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | I pixel di tipo CMYKColor in formato CMYK. |
+
+### Valore di ritorno
+
+L'array dei colori ARGB.
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColor(CmykColor) {#tocolor}
+
+La conversione da CMYKColor a Color. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgb`](../../cmykcolorhelper/toargb/).
+
+```csharp
+[Obsolete]
+public static Color ToColor(CmykColor cmykPixel)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixel | CmykColor | I pixel di tipo CMYKColor in formato CMYK. |
+
+### Valore di ritorno
+
+Il Color[].
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/cmykcolor/tocoloricc/_index.md
+++ b/italian/net/aspose.psd/cmykcolor/tocoloricc/_index.md
@@ -1,0 +1,116 @@
+---
+title: "CmykColor.ToColorIcc"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo CmykColor. La conversione da CMYKColor a Color usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace ToArgbIcc"
+type: docs
+weight: 140
+url: /it/net/aspose.psd/cmykcolor/tocoloricc/
+---
+{{< psd/tize >}}
+## ToColorIcc(CmykColor[]) {#tocoloricc_2}
+
+La conversione da CMYKColor a Color usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColorIcc(CmykColor[] cmykPixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | I pixel di tipo CMYKColor in formato CMYK. |
+
+### Valore di ritorno
+
+Il Color[].
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor) {#tocoloricc}
+
+La conversione da CMYKColor a Color usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color ToColorIcc(CmykColor cmykPixel)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixel | CmykColor | Il pixel di tipo CMYKColor in formato CMYK. |
+
+### Valore di ritorno
+
+Il [`Color`](../../color/).
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor[], Stream, Stream) {#tocoloricc_3}
+
+La conversione da CMYKColor a Color usando la conversione icc. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColorIcc(CmykColor[] cmykPixels, Stream cmykIccStream, Stream rgbIccStream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | I pixel di tipo CMYKColor in formato CMYK. |
+| cmykIccStream | Flusso | Il flusso contenente il profilo icc cmyk. |
+| rgbIccStream | Flusso | Il flusso contenente il profilo icc rgb. |
+
+### Valore di ritorno
+
+Il Color[].
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor, Stream, Stream) {#tocoloricc_1}
+
+La conversione da CMYKColor a Color usando la conversione icc. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color ToColorIcc(CmykColor cmykPixel, Stream cmykIccStream, Stream rgbIccStream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| cmykPixel | CmykColor | Il pixel di tipo CMYKColor in formato CMYK. |
+| cmykIccStream | Flusso | Il flusso contenente il profilo icc cmyk. |
+| rgbIccStream | Flusso | Il flusso contenente il profilo icc rgb. |
+
+### Valore di ritorno
+
+Il [`Color`](../../color/).
+
+### Vedi anche
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/color/tocmyk/_index.md
+++ b/italian/net/aspose.psd/color/tocmyk/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Color.ToCmyk"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Color. La conversione da Color a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace ToCmyk"
+type: docs
+weight: 1620
+url: /it/net/aspose.psd/color/tocmyk/
+---
+{{< psd/tize >}}
+## ToCmyk(Color[]) {#tocmyk_1}
+
+La conversione da Color a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmyk(Color[] pixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color[] | I pixel di tipo Color in formato RGB. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor[].
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmyk(Color) {#tocmyk}
+
+La conversione da Color a CMYKColor. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmyk(Color pixel)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color | Il pixel di tipo Color in formato RGB. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor.
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/color/tocmykicc/_index.md
+++ b/italian/net/aspose.psd/color/tocmykicc/_index.md
@@ -1,0 +1,116 @@
+---
+title: "Color.ToCmykIcc"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Color. La conversione da Color a CMYKColor usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace ToCmykIcc"
+type: docs
+weight: 1630
+url: /it/net/aspose.psd/color/tocmykicc/
+---
+{{< psd/tize >}}
+## ToCmykIcc(Color) {#tocmykicc}
+
+La conversione da Color a CMYKColor usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmykIcc(Color pixel)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color | Il pixel di tipo Color in formato RGB. |
+
+### Valore di ritorno
+
+Il [`CmykColor`](../../cmykcolor/).
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color[]) {#tocmykicc_2}
+
+La conversione da Color a CMYKColor usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmykIcc(Color[] pixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color[] | I pixel di tipo Color in formato RGB. |
+
+### Valore di ritorno
+
+Il !:CmykColor[].
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color[], Stream, Stream) {#tocmykicc_3}
+
+La conversione da Color a CMYKColor usando la conversione icc. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmykIcc(Color[] pixels, Stream rgbIccStream, Stream cmykIccStream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color[] | I pixel di tipo Color in formato RGB. |
+| rgbIccStream | Flusso | Il flusso contenente il profilo icc rgb. |
+| cmykIccStream | Flusso | Il flusso contenente il profilo icc cmyk. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor[].
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color, Stream, Stream) {#tocmykicc_1}
+
+La conversione da Color a CMYKColor usando la conversione icc con profili predefiniti. Questo metodo è deprecato. Si prega di utilizzare il più efficace [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmykIcc(Color pixel, Stream rgbIccStream, Stream cmykIccStream)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| pixel | Color | Il pixel di tipo Color in formato RGB. |
+| rgbIccStream | Flusso | Il flusso contenente il profilo icc rgb. |
+| cmykIccStream | Flusso | Il flusso contenente il profilo icc cmyk. |
+
+### Valore di ritorno
+
+Il Aspose:PSD:CmykColor[].
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/fontsettings/getsystemalternativefont/_index.md
+++ b/italian/net/aspose.psd/fontsettings/getsystemalternativefont/_index.md
@@ -1,0 +1,28 @@
+---
+title: "FontSettings.GetSystemAlternativeFont"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà FontSettings. Ottiene o imposta un valore che indica se ottenere il font alternativo"
+type: docs
+weight: 20
+url: /it/net/aspose.psd/fontsettings/getsystemalternativefont/
+---
+{{< psd/tize >}}
+## FontSettings.GetSystemAlternativeFont property
+
+Ottiene o imposta un valore che indica se [get alternative font].
+
+```csharp
+public static bool GetSystemAlternativeFont { get; set; }
+```
+
+### Property Value
+
+`true` se [get alternative font]; altrimenti, `false`.
+
+### Vedi anche
+
+* class [FontSettings](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/fontsettings/removefontcachefile/_index.md
+++ b/italian/net/aspose.psd/fontsettings/removefontcachefile/_index.md
@@ -1,0 +1,47 @@
+---
+title: "FontSettings.RemoveFontCacheFile"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo FontSettings. Rimuove il file della cache dei font"
+type: docs
+weight: 100
+url: /it/net/aspose.psd/fontsettings/removefontcachefile/
+---
+{{< psd/tize >}}
+## FontSettings.RemoveFontCacheFile method
+
+Rimuove il file della cache dei font.
+
+```csharp
+public static void RemoveFontCacheFile()
+```
+
+## Esempi
+
+Il codice seguente dimostra il metodo per rimuovere il file con la cache dei font caricati.
+
+```csharp
+[C#]
+
+string src = "SimpleText.psd";
+
+FontSettings.RemoveFontCacheFile();
+
+using (var psdImage = (PsdImage)Image.Load(src))
+{
+    foreach (var layer in psdImage.Layers)
+    {
+        if (layer is TextLayer textLayer)
+        {
+            textLayer.GetFonts();
+        }
+    }
+}
+```
+
+### Vedi anche
+
+* class [FontSettings](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/graphics/paintableimageoptions/_index.md
+++ b/italian/net/aspose.psd/graphics/paintableimageoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Graphics.PaintableImageOptions"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà Graphics. Ottiene o imposta le opzioni immagine usate per creare immagini vettoriali dipingibili da disegnare"
+type: docs
+weight: 110
+url: /it/net/aspose.psd/graphics/paintableimageoptions/
+---
+{{< psd/tize >}}
+## Graphics.PaintableImageOptions property
+
+Ottiene o imposta le opzioni immagine, usate per creare immagini vettoriali dipingibili da disegnare.
+
+```csharp
+public ImageOptionsBase PaintableImageOptions { get; set; }
+```
+
+### Property Value
+
+Le opzioni immagine, usate per creare immagini vettoriali dipingibili da disegnare.
+
+### Vedi anche
+
+* class [ImageOptionsBase](../../imageoptionsbase/)
+* class [Graphics](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/image/usepalette/_index.md
+++ b/italian/net/aspose.psd/image/usepalette/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Image.UsePalette"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà Image. Restituisce un valore che indica se la tavolozza dell'immagine è utilizzata"
+type: docs
+weight: 150
+url: /it/net/aspose.psd/image/usepalette/
+---
+{{< psd/tize >}}
+## Image.UsePalette property
+
+Ottiene un valore che indica se la palette dell'immagine è utilizzata.
+
+```csharp
+public virtual bool UsePalette { get; }
+```
+
+### Property Value
+
+`true` se la tavolozza è utilizzata nell'immagine; altrimenti, `false`.
+
+### Vedi anche
+
+* class [Image](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/metered/getproductname/_index.md
+++ b/italian/net/aspose.psd/metered/getproductname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metered.GetProductName"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Metered. Ottiene il nome del prodotto"
+type: docs
+weight: 30
+url: /it/net/aspose.psd/metered/getproductname/
+---
+{{< psd/tize >}}
+## Metered.GetProductName method
+
+Ottiene il nome del prodotto.
+
+```csharp
+public string GetProductName()
+```
+
+### Valore di ritorno
+
+Nome del prodotto con licenza
+
+### Vedi anche
+
+* class [Metered](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/metered/ismeteredlicensed/_index.md
+++ b/italian/net/aspose.psd/metered/ismeteredlicensed/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metered.IsMeteredLicensed"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Metered. Verifica se Metered è con licenza"
+type: docs
+weight: 70
+url: /it/net/aspose.psd/metered/ismeteredlicensed/
+---
+{{< psd/tize >}}
+## Metered.IsMeteredLicensed method
+
+Verifica se Metered è con licenza
+
+```csharp
+public static bool IsMeteredLicensed()
+```
+
+### Valore di ritorno
+
+Vero o falso
+
+### Vedi anche
+
+* class [Metered](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/pixelsdata/clone/_index.md
+++ b/italian/net/aspose.psd/pixelsdata/clone/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PixelsData.Clone"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo PixelsData. Crea una copia completa dell'istanza"
+type: docs
+weight: 40
+url: /it/net/aspose.psd/pixelsdata/clone/
+---
+{{< psd/tize >}}
+## PixelsData.Clone method
+
+Crea una copia completa dell'istanza
+
+```csharp
+public object Clone()
+```
+
+### Valore di ritorno
+
+La copia dell'istanza
+
+### Vedi anche
+
+* class [PixelsData](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/pluginlicenseexception/_index.md
+++ b/italian/net/aspose.psd/pluginlicenseexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Classe PluginLicenseException"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Classe Aspose.PSD.PluginLicenseException. Eccezione per la licenza del plugin"
+type: docs
+weight: 5750
+url: /it/net/aspose.psd/pluginlicenseexception/
+---
+{{< psd/tize >}}
+## PluginLicenseException class
+
+Eccezione per la licenza del plugin
+
+```csharp
+public class PluginLicenseException : Exception
+```
+
+## Costruttori
+
+| Nome | Descrizione |
+| --- | --- |
+| [PluginLicenseException](pluginlicenseexception/)() | Il costruttore predefinito. |
+
+### Vedi anche
+
+* namespace [Aspose.PSD](../../aspose.psd/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/italian/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/_index.md
+++ b/italian/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PluginLicenseException.PluginLicenseException"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Costruttore PluginLicenseException. Il costruttore predefinito"
+type: docs
+weight: 10
+url: /it/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/
+---
+{{< psd/tize >}}
+## PluginLicenseException constructor
+
+Il costruttore predefinito.
+
+```csharp
+public PluginLicenseException()
+```
+
+### Vedi anche
+
+* class [PluginLicenseException](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/rasterimage/loadcmykpixels/_index.md
+++ b/italian/net/aspose.psd/rasterimage/loadcmykpixels/_index.md
@@ -1,0 +1,35 @@
+---
+title: "RasterImage.LoadCmykPixels"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RasterImage. Carica i pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare il metodo LoadCmyk32Pixels più efficace."
+type: docs
+weight: 380
+url: /it/net/aspose.psd/rasterimage/loadcmykpixels/
+---
+{{< psd/tize >}}
+## RasterImage.LoadCmykPixels method
+
+Carica i pixel in formato CMYK. Questo metodo è deprecato. Si prega di utilizzare il metodo [`LoadCmyk32Pixels`](../loadcmyk32pixels/) più efficace.
+
+```csharp
+[Obsolete]
+public CmykColor[] LoadCmykPixels(Rectangle rectangle)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rettangolo | Rettangolo | Il rettangolo da cui caricare i pixel. |
+
+### Valore di ritorno
+
+L'array di pixel CMYK caricato.
+
+### Vedi anche
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Rectangle](../../rectangle/)
+* class [RasterImage](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/rasterimage/savecmykpixels/_index.md
+++ b/italian/net/aspose.psd/rasterimage/savecmykpixels/_index.md
@@ -1,0 +1,32 @@
+---
+title: "RasterImage.SaveCmykPixels"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo RasterImage. Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo SaveCmyk32Pixels più efficace."
+type: docs
+weight: 530
+url: /it/net/aspose.psd/rasterimage/savecmykpixels/
+---
+{{< psd/tize >}}
+## RasterImage.SaveCmykPixels method
+
+Salva i pixel. Questo metodo è deprecato. Si prega di utilizzare il metodo [`SaveCmyk32Pixels`](../savecmyk32pixels/) più efficace.
+
+```csharp
+[Obsolete]
+public void SaveCmykPixels(Rectangle rectangle, CmykColor[] pixels)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| rettangolo | Rettangolo | Il rettangolo in cui salvare i pixel. |
+| pixel | CmykColor[] | L'array di pixel CMYK. |
+
+### Vedi anche
+
+* struct [Rectangle](../../rectangle/)
+* struct [CmykColor](../../cmykcolor/)
+* class [RasterImage](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/region/gethashcode/_index.md
+++ b/italian/net/aspose.psd/region/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Region.GetHashCode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo Region. Ottieni il codice hash dell'oggetto corrente"
+type: docs
+weight: 60
+url: /it/net/aspose.psd/region/gethashcode/
+---
+{{< psd/tize >}}
+## Region.GetHashCode method
+
+Ottiene il codice hash dell'oggetto corrente.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Valore di ritorno
+
+Il codice hash.
+
+### Vedi anche
+
+* class [Region](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/stringformat/customcharident/_index.md
+++ b/italian/net/aspose.psd/stringformat/customcharident/_index.md
@@ -1,0 +1,29 @@
+---
+title: "StringFormat.CustomCharIdent"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Proprietà StringFormat. Ottiene o imposta l'ident del carattere personalizzato"
+type: docs
+weight: 50
+url: /it/net/aspose.psd/stringformat/customcharident/
+---
+{{< psd/tize >}}
+## StringFormat.CustomCharIdent property
+
+Ottiene o imposta l'ident del carattere personalizzato.
+
+```csharp
+public PointF CustomCharIdent { get; set; }
+```
+
+### Property Value
+
+L'ident del carattere personalizzato.
+
+### Vedi anche
+
+* struct [PointF](../../pointf/)
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/stringformat/equals/_index.md
+++ b/italian/net/aspose.psd/stringformat/equals/_index.md
@@ -1,0 +1,32 @@
+---
+title: "StringFormat.Equals"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo StringFormat. Verifica se gli oggetti sono uguali"
+type: docs
+weight: 150
+url: /it/net/aspose.psd/stringformat/equals/
+---
+{{< psd/tize >}}
+## StringFormat.Equals method
+
+Verifica se gli oggetti sono uguali.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parametro | Tipo | Descrizione |
+| --- | --- | --- |
+| obj | Object | L'altro oggetto. |
+
+### Valore di ritorno
+
+Il risultato del confronto di uguaglianza.
+
+### Vedi anche
+
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/italian/net/aspose.psd/stringformat/gethashcode/_index.md
+++ b/italian/net/aspose.psd/stringformat/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "StringFormat.GetHashCode"
+second_title: "Riferimento API Aspose.PSD per .NET"
+description: "Metodo StringFormat. Ottieni il codice hash dell'oggetto corrente"
+type: docs
+weight: 160
+url: /it/net/aspose.psd/stringformat/gethashcode/
+---
+{{< psd/tize >}}
+## StringFormat.GetHashCode method
+
+Ottiene il codice hash dell'oggetto corrente.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Valore di ritorno
+
+Il codice hash.
+
+### Vedi anche
+
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+


### PR DESCRIPTION
🔄 **In progress** — incremental translation of NET API Reference to **Italian** (`it`).

Updated at each cache checkpoint. Source: `english/net`

🤖 Generated by RDA