### PR TITLE
[draft] Translate NET API Reference to Netherlands

### DIFF
--- a/netherlands/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/_index.md
+++ b/netherlands/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LinearGradientBrush.InterpolationColors"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LinearGradientBrush property. Haalt een ColorBlend op of stelt deze in die een meerkleurige lineaire gradient definieert"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.brushes/lineargradientbrush/interpolationcolors/
+---
+{{< psd/tize >}}
+## LinearGradientBrush.InterpolationColors property
+
+Haalt een [`ColorBlend`](../../../aspose.psd/colorblend/) op of stelt deze in die een meerkleurige lineaire gradient definieert.
+
+```csharp
+[Obsolete("This property is not used anymore in this class. Use instance of the LinearMulticolorGradientBrush class instead.")]
+public ColorBlend InterpolationColors { get; set; }
+```
+
+### Property Value
+
+Een [`ColorBlend`](../../../aspose.psd/colorblend/) die een meerkleurige lineaire gradient definieert.
+
+### Zie ook
+
+* class [ColorBlend](../../../aspose.psd/colorblend/)
+* class [LinearGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.brushes/lineargradientbrush/linearcolors/_index.md
+++ b/netherlands/net/aspose.psd.brushes/lineargradientbrush/linearcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LinearGradientBrush.LinearColors"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LinearGradientBrush property. Haalt de begin- en eindkleuren van de gradient op of stelt deze in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.brushes/lineargradientbrush/linearcolors/
+---
+{{< psd/tize >}}
+## LinearGradientBrush.LinearColors property
+
+Haalt de begin- en eindkleuren van de gradient op of stelt deze in.
+
+```csharp
+[Obsolete("Use StartColor and EndColor properties instead.")]
+public Color[] LinearColors { get; set; }
+```
+
+### Property Value
+
+Een array van twee [`Color`](../../../aspose.psd/color/) structuren die de begin- en eindkleuren van de gradient weergeven.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [LinearGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/_index.md
+++ b/netherlands/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/_index.md
@@ -1,0 +1,30 @@
+---
+title: "PathGradientBrush.InterpolationColors"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathGradientBrush-eigenschap. Haalt een ColorBlend op of stelt deze in die een meerkleurige lineaire gradiënt definieert."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.brushes/pathgradientbrush/interpolationcolors/
+---
+{{< psd/tize >}}
+## PathGradientBrush.InterpolationColors property
+
+Haalt een [`ColorBlend`](../../../aspose.psd/colorblend/) op of stelt deze in die een meerkleurige lineaire gradient definieert.
+
+```csharp
+[Obsolete("This property is not used in this class anymore. Use PathMulticolorGradientBrush class instead.")]
+public ColorBlend InterpolationColors { get; set; }
+```
+
+### Property Value
+
+Een [`ColorBlend`](../../../aspose.psd/colorblend/) die een meerkleurige lineaire gradient definieert.
+
+### Zie ook
+
+* class [ColorBlend](../../../aspose.psd/colorblend/)
+* class [PathGradientBrush](../)
+* namespace [Aspose.PSD.Brushes](../../../aspose.psd.brushes/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.customfonthandler/_index.md
+++ b/netherlands/net/aspose.psd.customfonthandler/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.PSD.CustomFontHandler"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "De namespace verwerkt de verwerking van aangepaste lettertypen"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.customfonthandler/
+---
+{{< psd/tize >}}
+De namespace verwerkt de verwerking van aangepaste lettertypen.
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [CustomFontData](./customfontdata/) | Aangepaste lettertypegegevensklasse |
+
+

--- a/netherlands/net/aspose.psd.customfonthandler/customfontdata/_index.md
+++ b/netherlands/net/aspose.psd.customfonthandler/customfontdata/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Klasse CustomFontData"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.CustomFontHandler.CustomFontData klasse. Aangepaste lettertypegegevensklasse"
+type: docs
+weight: 700
+url: /nl/net/aspose.psd.customfonthandler/customfontdata/
+---
+{{< psd/tize >}}
+## CustomFontData class
+
+Aangepaste lettertypegegevensklasse
+
+```csharp
+public class CustomFontData
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [CustomFontData](customfontdata/)(string, byte[]) | Initialiseert een nieuw exemplaar van de `CustomFontData`-klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [FontData](../../aspose.psd.customfonthandler/customfontdata/fontdata/) { get; } | Haalt de lettertypegegevens op. |
+| [FontName](../../aspose.psd.customfonthandler/customfontdata/fontname/) { get; } | Haalt de naam van het lettertype op. |
+
+### Zie ook
+
+* namespace [Aspose.PSD.CustomFontHandler](../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.customfonthandler/customfontdata/customfontdata/_index.md
+++ b/netherlands/net/aspose.psd.customfonthandler/customfontdata/customfontdata/_index.md
@@ -1,0 +1,29 @@
+---
+title: "CustomFontData.CustomFontData"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CustomFontData constructor. Initialiseert een nieuw exemplaar van de CustomFontData-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.customfonthandler/customfontdata/customfontdata/
+---
+{{< psd/tize >}}
+## CustomFontData constructor
+
+Initialiseert een nieuw exemplaar van de [`CustomFontData`](../)-klasse.
+
+```csharp
+public CustomFontData(string fontName, byte[] fontData)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| fontName | String | Naam van het lettertype. |
+| fontData | Byte[] | De lettertypegegevens. |
+
+### Zie ook
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.customfonthandler/customfontdata/fontdata/_index.md
+++ b/netherlands/net/aspose.psd.customfonthandler/customfontdata/fontdata/_index.md
@@ -1,0 +1,28 @@
+---
+title: "CustomFontData.FontData"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CustomFontData property. Haalt de lettertypegegevens op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.customfonthandler/customfontdata/fontdata/
+---
+{{< psd/tize >}}
+## CustomFontData.FontData property
+
+Haalt de lettertypegegevens op.
+
+```csharp
+public byte[] FontData { get; }
+```
+
+### Property Value
+
+De lettertypegegevens.
+
+### Zie ook
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.customfonthandler/customfontdata/fontname/_index.md
+++ b/netherlands/net/aspose.psd.customfonthandler/customfontdata/fontname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "CustomFontData.FontName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CustomFontData property. Haalt de naam van het lettertype op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.customfonthandler/customfontdata/fontname/
+---
+{{< psd/tize >}}
+## CustomFontData.FontName property
+
+Haalt de naam van het lettertype op.
+
+```csharp
+public string FontName { get; }
+```
+
+### Property Value
+
+De naam van het lettertype.
+
+### Zie ook
+
+* class [CustomFontData](../)
+* namespace [Aspose.PSD.CustomFontHandler](../../../aspose.psd.customfonthandler/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.extensions/imageextensions/togdiimage/_index.md
+++ b/netherlands/net/aspose.psd.extensions/imageextensions/togdiimage/_index.md
@@ -1,0 +1,38 @@
+---
+title: "ImageExtensions.ToGdiImage"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ImageExtensions-methode. Converteert de Image naar de Image"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.extensions/imageextensions/togdiimage/
+---
+{{< psd/tize >}}
+## ImageExtensions.ToGdiImage method
+
+Converteert de Image naar de Image.
+
+```csharp
+[Obsolete("Please do not use this method as you may get OutOfMemoryException if image is too large for GDI to fit.")]
+public static Image ToGdiImage(Image image)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| afbeelding | Afbeelding | De Image om te converteren. |
+
+### Retourwaarde
+
+De geconverteerde Image.
+
+## Opmerkingen
+
+Waarschuwing, de GDI-afbeelding kan lagere grenzen hebben dan *image* heeft. Om alle delen van de afbeelding te krijgen, gebruik de veiligere extensiemethode ToGdiImageFull.
+
+### Zie ook
+
+* class [Image](../../../aspose.psd/image/)
+* class [ImageExtensions](../)
+* namespace [Aspose.PSD.Extensions](../../../aspose.psd.extensions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.ai/aiimage/activepageindex/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.ai/aiimage/activepageindex/_index.md
@@ -1,0 +1,61 @@
+---
+title: "AiImage.ActivePageIndex"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AiImage-eigenschap. Haalt of stelt de index van de actieve pagina"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.ai/aiimage/activepageindex/
+---
+{{< psd/tize >}}
+## AiImage.ActivePageIndex property
+
+Haalt of stelt de index van de actieve pagina.
+
+```csharp
+public int ActivePageIndex { get; set; }
+```
+
+### Property Value
+
+Deze eigenschap is alleen van toepassing op AI-afbeeldingen in PDF-formaat. Als de afbeelding niet in PDF-formaat is of er geen pagina's zijn, zal de eigenschap -1 zijn. Deze eigenschap geeft aan welke pagina van de AI-afbeelding de basis zal vormen voor weergave.
+
+## Voorbeelden
+
+De volgende code demonstreert de mogelijkheid om de actieve pagina in AI-afbeeldingen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "threePages.ai";
+string firstPageOutputPng = "firstPageOutput.png";
+string secondPageOutputPng = "secondPageOutput.png";
+string thirdPageOutputPng = "thirdPageOutput.png";
+
+// Laad de AI-afbeelding.
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    // Standaard is de ActivePageIndex 0.
+    // Dus als je de AI-afbeelding opslaat zonder deze eigenschap te wijzigen, wordt de eerste pagina gerenderd en opgeslagen.
+    image.Save(firstPageOutputPng, new PngOptions());
+
+    // Wijzig de index van de actieve pagina naar de tweede pagina.
+    image.ActivePageIndex = 1;
+
+    // Sla de tweede pagina van de AI-afbeelding op als een PNG-afbeelding.
+    image.Save(secondPageOutputPng, new PngOptions());
+
+    // Wijzig de index van de actieve pagina naar de derde pagina.
+    image.ActivePageIndex = 2;
+
+    // Sla de derde pagina van de AI-afbeelding op als een PNG-afbeelding.
+    image.Save(thirdPageOutputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.ai/aiimage/pagecount/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.ai/aiimage/pagecount/_index.md
@@ -1,0 +1,63 @@
+---
+title: "AiImage.PageCount"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AiImage property. Het aantal pagina's. Voor het oude AI-formaat zijn afbeeldingen altijd gelijk aan 0"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.ai/aiimage/pagecount/
+---
+{{< psd/tize >}}
+## AiImage.PageCount property
+
+Het aantal pagina's. Voor het oude AI-formaat zijn afbeeldingen altijd gelijk aan 0.
+
+```csharp
+public int PageCount { get; }
+```
+
+### Property Value
+
+Het aantal pagina's.
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de AiImage-eigenschap voor het aantal pagina's AiImage.PageCount.
+
+```csharp
+[C#]
+
+string sourceFile = "2241.ai";
+string[] outputFiles = new string[3]
+{
+    "2241_pageNumber_0.png",
+    "2241_pageNumber_1.png",
+    "2241_pageNumber_2.png",
+};
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.PageCount, 3);
+
+    for (int i = 0; i < image.PageCount; i++)
+    {
+        image.ActivePageIndex = i;
+        image.Save(outputFiles[i], new PngOptions());
+    }
+}
+```
+
+### Zie ook
+
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.ai/aiimage/xmpdata/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.ai/aiimage/xmpdata/_index.md
@@ -1,0 +1,92 @@
+---
+title: "AiImage.XmpData"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AiImage property. Haalt de XMP-metadata op"
+type: docs
+weight: 150
+url: /nl/net/aspose.psd.fileformats.ai/aiimage/xmpdata/
+---
+{{< psd/tize >}}
+## AiImage.XmpData property
+
+Haalt de XMP-metadata op.
+
+```csharp
+public XmpPacketWrapper XmpData { get; }
+```
+
+### Property Value
+
+De XMP-gegevens.
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de AiImage.XmpData-eigenschap.
+
+```csharp
+[C#]
+
+string sourceFile = "ai_one.ai";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object testObject)
+{
+    if (testObject == null)
+    {
+        throw new Exception("Test object are null.");
+    }
+}
+
+string creatorToolKey = ":CreatorTool";
+string nPagesKey = "xmpTPg:NPages";
+string unitKey = "stDim:unit";
+string heightKey = "stDim:h";
+string widthKey = "stDim:w";
+
+string expectedCreatorTool = "Adobe Illustrator CC 22.1 (Windows)";
+string expectedNPages = "1";
+string expectedUnit = "Pixels";
+double expectedHeight = 768;
+double expectedWidth = 1366;
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    // XMP-metadata is toegevoegd.
+    var xmpMetaData = image.XmpData;
+
+    AssertIsNotNull(xmpMetaData);
+
+    // Nee, we kunnen toegang krijgen tot XMP-pakketten van AI-bestanden.
+    var basicPackage = xmpMetaData.GetPackage(Namespaces.XmpBasic) as XmpBasicPackage;
+    var package = xmpMetaData.Packages[4];
+
+    // En we hebben toegang tot de inhoud van deze pakketten.
+    var creatorTool = basicPackage[creatorToolKey].ToString();
+    var nPages = package[nPagesKey];
+    var unit = package[unitKey];
+    var height = double.Parse(package[heightKey].ToString(), CultureInfo.InvariantCulture);
+    var width = double.Parse(package[widthKey].ToString(), CultureInfo.InvariantCulture);
+
+    AssertAreEqual(creatorTool, expectedCreatorTool);
+    AssertAreEqual(nPages, expectedNPages);
+    AssertAreEqual(unit, expectedUnit);
+    AssertAreEqual(height, expectedHeight);
+    AssertAreEqual(width, expectedWidth);
+}
+```
+
+### Zie ook
+
+* class [XmpPacketWrapper](../../../aspose.psd.xmp/xmppacketwrapper/)
+* class [AiImage](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.ai/ailayersection/colorindex/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.ai/ailayersection/colorindex/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AiLayerSection.ColorIndex"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AiLayerSection-eigenschap. Haalt of stelt de index van de kleur. Dit argument kan waarden tussen 1 en 26 aannemen. Elk geheel getal vertegenwoordigt een kleur die aan de laag kan worden toegewezen voor gebruikersidentificatiedoeleinden"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.ai/ailayersection/colorindex/
+---
+{{< psd/tize >}}
+## AiLayerSection.ColorIndex property
+
+Haalt of stelt de index van de kleur. Dit argument kan waarden tussen –1 en 26 aannemen. Elk geheel getal vertegenwoordigt een kleur die aan de laag kan worden toegewezen voor gebruikersidentificatiedoeleinden.
+
+```csharp
+public int ColorIndex { get; set; }
+```
+
+### Property Value
+
+De index van de kleur.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van HasMultiLayerMasks- en ColorIndex-eigenschappen in AiLayerSection.
+
+```csharp
+[C#]
+
+string sourceFile = "example.ai";
+string outputFilePath = "example.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.Layers.Length, 2);
+    AssertAreEqual(image.Layers[0].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[0].ColorIndex, -1);
+    AssertAreEqual(image.Layers[1].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[1].ColorIndex, -1);
+
+    image.Save(outputFilePath, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [AiLayerSection](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/_index.md
@@ -1,0 +1,58 @@
+---
+title: "AiLayerSection.HasMultiLayerMasks"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AiLayerSection-eigenschap. Haalt of stelt een waarde in die aangeeft of deze instantie multilayer-masks heeft"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.ai/ailayersection/hasmultilayermasks/
+---
+{{< psd/tize >}}
+## AiLayerSection.HasMultiLayerMasks property
+
+Haalt of stelt een waarde in die aangeeft of deze instantie multilayer-masks heeft.
+
+```csharp
+public bool HasMultiLayerMasks { get; set; }
+```
+
+### Property Value
+
+`true` als deze instantie multilayer-masks heeft; anders `false`.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van HasMultiLayerMasks- en ColorIndex-eigenschappen in AiLayerSection.
+
+```csharp
+[C#]
+
+string sourceFile = "example.ai";
+string outputFilePath = "example.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (AiImage image = (AiImage)Image.Load(sourceFile))
+{
+    AssertAreEqual(image.Layers.Length, 2);
+    AssertAreEqual(image.Layers[0].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[0].ColorIndex, -1);
+    AssertAreEqual(image.Layers[1].HasMultiLayerMasks, false);
+    AssertAreEqual(image.Layers[1].ColorIndex, -1);
+
+    image.Save(outputFilePath, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [AiLayerSection](../)
+* namespace [Aspose.PSD.FileFormats.Ai](../../../aspose.psd.fileformats.ai/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "VectorShapeBoundingBox.PointsUnitType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorShapeBoundingBox-eigenschap. Haalt het eenheidstype van de punten op of stelt dit in die de hoeken van de doos bepalen."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.core.vectorpaths/vectorshapeboundingbox/pointsunittype/
+---
+{{< psd/tize >}}
+## VectorShapeBoundingBox.PointsUnitType property
+
+Haalt het eenheidstype van de punten op of stelt dit in die de hoeken van de doos bepalen.
+
+```csharp
+public UnitTypes PointsUnitType { get; set; }
+```
+
+### Zie ook
+
+* enum [UnitTypes](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/unittypes/)
+* class [VectorShapeBoundingBox](../)
+* namespace [Aspose.PSD.FileFormats.Core.VectorPaths](../../../aspose.psd.fileformats.core.vectorpaths/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/_index.md
@@ -1,0 +1,20 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Core.RawColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "De namespace bevat de PSD RawColor Class-hiërarchie inclusief ColorComponent"
+type: docs
+weight: 220
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/
+---
+{{< psd/tize >}}
+De namespace bevat de PSD RawColor Class-hiërarchie inclusief ColorComponent
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [ColorComponent](./colorcomponent/) | Kleurcomponent is een abstractie van Channel Value en Channel Value. Elke kleur bestaat uit een array van ColorComponent |
+| [RawColor](./rawcolor/) | Raw Color Class helpt bij het opslaan van kleuren met elk aantal kanalen, elke kleermodus en elke bitdiepte. Houd er rekening mee dat sommige interne klassen problemen kunnen hebben met het converteren van RawColor naar het eigen formaat, dus als de API een CMYK-kleur levert, is het betrouwbaarder om het geleverde formaat te gebruiken. Ook kunnen er gevallen zijn waarin Raw Color kan worden geconverteerd. |
+| [RawColorHelper](./rawcolorhelper/) | Raw Color Helper Class helpt bij het sneller maken van RawColor, met behulp van vooraf gedefinieerde kanaalmetadata |
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/_index.md
@@ -1,0 +1,46 @@
+---
+title: "Klasse ColorComponent"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.ColorComponent klasse. Kleurcomponent is een abstractie over Channel Value en Channel Value. Elke kleur bestaat uit een array van ColorComponent."
+type: docs
+weight: 1640
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/
+---
+{{< psd/tize >}}
+## ColorComponent class
+
+Kleurcomponent is een abstractie van Channel Value en Channel Value. Elke kleur bestaat uit een array van ColorComponent
+
+```csharp
+public sealed class ColorComponent
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorComponent](colorcomponent/)(byte, string) | Initialiseert een nieuw exemplaar van de `ColorComponent`-klasse. Controleer alstublieft. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BitDepth](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/) { get; } | Haalt de bitdiepte op van Color Component/Channel |
+| [Description](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/) { get; } | Haalt de beschrijving op van Color Component |
+| [FullName](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/) { get; } | Haalt de volledige naam op van het kleurcomponent met naam en door spaties gescheiden beschrijving |
+| [Name](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/) { get; } | Haalt de naam op van het kleurcomponent. |
+| [Value](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/) { get; set; } | Haalt de waarde op of stelt deze in. Let op, als u probeert een waarde in te stellen die groter is dan wat mogelijk is opgeslagen in de huidige bitdiepte, krijgt u een uitzondering. |
+| static [PermittedFullNames](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/) { get; } | Haalt de toegestane volledige namen op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/)() | Haal de hashcode op van het huidige object. |
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.BitDepth"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent property. Haalt de bitdiepte op van de Color Component/Kanaal"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/bitdepth/
+---
+{{< psd/tize >}}
+## ColorComponent.BitDepth property
+
+Haalt de bitdiepte op van Color Component/Channel
+
+```csharp
+public byte BitDepth { get; }
+```
+
+### Property Value
+
+De bitdiepte.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/_index.md
@@ -1,0 +1,29 @@
+---
+title: "ColorComponent.ColorComponent"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent constructor. Initialiseert een nieuw exemplaar van de ColorComponent klasse. Controleer alstublieft."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/colorcomponent/
+---
+{{< psd/tize >}}
+## ColorComponent constructor
+
+Initialiseert een nieuw exemplaar van the [`ColorComponent`](../) klasse. Controleer alstublieft.
+
+```csharp
+public ColorComponent(byte bitDepth, string fullName)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bitDepth | Byte | De bitdiepte. |
+| fullName | String | De volledige naam. |
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Description"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent property. Haalt de beschrijving van de Color Component op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/description/
+---
+{{< psd/tize >}}
+## ColorComponent.Description property
+
+Haalt de beschrijving op van Color Component
+
+```csharp
+public string Description { get; }
+```
+
+### Property Value
+
+De beschrijving.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.FullName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent eigenschap. Haalt de volledige naam van het kleurcomponent op met naam en door spaties gescheiden beschrijving."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/fullname/
+---
+{{< psd/tize >}}
+## ColorComponent.FullName property
+
+Haalt de volledige naam op van het kleurcomponent met naam en door spaties gescheiden beschrijving
+
+```csharp
+public string FullName { get; }
+```
+
+### Property Value
+
+De volledige naam.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.GetHashCode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent methode. Haalt de hashcode op van het huidige object."
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/gethashcode/
+---
+{{< psd/tize >}}
+## ColorComponent.GetHashCode method
+
+Haal de hashcode op van het huidige object.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Retourwaarde
+
+De hashcode.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Name"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent property. Haalt de naam van het kleurcomponent op"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/name/
+---
+{{< psd/tize >}}
+## ColorComponent.Name property
+
+Haalt de naam op van het kleurcomponent.
+
+```csharp
+public string Name { get; }
+```
+
+### Property Value
+
+De naam.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.PermittedFullNames"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent property. Haalt de toegestane volledige namen op"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/permittedfullnames/
+---
+{{< psd/tize >}}
+## ColorComponent.PermittedFullNames property
+
+Haalt de toegestane volledige namen op.
+
+```csharp
+public static string[] PermittedFullNames { get; }
+```
+
+### Property Value
+
+De toegestane volledige namen.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/_index.md
@@ -1,0 +1,28 @@
+---
+title: "ColorComponent.Value"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorComponent property. Let op: als je probeert een waarde in te stellen die groter is dan wat mogelijk is in de huidige bitdiepte, krijg je een uitzondering."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/colorcomponent/value/
+---
+{{< psd/tize >}}
+## ColorComponent.Value property
+
+Haalt de waarde op of stelt deze in. Let op, als u probeert een waarde in te stellen die groter is dan wat mogelijk is opgeslagen in de huidige bitdiepte, krijgt u een uitzondering.
+
+```csharp
+public ulong Value { get; set; }
+```
+
+### Property Value
+
+De waarde.
+
+### Zie ook
+
+* class [ColorComponent](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/_index.md
@@ -1,0 +1,87 @@
+---
+title: "Klasse RawColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.RawColor class. Raw Color Class helpt bij het opslaan van kleuren met elk aantal kanalen, elke kleermodus en elke bitdiepte. Houd er rekening mee dat sommige interne klassen problemen kunnen hebben met het converteren van RawColor naar zijn native formaat, dus als de API een CMYK‑kleur levert, is het betrouwbaarder om het geleverde formaat te gebruiken. Er kunnen ook gevallen zijn waarin Raw Color kan worden geconverteerd"
+type: docs
+weight: 1650
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/
+---
+{{< psd/tize >}}
+## RawColor class
+
+Raw Color Class helpt bij het opslaan van kleuren met elk aantal kanalen, elke kleermodus en elke bitdiepte. Houd er rekening mee dat sommige interne klassen problemen kunnen hebben met het converteren van RawColor naar het eigen formaat, dus als de API een CMYK-kleur levert, is het betrouwbaarder om het geleverde formaat te gebruiken. Ook kunnen er gevallen zijn waarin Raw Color kan worden geconverteerd.
+
+```csharp
+public sealed class RawColor
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [RawColor](rawcolor/#constructor)(ColorComponent[]) | Initialiseert een nieuw exemplaar van de `RawColor` class. |
+| [RawColor](rawcolor/#constructor_1)(PixelDataFormat, short) | Initialiseert een nieuw exemplaar van de `RawColor` class vanuit pixel‑dataformaat met behulp van vooraf gedefinieerde kleermodi |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorMode](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/) { get; set; } | Modus voor de te volgen kleur. |
+| [Components](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/) { get; } | Haalt de componenten van de kleur op. Elke component is een afzonderlijk kanaal, en als u een niet‑populair kleurenschema gebruikt, is het beter om met elk kanaal afzonderlijk te werken. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Equals](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/)(object) | Bepaalt of het opgegeven Object gelijk is aan deze instantie. |
+| [GetAsInt](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/)() | Haalt de kleur op als int voor het geval het mogelijk is om deze te verkrijgen. |
+| [GetAsLong](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/)() | Haalt de kleur op als long voor het geval het mogelijk is om deze te verkrijgen. |
+| [GetBitDepth](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/)() | Haalt de bitdiepte op van Raw Color. Bijvoorbeeld voor een ARGB-kleur met 8 bits per kanaal/component is 32 Bit Depth; van een volledige ARGB-kleur met 16 bits per kanaal/component is 64. Bit Depth wordt opgeteld uit de som van de bitdieptes van de kanalen. Het is mogelijk als verschillende kanalen verschillende bitdieptes hebben. |
+| [GetColorModeName](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/)() | Haalt de naam van de kleermodus op. De naam van de kleermodus wordt opgebouwd uit de namen van kanalen/componenten. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/)() | Haal de hashcode op van het huidige object. |
+| [SetAsInt](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/)(int) | Stelt gegevens in voor alle kanalen vanuit een int-argument als dit mogelijk is. |
+| [SetAsLong](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/)(long) | Stelt gegevens in voor alle kanalen vanuit een int-argument als dit mogelijk is. |
+| [operator ==](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/) | Implementeert de operator ==. |
+| [operator !=](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/) | Implementeert de operator !=. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de RawColor-klasse in plaats van de verouderde Color-struct.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+var color = new RawColor(PixelDataFormat.Rgba32Bpp);
+var oldColor = Color.FromArgb(5, 1, 2, 3);
+
+var argbValue = oldColor.ToArgb();
+color.SetAsInt(argbValue);
+
+AssertAreEqual("ARGB", color.GetColorModeName());
+AssertAreEqual(32, color.GetBitDepth());
+AssertAreEqual("A Alpha", color.Components[0].FullName);
+AssertAreEqual(5, (int)color.Components[0].Value);
+AssertAreEqual("R Red", color.Components[1].FullName);
+AssertAreEqual(1, (int)color.Components[1].Value);
+AssertAreEqual("G Green", color.Components[2].FullName);
+AssertAreEqual(2, (int)color.Components[2].Value);
+AssertAreEqual("B Blue", color.Components[3].FullName);
+AssertAreEqual(3, (int)color.Components[3].Value);
+
+AssertAreEqual(argbValue, color.GetAsInt());
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/_index.md
@@ -1,0 +1,24 @@
+---
+title: "RawColor.ColorMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor property. Modus voor de te volgen kleur"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/colormode/
+---
+{{< psd/tize >}}
+## RawColor.ColorMode property
+
+Modus voor de te volgen kleur.
+
+```csharp
+public short ColorMode { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/_index.md
@@ -1,0 +1,29 @@
+---
+title: "RawColor.Components"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor property. Haalt de componenten van de kleur op. Elke component is een afzonderlijk kanaal en als je een niet-populair kleurenschema gebruikt, is het beter om met elk kanaal afzonderlijk te werken."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/components/
+---
+{{< psd/tize >}}
+## RawColor.Components property
+
+Haalt de componenten van de kleur op. Elke component is een afzonderlijk kanaal, en als u een niet‑populair kleurenschema gebruikt, is het beter om met elk kanaal afzonderlijk te werken.
+
+```csharp
+public ColorComponent[] Components { get; }
+```
+
+### Property Value
+
+De componenten van de kleur
+
+### Zie ook
+
+* class [ColorComponent](../../colorcomponent/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/_index.md
@@ -1,0 +1,32 @@
+---
+title: "RawColor.Equals"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor method. Bepaalt of het opgegeven Object gelijk is aan deze instantie"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/equals/
+---
+{{< psd/tize >}}
+## RawColor.Equals method
+
+Bepaalt of het opgegeven Object gelijk is aan deze instantie.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | Object | Het Object om te vergelijken met deze instantie. |
+
+### Retourwaarde
+
+`true` als het opgegeven Object gelijk is aan deze instantie; anders `false`.
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.GetAsInt"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Haalt de kleur op als int in het geval dat het mogelijk is"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getasint/
+---
+{{< psd/tize >}}
+## RawColor.GetAsInt method
+
+Haalt de kleur op als int voor het geval het mogelijk is om deze te verkrijgen.
+
+```csharp
+public int GetAsInt()
+```
+
+### Retourwaarde
+
+Kanaalgegevens opgeslagen in Int
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| ArgumentException | De bitsdiepte van Raw Color is {depth} en is meer dan 32, je kunt het niet lezen als Int |
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.GetAsLong"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Haalt de kleur op als long in het geval dat het mogelijk is"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getaslong/
+---
+{{< psd/tize >}}
+## RawColor.GetAsLong method
+
+Haalt de kleur op als long voor het geval het mogelijk is om deze te verkrijgen.
+
+```csharp
+public long GetAsLong()
+```
+
+### Retourwaarde
+
+Kanaalgegevens opgeslagen in Int
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| ArgumentException | De bitsdiepte van Raw Color is {depth} en is meer dan 32, je kunt het niet lezen als Int |
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetBitDepth"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor method. Haalt de bitdiepte op van Raw Color. Bijvoorbeeld, voor een ARGB-kleur met 8 bits per kanaal/component is de bitdiepte 32; de volledige ARGB-kleur met 16 bits per kanaal/component heeft een bitdiepte van 64. De bitdiepte wordt verkregen door de som van de bitdieptes van de kanalen. Het is mogelijk dat verschillende kanalen verschillende bitdieptes hebben."
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getbitdepth/
+---
+{{< psd/tize >}}
+## RawColor.GetBitDepth method
+
+Haalt de bitdiepte op van Raw Color. Bijvoorbeeld voor een ARGB-kleur met 8 bits per kanaal/component is 32 Bit Depth; van een volledige ARGB-kleur met 16 bits per kanaal/component is 64. Bit Depth wordt opgeteld uit de som van de bitdieptes van de kanalen. Het is mogelijk als verschillende kanalen verschillende bitdieptes hebben.
+
+```csharp
+public int GetBitDepth()
+```
+
+### Retourwaarde
+
+De som van alle bitdieptes van de kanalen
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetColorModeName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor method. Haalt de naam van de kleurmodus op. Kleurmodusnaam opgebouwd uit namen van kanalen/componenten"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/getcolormodename/
+---
+{{< psd/tize >}}
+## RawColor.GetColorModeName method
+
+Haalt de naam van de kleermodus op. De naam van de kleermodus wordt opgebouwd uit de namen van kanalen/componenten.
+
+```csharp
+public string GetColorModeName()
+```
+
+### Retourwaarde
+
+String met de naam van de kleurmodus
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "RawColor.GetHashCode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor method. Haalt de hashcode op van het huidige object"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/gethashcode/
+---
+{{< psd/tize >}}
+## RawColor.GetHashCode method
+
+Haal de hashcode op van het huidige object.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Retourwaarde
+
+De hashcode.
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/_index.md
@@ -1,0 +1,33 @@
+---
+title: "RawColor.op_Equality"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Implementeert de operator"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_equality/
+---
+{{< psd/tize >}}
+## RawColor Equality operator
+
+Implementeert de operator ==.
+
+```csharp
+public static bool operator ==(RawColor left, RawColor right)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| links | RawColor | De eerste RawColor. |
+| rechts | RawColor | De tweede RawColor. |
+
+### Retourwaarde
+
+Het resultaat van de operator.
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/_index.md
@@ -1,0 +1,33 @@
+---
+title: "RawColor.op_Inequality"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Implementeert de operator"
+type: docs
+weight: 130
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/op_inequality/
+---
+{{< psd/tize >}}
+## RawColor Inequality operator
+
+Implementeert de operator !=.
+
+```csharp
+public static bool operator !=(RawColor left, RawColor right)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| links | RawColor | De eerste RawColor. |
+| rechts | RawColor | De tweede RawColor. |
+
+### Retourwaarde
+
+Het resultaat van de operator.
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/_index.md
@@ -1,0 +1,57 @@
+---
+title: "RawColor.RawColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor constructor. Initialiseert een nieuw exemplaar van de RawColor-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/rawcolor/
+---
+{{< psd/tize >}}
+## RawColor(ColorComponent[]) {#constructor}
+
+Initialiseert een nieuw exemplaar van de [`RawColor`](../) klasse.
+
+```csharp
+public RawColor(ColorComponent[] components)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| componenten | ColorComponent[] | De aangepaste kleurcomponenten. |
+
+### Zie ook
+
+* class [ColorComponent](../../colorcomponent/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## RawColor(PixelDataFormat, short) {#constructor_1}
+
+Initialiseert een nieuw exemplaar van de [`RawColor`](../) klasse vanuit pixelgegevensformaat met behulp van vooraf gedefinieerde kleurmodi
+
+```csharp
+public RawColor(PixelDataFormat pixelDataFormat, short colorMode = 0)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixelDataFormat | PixelDataFormat | Het pixelgegevensformaat. |
+| colorMode | Int16 | Modus voor de te volgen kleur. |
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| ArgumentException | Aantal kanalen verschilt van PixelFormat, index van kanalen kan niet worden verkregen. Maak alstublieft een RawColor met Components' Array argument |
+
+### Zie ook
+
+* class [PixelDataFormat](../../../aspose.psd/pixeldataformat/)
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.SetAsInt"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Stelt gegevens in voor alle kanalen vanuit een int-argument indien mogelijk"
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setasint/
+---
+{{< psd/tize >}}
+## RawColor.SetAsInt method
+
+Stelt gegevens in voor alle kanalen vanuit een int-argument als dit mogelijk is.
+
+```csharp
+public void SetAsInt(int value)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | Int32 | De int-waarde die componentgegevens bevat |
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| ArgumentException | De bitsdiepte van Raw Color is {depth}. Je kunt het niet instellen als Int, stel alstublieft de gegevens van de afzonderlijke kanalen in |
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/_index.md
@@ -1,0 +1,34 @@
+---
+title: "RawColor.SetAsLong"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColor methode. Stelt gegevens in voor alle kanalen vanuit een int-argument indien mogelijk"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolor/setaslong/
+---
+{{< psd/tize >}}
+## RawColor.SetAsLong method
+
+Stelt gegevens in voor alle kanalen vanuit een int-argument als dit mogelijk is.
+
+```csharp
+public void SetAsLong(long value)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | Int64 | De int-waarde die componentgegevens bevat |
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| ArgumentException | De bitsdiepte van Raw Color is {depth}. Je kunt het niet instellen als Int, stel alstublieft de gegevens van de afzonderlijke kanalen in |
+
+### Zie ook
+
+* class [RawColor](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/_index.md
@@ -1,0 +1,39 @@
+---
+title: "Klasse RawColorHelper"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Core.RawColor.RawColorHelper klasse. Raw Color Helper Class helpt bij het sneller maken van RawColor met behulp van vooraf gedefinieerde kanaalmetadata."
+type: docs
+weight: 1660
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/
+---
+{{< psd/tize >}}
+## RawColorHelper class
+
+Raw Color Helper Class helpt bij het sneller maken van RawColor, met behulp van vooraf gedefinieerde kanaalmetadata
+
+```csharp
+public class RawColorHelper
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [RawColorHelper](rawcolorhelper/)() | De standaardconstructor. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| static [CreateArgb16BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/)(ushort, ushort, ushort, ushort) | Creëert een ARGB-kleur met 16 bits per kanaal. |
+| static [CreateArgb8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/#createargb8bitcolor)(Color) | Creëert een ARGB-kleur met 8 bits per kanaal vanuit Drawing.Color |
+| static [CreateArgb8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/#createargb8bitcolor_1)(byte, byte, byte, byte) | Creëert een ARGB-kleur met 8 bits per kanaal. |
+| static [CreateCmyk16BitBitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/)(ushort, ushort, ushort, ushort) | Creëert een CMYK-kleur met 16 bits per kanaal. |
+| static [CreateCmyk8BitColor](../../aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/)(byte, byte, byte, byte) | Maakt een 8-bit per kanaal CMYK-kleur. |
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateArgb16BitColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColorHelper methode. Maakt een 16-bit per kanaal ARGB-kleur."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb16bitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateArgb16BitColor method
+
+Creëert een ARGB-kleur met 16 bits per kanaal.
+
+```csharp
+public static RawColor CreateArgb16BitColor(ushort a, ushort r, ushort g, ushort b)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| a | UInt16 | De alfa componentwaarde (0-65535). |
+| r | UInt16 | De rode componentwaarde (0-65535). |
+| g | UInt16 | De groene componentwaarde (0-65535). |
+| b | UInt16 | De blauwe componentwaarde (0-65535). |
+
+### Retourwaarde
+
+Een nieuw [`RawColor`](../../rawcolor/) exemplaar dat de ARGB-kleur vertegenwoordigt.
+
+## Opmerkingen
+
+De kleurcomponenten worden verpakt in een 64-bit geheel getal in de volgorde: alfa (bits 48-63), rood (bits 32-47), groen (bits 16-31) en blauw (bits 0-15).
+
+### Zie ook
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/_index.md
@@ -1,0 +1,70 @@
+---
+title: "RawColorHelper.CreateArgb8BitColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColorHelper-methode. Maakt een 8‑bit per kanaal ARGB-kleur"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createargb8bitcolor/
+---
+{{< psd/tize >}}
+## CreateArgb8BitColor(byte, byte, byte, byte) {#createargb8bitcolor_1}
+
+Creëert een ARGB-kleur met 8 bits per kanaal.
+
+```csharp
+public static RawColor CreateArgb8BitColor(byte a, byte r, byte g, byte b)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| a | Byte | De alfacomponentwaarde (0-255). |
+| r | Byte | De rode componentwaarde (0-255). |
+| g | Byte | De groene componentwaarde (0-255). |
+| b | Byte | De blauwe componentwaarde (0-255). |
+
+### Retourwaarde
+
+Een nieuw [`RawColor`](../../rawcolor/) exemplaar dat de ARGB-kleur vertegenwoordigt.
+
+## Opmerkingen
+
+De kleurcomponenten worden verpakt in een 32‑bit integer in de volgorde: alfa (bits 24-31), rood (bits 16-23), groen (bits 8-15) en blauw (bits 0-7).
+
+### Zie ook
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## CreateArgb8BitColor(Color) {#createargb8bitcolor}
+
+Creëert een ARGB-kleur met 8 bits per kanaal vanuit Drawing.Color
+
+```csharp
+public static RawColor CreateArgb8BitColor(Color drawingColor)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| drawingColor | Color | De System.Drawing Color |
+
+### Retourwaarde
+
+Een nieuw [`RawColor`](../../rawcolor/) exemplaar dat de ARGB-kleur vertegenwoordigt.
+
+## Opmerkingen
+
+De kleurcomponenten worden verpakt in een 32‑bit integer in de volgorde: alfa (bits 24-31), rood (bits 16-23), groen (bits 8-15) en blauw (bits 0-7).
+
+### Zie ook
+
+* class [RawColor](../../rawcolor/)
+* struct [Color](../../../aspose.psd/color/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateCmyk16BitBitColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColorHelper-methode. Maakt een 16‑bit per kanaal CMYK-kleur"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk16bitbitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateCmyk16BitBitColor method
+
+Creëert een CMYK-kleur met 16 bits per kanaal.
+
+```csharp
+public static RawColor CreateCmyk16BitBitColor(ushort c, ushort m, ushort y, ushort k)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| c | UInt16 | De cyaancomponentwaarde (0-65535). |
+| m | UInt16 | De magentacomponentwaarde (0-65535). |
+| y | UInt16 | De geelcomponentwaarde (0-65535). |
+| k | UInt16 | De sleutel (zwart) componentwaarde (0-65535). |
+
+### Retourwaarde
+
+Een nieuw [`RawColor`](../../rawcolor/) exemplaar dat de CMYK-kleur vertegenwoordigt.
+
+## Opmerkingen
+
+De kleurcomponenten worden verpakt in een 64‑bit integer in de volgorde: cyaan (bits 48-63), magenta (bits 32-47), geel (bits 16-31) en sleutel/zwart (bits 0-15).
+
+### Zie ook
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/_index.md
@@ -1,0 +1,40 @@
+---
+title: "RawColorHelper.CreateCmyk8BitColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColorHelper methode. Maakt een 8-bit per kanaal CMYK-kleur."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/createcmyk8bitcolor/
+---
+{{< psd/tize >}}
+## RawColorHelper.CreateCmyk8BitColor method
+
+Maakt een 8-bit per kanaal CMYK-kleur.
+
+```csharp
+public static RawColor CreateCmyk8BitColor(byte c, byte m, byte y, byte k)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| c | Byte | De cyaancomponentwaarde (0-255). |
+| m | Byte | De magentacomponentwaarde (0-255). |
+| y | Byte | De geelcomponentwaarde (0-255). |
+| k | Byte | De sleutel (zwart) componentwaarde (0-255). |
+
+### Retourwaarde
+
+Een nieuw [`RawColor`](../../rawcolor/) exemplaar dat de CMYK-kleur vertegenwoordigt.
+
+## Opmerkingen
+
+De kleurcomponenten worden verpakt in een 32‑bit integer in de volgorde: cyaan (bits 24-31), magenta (bits 16-23), geel (bits 8-15) en sleutel/zwart (bits 0-7).
+
+### Zie ook
+
+* class [RawColor](../../rawcolor/)
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/_index.md
@@ -1,0 +1,24 @@
+---
+title: "RawColorHelper.RawColorHelper"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RawColorHelper constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.core.rawcolor/rawcolorhelper/rawcolorhelper/
+---
+{{< psd/tize >}}
+## RawColorHelper constructor
+
+De standaardconstructor.
+
+```csharp
+public RawColorHelper()
+```
+
+### Zie ook
+
+* class [RawColorHelper](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Core.RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/_index.md
@@ -1,0 +1,133 @@
+---
+title: "Klasse CmykCorrection"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.CmykCorrection klasse. Kleurcorrectie in selectieve kleur-aanpassingslaag"
+type: docs
+weight: 1750
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/
+---
+{{< psd/tize >}}
+## CmykCorrection class
+
+Kleurcorrectie in selectieve kleur-aanpassingslaag.
+
+```csharp
+public class CmykCorrection
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [CmykCorrection](cmykcorrection/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Black](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/) { get; set; } | Haalt of stelt zwarte kleurcorrectie in. |
+| [Cyan](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/) { get; set; } | Haalt of stelt cyaan kleurcorrectie in. |
+| [Magenta](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/) { get; set; } | Haalt of stelt magenta kleurcorrectie in. |
+| [Yellow](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/) { get; set; } | Haalt of stelt gele kleurcorrectie in. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Black"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykCorrection eigenschap. Haalt of stelt zwart kleurcorrectie in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/black/
+---
+{{< psd/tize >}}
+## CmykCorrection.Black property
+
+Haalt of stelt zwarte kleurcorrectie in.
+
+```csharp
+public short Black { get; set; }
+```
+
+### Zie ook
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.CmykCorrection"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykCorrection constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cmykcorrection/
+---
+{{< psd/tize >}}
+## CmykCorrection constructor
+
+De standaardconstructor.
+
+```csharp
+public CmykCorrection()
+```
+
+### Zie ook
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Cyan"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykCorrection eigenschap. Haalt of stelt cyan kleurcorrectie in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/cyan/
+---
+{{< psd/tize >}}
+## CmykCorrection.Cyan property
+
+Haalt of stelt cyaan kleurcorrectie in.
+
+```csharp
+public short Cyan { get; set; }
+```
+
+### Zie ook
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Magenta"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykCorrection eigenschap. Haalt de magenta kleurcorrectie op of stelt deze in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/magenta/
+---
+{{< psd/tize >}}
+## CmykCorrection.Magenta property
+
+Haalt of stelt magenta kleurcorrectie in.
+
+```csharp
+public short Magenta { get; set; }
+```
+
+### Zie ook
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/_index.md
@@ -1,0 +1,24 @@
+---
+title: "CmykCorrection.Yellow"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykCorrection eigenschap. Haalt de gele kleurcorrectie op of stelt deze in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/cmykcorrection/yellow/
+---
+{{< psd/tize >}}
+## CmykCorrection.Yellow property
+
+Haalt of stelt gele kleurcorrectie in.
+
+```csharp
+public short Yellow { get; set; }
+```
+
+### Zie ook
+
+* class [CmykCorrection](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/_index.md
@@ -1,0 +1,125 @@
+---
+title: "Enum CorrectionMethodTypes"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.CorrectionMethodTypes enum. Correctiemethode in selectieve kleur aanpassingslaag"
+type: docs
+weight: 1780
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/correctionmethodtypes/
+---
+{{< psd/tize >}}
+## CorrectionMethodTypes enumeration
+
+Correctiemethode in selectieve kleur aanpassingslaag.
+
+```csharp
+public enum CorrectionMethodTypes
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Relative | `0` | Pas kleuraanpassing toe in relatieve modus. |
+| Absolute | `1` | Pas kleuraanpassing toe in absolute modus. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/_index.md
@@ -1,0 +1,222 @@
+---
+title: "Klasse GradientMapLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.GradientMapLayer klasse. Gradient map-laag. Verwerkt het renderen van Gradient map met gegevens uit GrdmResource"
+type: docs
+weight: 1810
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/
+---
+{{< psd/tize >}}
+## GradientMapLayer class
+
+Gradient map-laag. Verwerkt het renderen van Gradient map met gegevens uit GrdmResource.
+
+```csharp
+public class GradientMapLayer : AdjustmentLayer
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de palette automatisch wordt aangepast. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Haalt of stelt een waarde in voor de achtergrondkleur. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Haalt het aantal bits per pixel van de afbeelding op. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Haalt of stelt de mengmodus van het bijgesneden element in. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Haalt de mengopties op. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Haalt de blend-modus handtekening op. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Haalt of stelt de positie van de onderste laag in. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Haalt de afbeeldinggrenzen op. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Haalt of stelt de kanaalinformatie in. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Haalt het aantal kanalen van de laag op. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Haalt of stelt de laagclip in. 0 = basis, 1 = niet-basis. |
+| [Container](../../aspose.psd/image/container/) { get; } | Haalt de [`Image`](../../aspose.psd/image/) container op. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Haalt de gegevensstroom van het object op. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Haalt of stelt de weergavenaam van de laag in. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Haalt een waarde op die aangeeft of deze instantie is vrijgegeven. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Haalt de lengte van extra laaginformatie op in bytes. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Haalt een bestandsformaatwaarde op. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Haalt of stelt de laagvuller in. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Haalt of stelt de vulopaciteit in. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Haalt of stelt de laagvlaggen in. bit 0 = transparantie beschermd; bit 1 = zichtbaar; bit 2 = verouderd; bit 3 = 1 voor Photoshop 5.0 en later, geeft aan of bit 4 nuttige informatie bevat; bit 4 = pixelgegevens irrelevant voor het uiterlijk van het document. |
+| [GradientSettings](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/) { get; set; } | Haalt op of stelt de Gradient-instellingeninstantie in die is doorgegeven vanuit de GrdmResource-instantie. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Haalt een waarde op die aangeeft of deze instantie een alfa-kanaal heeft. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de afbeelding een achtergrondkleur heeft. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Haalt een waarde op die aangeeft of de afbeelding een transparante kleur heeft. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Haalt de afbeeldinghoogte op. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Haalt of stelt de horizontale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) in. |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Haalt de opaciteit van deze afbeelding op. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Haalt of stelt de interruptmonitor in. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Haalt een waarde op die aangeeft of afbeeldingsgegevens momenteel in de cache staan. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Haalt een waarde op die aangeeft of het laden van ruwe gegevens beschikbaar is. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de laag zichtbaar is |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Haalt een waarde op die aangeeft of deze instantie zichtbaar is in de groep (Als de laag niet in een groep zit, betekent dit de hoofdgroep). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Haalt de gegevens van de laagmengbereiken op of stelt deze in. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Haalt de aanmaakdatum en -tijd van de laag op of stelt deze in. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Haalt de vergrendeling van de laag op of stelt deze in. Merk op dat als de vlag LayerFlags.TransparencyProtected is ingesteld, deze wordt overschreven door de vergrendelingsvlag van de laag. Om de vlag LayerFlags.TransparencyProtected terug te geven, moet de laagoptie layer.Flags &#x7C;= LayerFlags.TransparencyProtected worden toegepast |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Haalt de maskergegevens van de laag op of stelt deze in. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Haalt de laagopties op. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Haalt de positie van de linkse laag op of stelt deze in. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Haalt de totale laaglengte in bytes op. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Haalt de laagnaam op of stelt deze in. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Haalt de laagopaciteit op of stelt deze in. 0 = transparant, 255 = ondoorzichtig. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Haalt het kleurenpalet op of stelt dit in. Het kleurenpalet wordt niet gebruikt wanneer pixels direct worden weergegeven. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de afbeeldingscomponenten voorvermenigvuldigd moeten worden. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Haalt de aangepaste kleuromschakelaar op of stelt deze in. |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Haalt het ruwe gegevensformaat op. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Haalt de huidige ruwe gegevensinstellingen op. Merk op dat bij het gebruik van deze instellingen de gegevens zonder conversie worden geladen. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Haalt de fallback-index op of stelt deze in die moet worden gebruikt wanneer de paletindex buiten de grenzen valt |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Haalt de geïndexeerde kleuromschakelaar op of stelt deze in |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Haalt de ruwe regelgrootte in bytes op. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Haalt de laagbronnen op of stelt deze in. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Haalt de positie van de rechter laag op of stelt deze in. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Haalt de decoratieve bladkleurmarkering in de lagenlijst op of stelt deze in |
+| [Size](../../aspose.psd/image/size/) { get; } | Haalt de afbeeldingsgrootte op. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Haalt de positie van de bovenste laag op of stelt deze in. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Haalt de transparante kleur van de afbeelding op. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de XMP-metadata moet worden bijgewerkt. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of ruwe gegevens moeten worden geladen wanneer het laden van ruwe gegevens beschikbaar is. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Haalt de verticale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) op of stelt deze in. |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Haalt de breedte van de afbeelding op. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Haalt de XMP-metadata op of stelt deze in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Voegt het masker toe aan de huidige laag. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Past de helderheid van de afbeelding aan. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Afbeeldingscontrast |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Gamma-correctie van een afbeelding. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Gamma-correctie van een afbeelding. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Past het laagmasker toe op de laag en verwijdert vervolgens het masker. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarisatie van een afbeelding met een vooraf gedefinieerde drempel. |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarisatie van een afbeelding met Otsu-drempeling. |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Cachet de gegevens en zorgt ervoor dat er geen extra gegevens worden geladen vanuit de onderliggende [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/). |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Bepaalt of de afbeelding kan worden opgeslagen in het opgegeven bestandsformaat dat wordt vertegenwoordigd door de meegegeven opslagopties. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Bijsnijden van de afbeelding. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Afbeelding bijsnijden met verschuivingen. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Disposeert de huidige instantie. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Voert dithering uit op de huidige afbeelding. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Voert dithering uit op de huidige afbeelding. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Tekent de afbeelding op de laag. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtert de opgegeven rechthoek. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Haalt een 32-bit ARGB-pixel van de afbeelding op. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Haalt de standaard 32-bit ARGB-pixelarray op. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Haalt de standaardopties op. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Haalt de standaardpixelarray op met behulp van de gedeeltelijke pixelloader. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Haalt de standaard ruwe gegevensarray op. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Haalt de standaard ruwe gegevensarray op met behulp van de gedeeltelijke pixelloader. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Retourneert een hashcode voor deze instantie. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Haalt de datum en tijd op waarop de bronafbeelding voor het laatst is gewijzigd. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Haalt de opties op op basis van de oorspronkelijke bestandsinstellingen. Dit kan handig zijn om de bitsdiepte en andere parameters van de oorspronkelijke afbeelding ongewijzigd te houden. Bijvoorbeeld, als we een zwart-wit PNG-afbeelding met 1 bit per pixel laden en deze vervolgens opslaan met de [`Save`](../../aspose.psd/datastreamsupporter/save/) methode, wordt een PNG-afbeelding met 8-bit per pixel gegenereerd. Om dit te voorkomen en een PNG-afbeelding met 1-bit per pixel op te slaan, gebruik deze methode om de bijbehorende opslagopties te verkrijgen en geef ze door aan de [`Save`](../../aspose.psd/image/save/) methode als tweede parameter. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Haalt een afbeeldingspixel op. Prestatiewaarschuwing: Vermijd het gebruik van deze methode om over alle afbeeldingspixels te itereren, omdat dit kan leiden tot aanzienlijke prestatieproblemen. Voor efficiëntere pixelmanipulatie, gebruik de `LoadArgb32Pixels` methode om de volledige pixelarray in één keer op te halen. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Haalt de scheefstandhoek op. Deze methode is toepasbaar op gescande tekstdocumenten om de scheefstandhoek bij het scannen te bepalen. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Transformatie van een afbeelding naar zijn grijswaardenrepresentatie |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Laadt 32-bit ARGB-pixels. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Laadt 64-bit ARGB-pixels. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Laadt pixels in CMYK-formaat. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Laadt pixels in CMYK-formaat. Deze methode is verouderd. Gebruik alstublieft de effectievere [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/) methode. |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Laadt 32-bit ARGB-pixels gedeeltelijk per pakketten. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Laadt pixels gedeeltelijk per pakketten. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Laadt pixels. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Voegt de laag samen met de opgegeven laag |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Wijzigt de grootte van de afbeelding. De standaard NearestNeighbourResample wordt gebruikt. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Wijzigt de grootte van de afbeelding. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Wijzigt de grootte van de afbeelding. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Wijzigt de hoogte proportioneel. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Wijzigt de breedte proportioneel. De standaard NearestNeighbourResample wordt gebruikt. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Wijzigt de breedte proportioneel. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Wijzigt de breedte proportioneel. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Roteer de afbeelding rond het centrum. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Roteer de afbeelding rond het centrum. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Roteert, spiegelt of roteert en spiegelt de afbeelding. |
+| [Save](../../aspose.psd/image/save/)() | Slaat de afbeeldingsgegevens op in de onderliggende stream. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Slaat de gegevens van het object op in de opgegeven stream. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Slaat de 32-bit ARGB-pixels op. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Slaat de pixels op. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Slaat de pixels op. Deze methode is verouderd. Gebruik alstublieft de meer effectieve [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/) methode. |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Slaat de pixels op. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Slaat de ruwe gegevens op. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Stelt een 32-bit ARGB-pixel van de afbeelding in voor de opgegeven positie. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Stelt het kleurenpalet van de afbeelding in. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Stelt een afbeeldingspixel in voor de opgegeven positie. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Stelt de resolutie in voor deze [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Maakt een ondiepe kopie van de huidige laag. Zie [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) voor uitleg. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converteert rasterafbeelding naar de bitmap. |
+| [Update](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/)() | Werk laaggegevens bij in gerelateerde laagresource [`GrdmResource`](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/). |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Gradient map-laag.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Voeg Gradient map-aanpassingslaag toe.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/_index.md
@@ -1,0 +1,67 @@
+---
+title: "GradientMapLayer.GradientSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapLayer-eigenschap. Haalt of stelt Gradient-instellingen instantie doorgegeven vanuit GrdmResource-instantie"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/gradientsettings/
+---
+{{< psd/tize >}}
+## GradientMapLayer.GradientSettings property
+
+Haalt op of stelt de Gradient-instellingeninstantie in die is doorgegeven vanuit de GrdmResource-instantie.
+
+```csharp
+public GradientMapSettings GradientSettings { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Gradient map-laag.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Voeg Gradient map-aanpassingslaag toe.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GradientMapSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/)
+* class [GradientMapLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientMapLayer.Update"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapLayer-methode. Werk laaggegevens bij in gerelateerde laagresource GrdmResource"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/update/
+---
+{{< psd/tize >}}
+## GradientMapLayer.Update method
+
+Werk laaggegevens bij in gerelateerde laagresource [`GrdmResource`](../../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/).
+
+```csharp
+public void Update()
+```
+
+### Zie ook
+
+* class [GradientMapLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/_index.md
@@ -1,0 +1,277 @@
+---
+title: "Klasse SelectiveColorLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.SelectiveColorLayer klasse. Selectieve Kleur Aanpassingslaag"
+type: docs
+weight: 1900
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer class
+
+Selectieve Kleur Aanpassingslaag.
+
+```csharp
+public class SelectiveColorLayer : AdjustmentLayer
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de palette automatisch wordt aangepast. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Haalt of stelt een waarde in voor de achtergrondkleur. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Haalt het aantal bits per pixel van de afbeelding op. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Haalt of stelt de mengmodus van het bijgesneden element in. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Haalt de mengopties op. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Haalt de blend-modus handtekening op. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Haalt of stelt de positie van de onderste laag in. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Haalt de afbeeldinggrenzen op. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Haalt of stelt de kanaalinformatie in. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Haalt het aantal kanalen van de laag op. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Haalt of stelt de laagclip in. 0 = basis, 1 = niet-basis. |
+| [Container](../../aspose.psd/image/container/) { get; } | Haalt de [`Image`](../../aspose.psd/image/) container op. |
+| [CorrectionMethod](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/) { get; set; } | Haalt op of stelt de correctiemethode in. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Haalt de gegevensstroom van het object op. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Haalt of stelt de weergavenaam van de laag in. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Haalt een waarde op die aangeeft of deze instantie is vrijgegeven. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Haalt de lengte van extra laaginformatie op in bytes. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Haalt een bestandsformaatwaarde op. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Haalt of stelt de laagvuller in. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Haalt of stelt de vulopaciteit in. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Haalt of stelt de laagvlaggen in. bit 0 = transparantie beschermd; bit 1 = zichtbaar; bit 2 = verouderd; bit 3 = 1 voor Photoshop 5.0 en later, geeft aan of bit 4 nuttige informatie bevat; bit 4 = pixelgegevens irrelevant voor het uiterlijk van het document. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Haalt een waarde op die aangeeft of deze instantie een alfa-kanaal heeft. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de afbeelding een achtergrondkleur heeft. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Haalt een waarde op die aangeeft of de afbeelding een transparante kleur heeft. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Haalt de afbeeldinghoogte op. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Haalt of stelt de horizontale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) in. |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Haalt de opaciteit van deze afbeelding op. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Haalt of stelt de interruptmonitor in. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Haalt een waarde op die aangeeft of afbeeldingsgegevens momenteel in de cache staan. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Haalt een waarde op die aangeeft of het laden van ruwe gegevens beschikbaar is. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de laag zichtbaar is |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Haalt een waarde op die aangeeft of deze instantie zichtbaar is in de groep (Als de laag niet in een groep zit, betekent dit de hoofdgroep). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Haalt de gegevens van de laagmengbereiken op of stelt deze in. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Haalt de aanmaakdatum en -tijd van de laag op of stelt deze in. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Haalt de vergrendeling van de laag op of stelt deze in. Merk op dat als de vlag LayerFlags.TransparencyProtected is ingesteld, deze wordt overschreven door de vergrendelingsvlag van de laag. Om de vlag LayerFlags.TransparencyProtected terug te geven, moet de laagoptie layer.Flags &#x7C;= LayerFlags.TransparencyProtected worden toegepast |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Haalt de maskergegevens van de laag op of stelt deze in. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Haalt de laagopties op. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Haalt de positie van de linkse laag op of stelt deze in. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Haalt de totale laaglengte in bytes op. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Haalt de laagnaam op of stelt deze in. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Haalt de laagopaciteit op of stelt deze in. 0 = transparant, 255 = ondoorzichtig. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Haalt het kleurenpalet op of stelt dit in. Het kleurenpalet wordt niet gebruikt wanneer pixels direct worden weergegeven. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de afbeeldingscomponenten voorvermenigvuldigd moeten worden. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Haalt de aangepaste kleuromschakelaar op of stelt deze in. |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Haalt het ruwe gegevensformaat op. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Haalt de huidige ruwe gegevensinstellingen op. Merk op dat bij het gebruik van deze instellingen de gegevens zonder conversie worden geladen. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Haalt de fallback-index op of stelt deze in die moet worden gebruikt wanneer de paletindex buiten de grenzen valt |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Haalt de geïndexeerde kleuromschakelaar op of stelt deze in |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Haalt de ruwe regelgrootte in bytes op. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Haalt de laagbronnen op of stelt deze in. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Haalt de positie van de rechter laag op of stelt deze in. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Haalt de decoratieve bladkleurmarkering in de lagenlijst op of stelt deze in |
+| [Size](../../aspose.psd/image/size/) { get; } | Haalt de afbeeldingsgrootte op. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Haalt de positie van de bovenste laag op of stelt deze in. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Haalt de transparante kleur van de afbeelding op. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de XMP-metadata moet worden bijgewerkt. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of ruwe gegevens moeten worden geladen wanneer het laden van ruwe gegevens beschikbaar is. |
+| [Version](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/) { get; } | Haalt de versie op. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Haalt de verticale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) op of stelt deze in. |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Haalt de breedte van de afbeelding op. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Haalt de XMP-metadata op of stelt deze in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Voegt het masker toe aan de huidige laag. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Past de helderheid van de afbeelding aan. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Afbeeldingscontrast |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Gamma-correctie van een afbeelding. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Gamma-correctie van een afbeelding. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Past het laagmasker toe op de laag en verwijdert vervolgens het masker. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarisatie van een afbeelding met een vooraf gedefinieerde drempel. |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarisatie van een afbeelding met Otsu-drempeling. |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Cachet de gegevens en zorgt ervoor dat er geen extra gegevens worden geladen vanuit de onderliggende [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/). |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Bepaalt of de afbeelding kan worden opgeslagen in het opgegeven bestandsformaat dat wordt vertegenwoordigd door de meegegeven opslagopties. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Bijsnijden van de afbeelding. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Afbeelding bijsnijden met verschuivingen. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Disposeert de huidige instantie. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Voert dithering uit op de huidige afbeelding. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Voert dithering uit op de huidige afbeelding. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Tekent de afbeelding op de laag. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtert de opgegeven rechthoek. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Haalt een 32-bit ARGB-pixel van de afbeelding op. |
+| [GetCmykCorrection](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/)(SelectiveColorsTypes) | Haalt de cmyk-correctie op via selectieve kleur. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Haalt de standaard 32-bit ARGB-pixelarray op. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Haalt de standaardopties op. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Haalt de standaardpixelarray op met behulp van de gedeeltelijke pixelloader. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Haalt de standaard ruwe gegevensarray op. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Haalt de standaard ruwe gegevensarray op met behulp van de gedeeltelijke pixelloader. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Retourneert een hashcode voor deze instantie. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Haalt de datum en tijd op waarop de bronafbeelding voor het laatst is gewijzigd. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Haalt de opties op op basis van de oorspronkelijke bestandsinstellingen. Dit kan handig zijn om de bitsdiepte en andere parameters van de oorspronkelijke afbeelding ongewijzigd te houden. Bijvoorbeeld, als we een zwart-wit PNG-afbeelding met 1 bit per pixel laden en deze vervolgens opslaan met de [`Save`](../../aspose.psd/datastreamsupporter/save/) methode, wordt een PNG-afbeelding met 8-bit per pixel gegenereerd. Om dit te voorkomen en een PNG-afbeelding met 1-bit per pixel op te slaan, gebruik deze methode om de bijbehorende opslagopties te verkrijgen en geef ze door aan de [`Save`](../../aspose.psd/image/save/) methode als tweede parameter. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Haalt een afbeeldingspixel op. Prestatiewaarschuwing: Vermijd het gebruik van deze methode om over alle afbeeldingspixels te itereren, omdat dit kan leiden tot aanzienlijke prestatieproblemen. Voor efficiëntere pixelmanipulatie, gebruik de `LoadArgb32Pixels` methode om de volledige pixelarray in één keer op te halen. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Haalt de scheefstandhoek op. Deze methode is toepasbaar op gescande tekstdocumenten om de scheefstandhoek bij het scannen te bepalen. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Transformatie van een afbeelding naar zijn grijswaardenrepresentatie |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Laadt 32-bit ARGB-pixels. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Laadt 64-bit ARGB-pixels. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Laadt pixels in CMYK-formaat. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Laadt pixels in CMYK-formaat. Deze methode is verouderd. Gebruik alstublieft de effectievere [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/) methode. |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Laadt 32-bit ARGB-pixels gedeeltelijk per pakketten. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Laadt pixels gedeeltelijk per pakketten. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Laadt pixels. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Voegt de laag samen met de opgegeven laag |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Wijzigt de grootte van de afbeelding. De standaard NearestNeighbourResample wordt gebruikt. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Wijzigt de grootte van de afbeelding. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Wijzigt de grootte van de afbeelding. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Wijzigt de hoogte proportioneel. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Wijzigt de breedte proportioneel. De standaard NearestNeighbourResample wordt gebruikt. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Wijzigt de breedte proportioneel. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Wijzigt de breedte proportioneel. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Roteer de afbeelding rond het centrum. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Roteer de afbeelding rond het centrum. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Roteert, spiegelt of roteert en spiegelt de afbeelding. |
+| [Save](../../aspose.psd/image/save/)() | Slaat de afbeeldingsgegevens op in de onderliggende stream. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Slaat de gegevens van het object op in de opgegeven stream. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Slaat de 32-bit ARGB-pixels op. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Slaat de pixels op. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Slaat de pixels op. Deze methode is verouderd. Gebruik alstublieft de meer effectieve [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/) methode. |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Slaat de pixels op. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Slaat de ruwe gegevens op. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Stelt een 32-bit ARGB-pixel van de afbeelding in voor de opgegeven positie. |
+| [SetCmykCorrection](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/)(SelectiveColorsTypes, CmykCorrection) | Stelt de cmyk-correctie in via selectieve kleur. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Stelt het kleurenpalet van de afbeelding in. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Stelt een afbeeldingspixel in voor de opgegeven positie. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Stelt de resolutie in voor deze [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Maakt een ondiepe kopie van de huidige laag. Zie [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) voor uitleg. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converteert rasterafbeelding naar de bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/_index.md
@@ -1,0 +1,124 @@
+---
+title: "SelectiveColorLayer.CorrectionMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SelectiveColorLayer eigenschap. Haalt of stelt de correctiemethode in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/correctionmethod/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.CorrectionMethod property
+
+Haalt op of stelt de correctiemethode in.
+
+```csharp
+public CorrectionMethodTypes CorrectionMethod { get; set; }
+```
+
+### Property Value
+
+De correctiemethode.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* enum [CorrectionMethodTypes](../../correctionmethodtypes/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/_index.md
@@ -1,0 +1,129 @@
+---
+title: "SelectiveColorLayer.GetCmykCorrection"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SelectiveColorLayer methode. Haalt de cmyk-correctie op basis van selectieve kleur"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/getcmykcorrection/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.GetCmykCorrection method
+
+Haalt de cmyk-correctie op via selectieve kleur.
+
+```csharp
+public CmykCorrection GetCmykCorrection(SelectiveColorsTypes selectiveColorsType)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| selectiveColorsType | SelectiveColorsTypes | Selectieve kleuren. |
+
+### Retourwaarde
+
+Cmyk-correctie.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [CmykCorrection](../../cmykcorrection/)
+* enum [SelectiveColorsTypes](../../selectivecolorstypes/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/_index.md
@@ -1,0 +1,126 @@
+---
+title: "SelectiveColorLayer.SetCmykCorrection"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SelectiveColorLayer methode. Stelt de cmyk-correctie in op basis van selectieve kleur"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/setcmykcorrection/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.SetCmykCorrection method
+
+Stelt de cmyk-correctie in via selectieve kleur.
+
+```csharp
+public void SetCmykCorrection(SelectiveColorsTypes selectiveColorsType, CmykCorrection correction)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| selectiveColorsType | SelectiveColorsTypes | Type van de selectieve kleuren. |
+| correctie | CmykCorrection | Cmyk-correctie. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* enum [SelectiveColorsTypes](../../selectivecolorstypes/)
+* class [CmykCorrection](../../cmykcorrection/)
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SelectiveColorLayer.Version"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SelectiveColorLayer eigenschap. Haalt de versie op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/version/
+---
+{{< psd/tize >}}
+## SelectiveColorLayer.Version property
+
+Haalt de versie op.
+
+```csharp
+public short Version { get; }
+```
+
+### Property Value
+
+De versie.
+
+### Zie ook
+
+* class [SelectiveColorLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/_index.md
@@ -1,0 +1,132 @@
+---
+title: "Enum SelectiveColorsTypes"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.SelectiveColorsTypes enum. Kleurtypes in selectieve kleur-aanpassingslaag"
+type: docs
+weight: 1910
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorstypes/
+---
+{{< psd/tize >}}
+## SelectiveColorsTypes enumeration
+
+Kleurtypes in selectieve kleur-aanpassingslaag.
+
+```csharp
+public enum SelectiveColorsTypes
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Reds | `0` | De rode kleuren. |
+| Yellows | `1` | De gele kleuren. |
+| Greens | `2` | De groene kleuren. |
+| Cyans | `3` | De cyaankleuren. |
+| Blues | `4` | De blauwe kleuren. |
+| Magentas | `5` | De magentakleuren. |
+| Whites | `6` | De witte kleuren. |
+| Neutrals | `7` | De neutrale kleuren. |
+| Blacks | `8` | De zwarte kleuren. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/_index.md
@@ -1,0 +1,239 @@
+---
+title: "Klasse ThresholdLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers.ThresholdLayer klasse. Drempel Aanpassingslaag"
+type: docs
+weight: 1920
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/
+---
+{{< psd/tize >}}
+## ThresholdLayer class
+
+Drempel Aanpassingslaag.
+
+```csharp
+public class ThresholdLayer : AdjustmentLayer
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de palette automatisch wordt aangepast. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Haalt of stelt een waarde in voor de achtergrondkleur. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Haalt het aantal bits per pixel van de afbeelding op. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Haalt of stelt de mengmodus van het bijgesneden element in. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Haalt de mengopties op. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Haalt de blend-modus handtekening op. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Haalt of stelt de positie van de onderste laag in. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Haalt de afbeeldinggrenzen op. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Haalt of stelt de kanaalinformatie in. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Haalt het aantal kanalen van de laag op. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Haalt of stelt de laagclip in. 0 = basis, 1 = niet-basis. |
+| [Container](../../aspose.psd/image/container/) { get; } | Haalt de [`Image`](../../aspose.psd/image/) container op. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Haalt de gegevensstroom van het object op. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Haalt of stelt de weergavenaam van de laag in. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Haalt een waarde op die aangeeft of deze instantie is vrijgegeven. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Haalt de lengte van extra laaginformatie op in bytes. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Haalt een bestandsformaatwaarde op. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Haalt of stelt de laagvuller in. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Haalt of stelt de vulopaciteit in. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Haalt of stelt de laagvlaggen in. bit 0 = transparantie beschermd; bit 1 = zichtbaar; bit 2 = verouderd; bit 3 = 1 voor Photoshop 5.0 en later, geeft aan of bit 4 nuttige informatie bevat; bit 4 = pixelgegevens irrelevant voor het uiterlijk van het document. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Haalt een waarde op die aangeeft of deze instantie een alfa-kanaal heeft. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de afbeelding een achtergrondkleur heeft. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Haalt een waarde op die aangeeft of de afbeelding een transparante kleur heeft. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Haalt de afbeeldinghoogte op. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Haalt of stelt de horizontale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) in. |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Haalt de opaciteit van deze afbeelding op. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Haalt of stelt de interruptmonitor in. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Haalt een waarde op die aangeeft of afbeeldingsgegevens momenteel in de cache staan. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Haalt een waarde op die aangeeft of het laden van ruwe gegevens beschikbaar is. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de laag zichtbaar is |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Haalt een waarde op die aangeeft of deze instantie zichtbaar is in de groep (Als de laag niet in een groep zit, betekent dit de hoofdgroep). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Haalt de gegevens van de laagmengbereiken op of stelt deze in. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Haalt de aanmaakdatum en -tijd van de laag op of stelt deze in. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Haalt de vergrendeling van de laag op of stelt deze in. Merk op dat als de vlag LayerFlags.TransparencyProtected is ingesteld, deze wordt overschreven door de vergrendelingsvlag van de laag. Om de vlag LayerFlags.TransparencyProtected terug te geven, moet de laagoptie layer.Flags &#x7C;= LayerFlags.TransparencyProtected worden toegepast |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Haalt de maskergegevens van de laag op of stelt deze in. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Haalt de laagopties op. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Haalt de positie van de linkse laag op of stelt deze in. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Haalt de totale laaglengte in bytes op. |
+| [Level](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/) { get; set; } | Haalt op en stelt het drempelniveau in. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Haalt de laagnaam op of stelt deze in. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Haalt de laagopaciteit op of stelt deze in. 0 = transparant, 255 = ondoorzichtig. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Haalt het kleurenpalet op of stelt dit in. Het kleurenpalet wordt niet gebruikt wanneer pixels direct worden weergegeven. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de afbeeldingscomponenten voorvermenigvuldigd moeten worden. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Haalt de aangepaste kleuromschakelaar op of stelt deze in. |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Haalt het ruwe gegevensformaat op. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Haalt de huidige ruwe gegevensinstellingen op. Merk op dat bij het gebruik van deze instellingen de gegevens zonder conversie worden geladen. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Haalt de fallback-index op of stelt deze in die moet worden gebruikt wanneer de paletindex buiten de grenzen valt |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Haalt de geïndexeerde kleuromschakelaar op of stelt deze in |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Haalt de ruwe regelgrootte in bytes op. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Haalt de laagbronnen op of stelt deze in. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Haalt de positie van de rechter laag op of stelt deze in. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Haalt de decoratieve bladkleurmarkering in de lagenlijst op of stelt deze in |
+| [Size](../../aspose.psd/image/size/) { get; } | Haalt de afbeeldingsgrootte op. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Haalt de positie van de bovenste laag op of stelt deze in. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Haalt de transparante kleur van de afbeelding op. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de XMP-metadata moet worden bijgewerkt. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of ruwe gegevens moeten worden geladen wanneer het laden van ruwe gegevens beschikbaar is. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Haalt de verticale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) op of stelt deze in. |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Haalt de breedte van de afbeelding op. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Haalt de XMP-metadata op of stelt deze in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Voegt het masker toe aan de huidige laag. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Past de helderheid van de afbeelding aan. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Afbeeldingscontrast |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Gamma-correctie van een afbeelding. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Gamma-correctie van een afbeelding. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Past het laagmasker toe op de laag en verwijdert vervolgens het masker. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarisatie van een afbeelding met een vooraf gedefinieerde drempel. |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarisatie van een afbeelding met Otsu-drempeling. |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Cachet de gegevens en zorgt ervoor dat er geen extra gegevens worden geladen vanuit de onderliggende [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/). |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Bepaalt of de afbeelding kan worden opgeslagen in het opgegeven bestandsformaat dat wordt vertegenwoordigd door de meegegeven opslagopties. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Bijsnijden van de afbeelding. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Afbeelding bijsnijden met verschuivingen. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Disposeert de huidige instantie. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Voert dithering uit op de huidige afbeelding. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Voert dithering uit op de huidige afbeelding. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Tekent de afbeelding op de laag. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtert de opgegeven rechthoek. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Haalt een 32-bit ARGB-pixel van de afbeelding op. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Haalt de standaard 32-bit ARGB-pixelarray op. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Haalt de standaardopties op. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Haalt de standaardpixelarray op met behulp van de gedeeltelijke pixelloader. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Haalt de standaard ruwe gegevensarray op. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Haalt de standaard ruwe gegevensarray op met behulp van de gedeeltelijke pixelloader. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Retourneert een hashcode voor deze instantie. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Haalt de datum en tijd op waarop de bronafbeelding voor het laatst is gewijzigd. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Haalt de opties op op basis van de oorspronkelijke bestandsinstellingen. Dit kan handig zijn om de bitsdiepte en andere parameters van de oorspronkelijke afbeelding ongewijzigd te houden. Bijvoorbeeld, als we een zwart-wit PNG-afbeelding met 1 bit per pixel laden en deze vervolgens opslaan met de [`Save`](../../aspose.psd/datastreamsupporter/save/) methode, wordt een PNG-afbeelding met 8-bit per pixel gegenereerd. Om dit te voorkomen en een PNG-afbeelding met 1-bit per pixel op te slaan, gebruik deze methode om de bijbehorende opslagopties te verkrijgen en geef ze door aan de [`Save`](../../aspose.psd/image/save/) methode als tweede parameter. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Haalt een afbeeldingspixel op. Prestatiewaarschuwing: Vermijd het gebruik van deze methode om over alle afbeeldingspixels te itereren, omdat dit kan leiden tot aanzienlijke prestatieproblemen. Voor efficiëntere pixelmanipulatie, gebruik de `LoadArgb32Pixels` methode om de volledige pixelarray in één keer op te halen. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Haalt de scheefstandhoek op. Deze methode is toepasbaar op gescande tekstdocumenten om de scheefstandhoek bij het scannen te bepalen. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Transformatie van een afbeelding naar zijn grijswaardenrepresentatie |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Laadt 32-bit ARGB-pixels. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Laadt 64-bit ARGB-pixels. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Laadt pixels in CMYK-formaat. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Laadt pixels in CMYK-formaat. Deze methode is verouderd. Gebruik alstublieft de effectievere [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/) methode. |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Laadt 32-bit ARGB-pixels gedeeltelijk per pakketten. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Laadt pixels gedeeltelijk per pakketten. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Laadt pixels. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| override [MergeLayerTo](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/adjustmentlayer/mergelayerto/)(Layer) | Voegt de laag samen met de opgegeven laag |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Wijzigt de grootte van de afbeelding. De standaard NearestNeighbourResample wordt gebruikt. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Wijzigt de grootte van de afbeelding. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Wijzigt de grootte van de afbeelding. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Wijzigt de hoogte proportioneel. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Wijzigt de breedte proportioneel. De standaard NearestNeighbourResample wordt gebruikt. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Wijzigt de breedte proportioneel. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Wijzigt de breedte proportioneel. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Roteer de afbeelding rond het centrum. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Roteer de afbeelding rond het centrum. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Roteert, spiegelt of roteert en spiegelt de afbeelding. |
+| [Save](../../aspose.psd/image/save/)() | Slaat de afbeeldingsgegevens op in de onderliggende stream. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Slaat de gegevens van het object op in de opgegeven stream. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Slaat de 32-bit ARGB-pixels op. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Slaat de pixels op. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Slaat de pixels op. Deze methode is verouderd. Gebruik alstublieft de meer effectieve [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/) methode. |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Slaat de pixels op. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Slaat de ruwe gegevens op. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Stelt een 32-bit ARGB-pixel van de afbeelding in voor de opgegeven positie. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Stelt het kleurenpalet van de afbeelding in. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Stelt een afbeeldingspixel in voor de opgegeven positie. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Stelt de resolutie in voor deze [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Maakt een ondiepe kopie van de huidige laag. Zie [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) voor uitleg. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converteert rasterafbeelding naar de bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de ThresholdLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Threshold-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Haal Threshold-aanpassingslaag op.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Controleer laagparameters.
+            AssertAreEqual(level, (short)115);
+
+            // Stel laagparameters in.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Threshold-aanpassingslaag toe en stel deze in op de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Voeg Threshold-aanpassingslaag toe.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Stel laagparameters in.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [AdjustmentLayer](../adjustmentlayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/_index.md
@@ -1,0 +1,88 @@
+---
+title: "ThresholdLayer.Level"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ThresholdLayer eigenschap. Haalt en stelt het drempelniveau in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/level/
+---
+{{< psd/tize >}}
+## ThresholdLayer.Level property
+
+Haalt op en stelt het drempelniveau in.
+
+```csharp
+public short Level { get; set; }
+```
+
+### Property Value
+
+Het niveau.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de ThresholdLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Threshold-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Haal Threshold-aanpassingslaag op.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Controleer laagparameters.
+            AssertAreEqual(level, (short)115);
+
+            // Stel laagparameters in.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Threshold-aanpassingslaag toe en stel deze in op de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Voeg Threshold-aanpassingslaag toe.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Stel laagparameters in.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [ThresholdLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.AdjustmentLayers](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/_index.md
@@ -1,0 +1,49 @@
+---
+title: "Timeline.ActiveFrameIndex"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Timeline-eigenschap. Haalt de actieve frame-index op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.animation/timeline/activeframeindex/
+---
+{{< psd/tize >}}
+## Timeline.ActiveFrameIndex property
+
+Haalt de actieve frame-index op.
+
+```csharp
+public int ActiveFrameIndex { get; }
+```
+
+## Voorbeelden
+
+De volgende code toont een nieuwe benadering om met de Timeline te werken.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Voeg nog een frame toe
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Zie ook
+
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/_index.md
@@ -1,0 +1,84 @@
+---
+title: "Timeline.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Timeline-methode. Slaat de PsdImages en Timeline-gegevens op naar de opgegeven bestandslocatie in het opgegeven formaat volgens de opslagopties"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.animation/timeline/save/
+---
+{{< psd/tize >}}
+## Save(string, ImageOptionsBase) {#save_1}
+
+Slaat de PsdImage's en Timeline-gegevens op naar de opgegeven bestandslocatie in het opgegeven formaat volgens de opslagopties.
+
+```csharp
+public void Save(string filePath, ImageOptionsBase options)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| filePath | String | Het bestandspad. |
+| options | ImageOptionsBase | De opties. |
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning voor het exporteren van Timeline naar een GIF-afbeelding.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputGif = "out_4_animated.psd.gif";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Timeline.Save(outputGif, new GifOptions());
+}
+```
+
+### Zie ook
+
+* class [ImageOptionsBase](../../../aspose.psd/imageoptionsbase/)
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## Save(Stream, ImageOptionsBase) {#save}
+
+Slaat de PsdImage's en Timeline-gegevens op naar de opgegeven stream in het opgegeven formaat volgens de opslagopties.
+
+```csharp
+public void Save(Stream outputStream, ImageOptionsBase options)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| outputStream | Stroom | De uitvoerstream. |
+| options | ImageOptionsBase | De opties. |
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning voor het exporteren van Timeline naar een GIF-afbeelding.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputGif = "out_4_animated.psd.gif";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Timeline.Save(outputGif, new GifOptions());
+}
+```
+
+### Zie ook
+
+* class [ImageOptionsBase](../../../aspose.psd/imageoptionsbase/)
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/_index.md
@@ -1,0 +1,59 @@
+---
+title: "Timeline.SwitchActiveFrame"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Timeline-methode. Schakelt het actieve frame naar het doel"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.animation/timeline/switchactiveframe/
+---
+{{< psd/tize >}}
+## Timeline.SwitchActiveFrame method
+
+Schakelt het actieve frame naar het doel.
+
+```csharp
+public void SwitchActiveFrame(int targetActiveFrameIndex)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| targetActiveFrameIndex | Int32 | De index van het doelframe. |
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| IndexOutOfRangeException | De nieuwe index van het actieve frame moet binnen het bereik van het aantal frames liggen. |
+
+## Voorbeelden
+
+De volgende code toont een nieuwe benadering om met de Timeline te werken.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Voeg nog een frame toe
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Zie ook
+
+* class [Timeline](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Animation](../../../aspose.psd.fileformats.psd.layers.animation/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Klasse BaseGradientFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.BaseGradientFillSettings class. Basisklasse voor gradientdefinitie. Het bevat gemeenschappelijke eigenschappen voor beide typen gradient Solid en Noise"
+type: docs
+weight: 2030
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings class
+
+Basisgradientdefinitieklasse. Het bevat gemeenschappelijke eigenschappen voor beide soorten gradient (Solid en Noise).
+
+```csharp
+public abstract class BaseGradientFillSettings : BaseFillSettings, IGradientFillSettings
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BaseGradientFillSettings](basegradientfillsettings/)() | Initialiseert een nieuw exemplaar van de `BaseGradientFillSettings`-klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AlignWithLayer](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/) { get; set; } | Haalt een waarde op of stelt een waarde in die aangeeft of [align with layer]. |
+| [Angle](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/) { get; set; } | Haalt een waarde op of stelt de hoek in. |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/) { get; set; } | Haalt een waarde op of stelt een waarde in die aangeeft of dit `BaseGradientFillSettings` dither is. |
+| override [FillType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/) { get; } | Het vultype. |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/) { get; } | Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/) { get; set; } | Haalt een waarde op of stelt de naam van de gradient in. |
+| [GradientType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/) { get; set; } | Haalt op of stelt het type van de gradient in. |
+| [HorizontalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/) { get; set; } | Haalt op of stelt de horizontale offset in percentage in. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of deze `BaseGradientFillSettings` omgekeerd is. |
+| [Scale](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/) { get; set; } | Haalt op of stelt de schaal in. |
+| [VerticalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/) { get; set; } | Haalt op of stelt de verticale offset in percentage in. |
+
+### Zie ook
+
+* class [BaseFillSettings](../basefillsettings/)
+* interface [IGradientFillSettings](../igradientfillsettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.AlignWithLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt een waarde op of stelt deze in die aangeeft of uitlijnen met laag."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.AlignWithLayer property
+
+Haalt een waarde op of stelt een waarde in die aangeeft of [align with layer].
+
+```csharp
+public bool AlignWithLayer { get; set; }
+```
+
+### Property Value
+
+`true` als [uitlijnen met laag]; anders `false`.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/_index.md
@@ -1,0 +1,34 @@
+---
+title: "BaseGradientFillSettings.Angle"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de hoek op of stelt de hoek in."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Angle property
+
+Haalt een waarde op of stelt de hoek in.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+De hoek.
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | Hoek moet binnen het bereik van -180.0 tot 180.0 liggen. |
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseGradientFillSettings.BaseGradientFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings constructor. Initialiseert een nieuw exemplaar van de BaseGradientFillSettings klasse."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/basegradientfillsettings/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings constructor
+
+Initialiseert een nieuw exemplaar van de [`BaseGradientFillSettings`](../) klasse.
+
+```csharp
+public BaseGradientFillSettings()
+```
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.Color"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de kleur op of stelt deze in."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/color/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Color property
+
+Haalt de kleur op of stelt deze in.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+De kleur.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.ColorPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de kleurpunten op of stelt deze in."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/colorpoints/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.ColorPoints property
+
+Haalt of stelt de kleurpunten in.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+De kleurpunten.
+
+### Zie ook
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.Dither"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt een waarde op of stelt een waarde in die aangeeft of deze BaseGradientFillSettings geditherd is."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Dither property
+
+Haalt een waarde op of stelt een waarde in die aangeeft of deze [`BaseGradientFillSettings`](../) geditherd is.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+### Property Value
+
+`true` als geditherd; anders `false`.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradientFillSettings.FillType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Het vultype"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.FillType property
+
+Het vultype.
+
+```csharp
+public override FillType FillType { get; }
+```
+
+### Zie ook
+
+* enum [FillType](../../filltype/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradientFillSettings.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de modus voor deze gradiënt op. Bepaalt het gradiënttype Solid/Noise 0/1."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientMode property
+
+Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; }
+```
+
+### Zie ook
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.GradientName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de naam van de gradient op of stelt deze in."
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientName property
+
+Haalt een waarde op of stelt de naam van de gradient in.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+### Property Value
+
+De naam van de gradient.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/_index.md
@@ -1,0 +1,29 @@
+---
+title: "BaseGradientFillSettings.GradientType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt het type van de gradiënt op of stelt het type in."
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.GradientType property
+
+Haalt op of stelt het type van de gradient in.
+
+```csharp
+public GradientType GradientType { get; set; }
+```
+
+### Property Value
+
+Het type van de gradiënt.
+
+### Zie ook
+
+* enum [GradientType](../../gradienttype/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.HorizontalOffset"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de horizontale offset in percentage op of stelt deze in."
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.HorizontalOffset property
+
+Haalt op of stelt de horizontale offset in percentage in.
+
+```csharp
+public double HorizontalOffset { get; set; }
+```
+
+### Property Value
+
+De horizontale offset.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.Reverse"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt een waarde op of stelt deze in die aangeeft of deze BaseGradientFillSettings omgekeerd is."
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Reverse property
+
+Haalt een waarde op of stelt deze in die aangeeft of deze [`BaseGradientFillSettings`](../) omgekeerd is.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+### Property Value
+
+`true` als omgekeerd; anders `false`.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/_index.md
@@ -1,0 +1,34 @@
+---
+title: "BaseGradientFillSettings.Scale"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de schaal op of stelt de schaal in."
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.Scale property
+
+Haalt op of stelt de schaal in.
+
+```csharp
+public int Scale { get; set; }
+```
+
+### Property Value
+
+De schaal.
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | Schaal moet binnen het bereik van 1 tot 1000 liggen. |
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseGradientFillSettings.TransparencyPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de transparantiepunten op of stelt deze in."
+type: docs
+weight: 140
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/transparencypoints/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.TransparencyPoints property
+
+Haalt of stelt de transparantiepunten in.
+
+```csharp
+[Obsolete("This property is obsolete. It is moved to GradientFillSettings class. Property will be removed in 23.10 release.")]
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+De transparantiepunten.
+
+### Zie ook
+
+* interface [IGradientTransparencyPoint](../../igradienttransparencypoint/)
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradientFillSettings.VerticalOffset"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradientFillSettings eigenschap. Haalt de verticale offset in percentage op of stelt deze in."
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/
+---
+{{< psd/tize >}}
+## BaseGradientFillSettings.VerticalOffset property
+
+Haalt op of stelt de verticale offset in percentage in.
+
+```csharp
+public double VerticalOffset { get; set; }
+```
+
+### Property Value
+
+De verticale offset.
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ColorFillSettings.ColorFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorFillSettings constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/colorfillsettings/colorfillsettings/
+---
+{{< psd/tize >}}
+## ColorFillSettings constructor
+
+De standaardconstructor.
+
+```csharp
+public ColorFillSettings()
+```
+
+### Zie ook
+
+* class [ColorFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "GradientColorPoint.Color"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientColorPoint property. Haalt de kleur op of stelt deze in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/color/
+---
+{{< psd/tize >}}
+## GradientColorPoint.Color property
+
+Haalt de kleur op of stelt deze in.
+
+```csharp
+[Obsolete]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+De kleur.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [GradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GradientColorPoint.ColorMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientColorPoint property. Modus die de kleur volgt"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/colormode/
+---
+{{< psd/tize >}}
+## GradientColorPoint.ColorMode property
+
+Modus die de kleur volgt
+
+```csharp
+public short ColorMode { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GradientFillSettings.Gradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientFillSettings eigenschap. Haalt op of stelt een specifieke gradientdefinitie-instantie Solid/Noise in"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/gradient/
+---
+{{< psd/tize >}}
+## GradientFillSettings.Gradient property
+
+Haalt een waarde op of stelt een specifieke gradientdefinitie‑instantie in (Solid/Noise).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+### Zie ook
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientFillSettings.Interpolation"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientFillSettings eigenschap. Haalt op of stelt Interpolation in. Bepaalt de gladheid wanneer Gradient Type Solid. Waardebereik 04096"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolation/
+---
+{{< psd/tize >}}
+## GradientFillSettings.Interpolation property
+
+Haalt of stelt Interpolatie in. Bepaalt Gladheid, wanneer 'Gradient Type' = 'Solid'. Waardenbereik: 0-4096.
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Zie ook
+
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GradientFillSettings.InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientFillSettings eigenschap. Haalt op of stelt de interpolatiemethode voor de gradient in"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientfillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## GradientFillSettings.InterpolationMethod property
+
+Haalt een waarde op of stelt de interpolatiemethode voor de gradient in.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* class [GradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/_index.md
@@ -1,0 +1,146 @@
+---
+title: "Klasse GradientMapSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.GradientMapSettings class. Gradientinstellingenklasse voor gradientmaplaag. Het bevat gemeenschappelijke eigenschappen voor beide typen gradient Solid en Noise"
+type: docs
+weight: 2080
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/
+---
+{{< psd/tize >}}
+## GradientMapSettings class
+
+Gradientinstellingenklasse voor gradientmaplaag. Het bevat gemeenschappelijke eigenschappen voor beide typen gradient (Solid en Noise).
+
+```csharp
+public class GradientMapSettings
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GradientMapSettings](gradientmapsettings/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/) { get; set; } | Haalt een waarde op of stelt een waarde in die aangeeft of dit [`GradientFillSettings`](../gradientfillsettings/) dither is. |
+| [Gradient](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/) { get; set; } | Haalt een waarde op of stelt een specifieke gradientdefinitie‑instantie in (Solid/Noise). |
+| [InterpolationMethod](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/) { get; set; } | Haalt een waarde op of stelt de interpolatiemethode voor de gradient in. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/) { get; set; } | Haalt een waarde op of stelt een waarde in die aangeeft of dit [`GradientFillSettings`](../gradientfillsettings/) omgekeerd is. |
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GradientMapSettings.Dither"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapSettings property. Haalt een waarde op of stelt deze in die aangeeft of deze GradientFillSettings geditherd is"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/dither/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Dither property
+
+Haalt een waarde op of stelt deze in die aangeeft of deze [`GradientFillSettings`](../../gradientfillsettings/) geditherd is.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+### Property Value
+
+`true` als geditherd; anders `false`.
+
+### Zie ook
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/_index.md
@@ -1,0 +1,133 @@
+---
+title: "GradientMapSettings.Gradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapSettings property. Haalt of stelt een specifieke gradientdefinitie‑instantie in (Solid/Noise)"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradient/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Gradient property
+
+Haalt een waarde op of stelt een specifieke gradientdefinitie‑instantie in (Solid/Noise).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GradientMapSettings.GradientMapSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapSettings constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/gradientmapsettings/
+---
+{{< psd/tize >}}
+## GradientMapSettings constructor
+
+De standaardconstructor.
+
+```csharp
+public GradientMapSettings()
+```
+
+### Zie ook
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GradientMapSettings.InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapSettings property. Haalt de interpolatiemethode voor de gradient op of stelt deze in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## GradientMapSettings.InterpolationMethod property
+
+Haalt een waarde op of stelt de interpolatiemethode voor de gradient in.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GradientMapSettings.Reverse"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientMapSettings property. Haalt een waarde op of stelt deze in die aangeeft of deze GradientFillSettings omgekeerd is"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/gradientmapsettings/reverse/
+---
+{{< psd/tize >}}
+## GradientMapSettings.Reverse property
+
+Haalt een waarde op of stelt deze in die aangeeft of deze [`GradientFillSettings`](../../gradientfillsettings/) omgekeerd is.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+### Property Value
+
+`true` als omgekeerd; anders `false`.
+
+### Zie ook
+
+* class [GradientMapSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/_index.md
@@ -1,0 +1,133 @@
+---
+title: "IGradientFillSettings.Gradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IGradientFillSettings eigenschap. Haalt op of stelt een specifieke gradientdefinitie-instantie Solid/Noise in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradient/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.Gradient property
+
+Haalt een waarde op of stelt een specifieke gradientdefinitie‑instantie in (Solid/Noise).
+
+```csharp
+public BaseGradient Gradient { get; set; }
+```
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseGradient](../../../aspose.psd.fileformats.psd.layers.gradient/basegradient/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IGradientFillSettings.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IGradientFillSettings eigenschap. Haalt gradientmodus op. Bepaalt Gradient Type Solid/Noise 0/1"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/gradientmode/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.GradientMode property
+
+Haalt gradientmodus op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; }
+```
+
+### Zie ook
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "IGradientFillSettings.InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IGradientFillSettings eigenschap. Haalt op of stelt de interpolatiemethode voor de gradient in"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/igradientfillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## IGradientFillSettings.InterpolationMethod property
+
+Haalt een waarde op of stelt de interpolatiemethode voor de gradient in.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [InterpolationMethod](../../interpolationmethod/)
+* interface [IGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/_index.md
@@ -1,0 +1,84 @@
+---
+title: "Enum InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.InterpolationMethod enum. Ingepakte fourCC-waarden voor Photoshop gradient interpolatiemethode. Descriptor‑sleutel gradientsInterpolationMethod"
+type: docs
+weight: 2160
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/
+---
+{{< psd/tize >}}
+## InterpolationMethod enumeration
+
+Ingepakte fourCC-waarden voor Photoshop gradient interpolatiemethode. Descriptor‑sleutel: "gradientsInterpolationMethod"
+
+```csharp
+public enum InterpolationMethod : uint
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Classic | `1197698163` | 'Gcls' — Klassiek (standaardwaarde uit het verleden wanneer sleutel ontbreekt). |
+| Perceptual | `1348825699` | 'Perc' — Perceptueel. |
+| Linear | `1282306592` | 'Lnr ' — Lineair (let op achterste spatie). |
+| Smooth | `1399680879` | 'Smoo' — Glad. |
+| Stripes | `1195986291` | 'GIMs' — Strepen. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/_index.md
@@ -1,0 +1,28 @@
+---
+title: "IPatternFillSettings.Angle"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPatternFillSettings eigenschap. Haalt de hoek op of stelt deze in."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/ipatternfillsettings/angle/
+---
+{{< psd/tize >}}
+## IPatternFillSettings.Angle property
+
+Haalt een waarde op of stelt de hoek in.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+De hoek.
+
+### Zie ook
+
+* interface [IPatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Klasse NoiseGradientFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.FillSettings.NoiseGradientFillSettings klasse. Noise gradient definitieklasse"
+type: docs
+weight: 2150
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings class
+
+Noise gradient definitieklasse.
+
+```csharp
+public class NoiseGradientFillSettings : BaseGradientFillSettings
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [NoiseGradientFillSettings](noisegradientfillsettings/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AlignWithLayer](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/alignwithlayer/) { get; set; } | Haalt een waarde op of stelt een waarde in die aangeeft of [align with layer]. |
+| [Angle](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/angle/) { get; set; } | Haalt een waarde op of stelt de hoek in. |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/) { get; set; } | Haalt op of stelt het kleurmodel - RGB/HSB/LAB (3/4/6) in. |
+| [Dither](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/dither/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of deze [`BaseGradientFillSettings`](../basegradientfillsettings/) geditherd is. |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/) { get; set; } | Haalt op of stelt het uitbreidingsaantal ( = 2 voor Photoshop 6.0) in. |
+| override [FillType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/filltype/) { get; } | Het vultype. |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientmode/) { get; } | Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradientname/) { get; set; } | Haalt een waarde op of stelt de naam van de gradient in. |
+| [GradientType](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/gradienttype/) { get; set; } | Haalt op of stelt het type van de gradient in. |
+| [HorizontalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/horizontaloffset/) { get; set; } | Haalt op of stelt de horizontale offset in percentage in. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/) { get; set; } | Haalt op of stelt de maximale kleur van PixelDataFormat in. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/) { get; set; } | Haalt op of stelt de minimale kleur van PixelDataFormat in. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/reverse/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of deze [`BaseGradientFillSettings`](../basegradientfillsettings/) omgekeerd is. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/) { get; set; } | Haalt op of stelt de willekeurige getal-seed in die wordt gebruikt om kleuren voor Noise gradient te genereren. |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/) { get; set; } | Haalt op of stelt de ruwheidsfactor in. |
+| [Scale](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/scale/) { get; set; } | Haalt op of stelt de schaal in. |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/) { get; set; } | Haalt op of stelt de vlag voor het tonen van transparantie in. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/) { get; set; } | Haalt op of stelt de vlag voor het gebruiken van vectorkleur in. |
+| [VerticalOffset](../../aspose.psd.fileformats.psd.layers.fillsettings/basegradientfillsettings/verticaloffset/) { get; set; } | Haalt op of stelt de verticale offset in percentage in. |
+
+### Zie ook
+
+* class [BaseGradientFillSettings](../basegradientfillsettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.ColorModel"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt het kleurmodel RGB/HSB/LAB 3/4/6 in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/colormodel/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ColorModel property
+
+Haalt op of stelt het kleurmodel - RGB/HSB/LAB (3/4/6) in.
+
+```csharp
+public NoiseColorModel ColorModel { get; set; }
+```
+
+### Zie ook
+
+* enum [NoiseColorModel](../../../aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/_index.md
@@ -1,0 +1,71 @@
+---
+title: "NoiseGradientFillSettings.ExpansionCount"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt het expansie-aantal in   2 voor Photoshop 6.0"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/expansioncount/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ExpansionCount property
+
+Haalt op of stelt het uitbreidingsaantal ( = 2 voor Photoshop 6.0) in.
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Gradient map-laag.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Voeg Gradient map-aanpassingslaag toe.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    GradientFillSettings gradientSettings = (GradientFillSettings)gradientMapLayer.GradientSettings;
+
+    AssertAreEqual(90.0, gradientSettings.Angle);
+    AssertAreEqual((short)4096, gradientSettings.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(true, gradientSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual(GradientType.Linear, gradientSettings.GradientType);
+    AssertAreEqual(100, gradientSettings.Scale);
+    AssertAreEqual(0.0, gradientSettings.HorizontalOffset);
+    AssertAreEqual(0.0, gradientSettings.VerticalOffset);
+    AssertAreEqual("Custom", gradientSettings.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.MaximumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt de maximale kleur van PixelDataFormat in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/maximumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.MaximumColor property
+
+Haalt op of stelt de maximale kleur van PixelDataFormat in.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradientFillSettings.MinimumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt de minimumkleur van PixelDataFormat in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/minimumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.MinimumColor property
+
+Haalt op of stelt de minimale kleur van PixelDataFormat in.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.NoiseGradientFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/noisegradientfillsettings/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings constructor
+
+De standaardconstructor.
+
+```csharp
+public NoiseGradientFillSettings()
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.RndNumberSeed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt het willekeurige getalzaad in dat wordt gebruikt om kleuren voor Noise gradient te genereren"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/rndnumberseed/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.RndNumberSeed property
+
+Haalt op of stelt de willekeurige getal-seed in die wordt gebruikt om kleuren voor Noise gradient te genereren.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.Roughness"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt de ruwheidsfactor in"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/roughness/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.Roughness property
+
+Haalt op of stelt de ruwheidsfactor in.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.ShowTransparency"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt de vlag in voor het weergeven van transparantie"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/showtransparency/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.ShowTransparency property
+
+Haalt op of stelt de vlag voor het tonen van transparantie in.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradientFillSettings.UseVectorColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradientFillSettings eigenschap. Haalt op of stelt de vlag in voor het gebruik van vectorkleur"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/noisegradientfillsettings/usevectorcolor/
+---
+{{< psd/tize >}}
+## NoiseGradientFillSettings.UseVectorColor property
+
+Haalt op of stelt de vlag voor het gebruiken van vectorkleur in.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradientFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PatternFillSettings.Angle"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PatternFillSettings eigenschap. Haalt de hoek op of stelt deze in."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/angle/
+---
+{{< psd/tize >}}
+## PatternFillSettings.Angle property
+
+Haalt een waarde op of stelt de hoek in.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+De hoek.
+
+### Zie ook
+
+* class [PatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PatternFillSettings.PatternFillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PatternFillSettings constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.fillsettings/patternfillsettings/patternfillsettings/
+---
+{{< psd/tize >}}
+## PatternFillSettings constructor
+
+De standaardconstructor.
+
+```csharp
+public PatternFillSettings()
+```
+
+### Zie ook
+
+* class [PatternFillSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.FillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Layers.Gradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "De namespace verwerkt de verwerking van het Psd-bestandsformaat"
+type: docs
+weight: 280
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/
+---
+{{< psd/tize >}}
+De namespace verwerkt de verwerking van het Psd-bestandsformaat.
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [BaseGradient](./basegradient/) | Basisgradientdefinitieklasse. Het bevat gemeenschappelijke eigenschappen voor beide soorten gradient (Solid en Noise). |
+| [NoiseGradient](./noisegradient/) | Noise gradient definitieklasse. |
+| [SolidGradient](./solidgradient/) | Instellingen voor gradientvullingseffect. |
+## Enumeratie
+
+| Enumeratie | Beschrijving |
+| --- | --- |
+| [GradientKind](./gradientkind/) | Gradienttype enum. |
+| [NoiseColorModel](./noisecolormodel/) | Kleurmodel wanneer 'Gradient type' = 'Noise', kunnen we 'Color Model' toewijzen aan RGB/SHB/LAB (3/4/6) |
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/_index.md
@@ -1,0 +1,138 @@
+---
+title: "Class BaseGradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.BaseGradient class. Base gradient definitieklasse. Het bevat gemeenschappelijke eigenschappen voor beide gradient types Solid en Noise"
+type: docs
+weight: 2190
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/
+---
+{{< psd/tize >}}
+## BaseGradient class
+
+Basisgradientdefinitieklasse. Het bevat gemeenschappelijke eigenschappen voor beide soorten gradient (Solid en Noise).
+
+```csharp
+public abstract class BaseGradient
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| abstract [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/) { get; } | Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Haalt een waarde op of stelt de naam van de gradient in. |
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "BaseGradient.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradient eigenschap. Haalt de modus voor deze gradient op. Bepaalt gradienttype  Solid/Noise 0/1"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientmode/
+---
+{{< psd/tize >}}
+## BaseGradient.GradientMode property
+
+Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public abstract GradientKind GradientMode { get; }
+```
+
+### Zie ook
+
+* enum [GradientKind](../../gradientkind/)
+* class [BaseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseGradient.GradientName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseGradient eigenschap. Haalt op of stelt de naam van de gradient in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/
+---
+{{< psd/tize >}}
+## BaseGradient.GradientName property
+
+Haalt een waarde op of stelt de naam van de gradient in.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+### Property Value
+
+De naam van de gradient.
+
+### Zie ook
+
+* class [BaseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/_index.md
@@ -1,0 +1,30 @@
+---
+title: "Enum GradientKind"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.GradientKind enum. Gradient type enum"
+type: docs
+weight: 2200
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/gradientkind/
+---
+{{< psd/tize >}}
+## GradientKind enumeration
+
+Gradienttype enum.
+
+```csharp
+public enum GradientKind
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Solid | `0` | Solid Gradient type |
+| Noise | `1` | Noise Gradient type |
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Enum NoiseColorModel"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.NoiseColorModel enum. Kleurmodel Wanneer Gradient type Noise kunnen we Kleurmodel toewijzen aan RGB/SHB/LAB 3/4/6"
+type: docs
+weight: 2210
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisecolormodel/
+---
+{{< psd/tize >}}
+## NoiseColorModel enumeration
+
+Kleurmodel wanneer 'Gradient type' = 'Noise', kunnen we 'Color Model' toewijzen aan RGB/SHB/LAB (3/4/6)
+
+```csharp
+public enum NoiseColorModel : short
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| RGB | `3` | RGB kleurmodel. |
+| HSB | `4` | HSB kleurmodel. |
+| LAB | `6` | LAB kleurmodel. |
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/_index.md
@@ -1,0 +1,153 @@
+---
+title: "Class NoiseGradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.NoiseGradient class. Noise gradient definitieklasse"
+type: docs
+weight: 2220
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/
+---
+{{< psd/tize >}}
+## NoiseGradient class
+
+Noise gradient definitieklasse.
+
+```csharp
+public class NoiseGradient : BaseGradient
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [NoiseGradient](noisegradient/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/) { get; set; } | Haalt op of stelt het kleurmodel - RGB/HSB/LAB (3/4/6) in. |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/) { get; set; } | Haalt op of stelt het uitbreidingsaantal ( = 2 voor Photoshop 6.0) in. |
+| override [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/) { get; } | Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Haalt een waarde op of stelt de naam van de gradient in. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/) { get; set; } | Haalt op of stelt de maximale kleur van PixelDataFormat in. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/) { get; set; } | Haalt op of stelt de minimale kleur van PixelDataFormat in. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/) { get; set; } | Haalt op of stelt de willekeurige getal-seed in die wordt gebruikt om kleuren voor Noise gradient te genereren. |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/) { get; set; } | Haalt op of stelt de ruwheidsfactor in. |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/) { get; set; } | Haalt op of stelt de vlag voor het tonen van transparantie in. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/) { get; set; } | Haalt op of stelt de vlag voor het gebruiken van vectorkleur in. |
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseGradient](../basegradient/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.ColorModel"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt het kleurmodel  RGB/HSB/LAB 3/4/6 in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/colormodel/
+---
+{{< psd/tize >}}
+## NoiseGradient.ColorModel property
+
+Haalt op of stelt het kleurmodel - RGB/HSB/LAB (3/4/6) in.
+
+```csharp
+public NoiseColorModel ColorModel { get; set; }
+```
+
+### Zie ook
+
+* enum [NoiseColorModel](../../noisecolormodel/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/_index.md
@@ -1,0 +1,66 @@
+---
+title: "NoiseGradient.ExpansionCount"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt het expansieaantal in   2 voor Photoshop 6.0"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/expansioncount/
+---
+{{< psd/tize >}}
+## NoiseGradient.ExpansionCount property
+
+Haalt op of stelt het uitbreidingsaantal ( = 2 voor Photoshop 6.0) in.
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Gradient map-laag.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Voeg Gradient map-aanpassingslaag toe.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt de modus voor deze gradient op. Bepaalt gradienttype  Solid/Noise 0/1"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/gradientmode/
+---
+{{< psd/tize >}}
+## NoiseGradient.GradientMode property
+
+Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public override GradientKind GradientMode { get; }
+```
+
+### Zie ook
+
+* enum [GradientKind](../../gradientkind/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.MaximumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt de maximale kleur van PixelDataFormat in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/maximumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.MaximumColor property
+
+Haalt op of stelt de maximale kleur van PixelDataFormat in.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "NoiseGradient.MinimumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient-eigenschap. Haalt of stelt de Minimum-kleur van PixelDataFormat in."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/minimumcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.MinimumColor property
+
+Haalt op of stelt de minimale kleur van PixelDataFormat in.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.NoiseGradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient constructor. De standaard constructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/noisegradient/
+---
+{{< psd/tize >}}
+## NoiseGradient constructor
+
+De standaardconstructor.
+
+```csharp
+public NoiseGradient()
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.RndNumberSeed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt de willekeurige getalseed in die wordt gebruikt om kleuren voor de Noise-gradient te genereren"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/rndnumberseed/
+---
+{{< psd/tize >}}
+## NoiseGradient.RndNumberSeed property
+
+Haalt op of stelt de willekeurige getal-seed in die wordt gebruikt om kleuren voor Noise gradient te genereren.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.Roughness"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt de ruwheidsfactor in"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/roughness/
+---
+{{< psd/tize >}}
+## NoiseGradient.Roughness property
+
+Haalt op of stelt de ruwheidsfactor in.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.ShowTransparency"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt de vlag in voor het weergeven van transparantie"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/showtransparency/
+---
+{{< psd/tize >}}
+## NoiseGradient.ShowTransparency property
+
+Haalt op of stelt de vlag voor het tonen van transparantie in.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NoiseGradient.UseVectorColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NoiseGradient eigenschap. Haalt op of stelt de vlag in voor het gebruik van vectorkleur"
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/noisegradient/usevectorcolor/
+---
+{{< psd/tize >}}
+## NoiseGradient.UseVectorColor property
+
+Haalt op of stelt de vlag voor het gebruiken van vectorkleur in.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Zie ook
+
+* class [NoiseGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/_index.md
@@ -1,0 +1,158 @@
+---
+title: "Class SolidGradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Gradient.SolidGradient class. Gradient vul effectinstellingen"
+type: docs
+weight: 2230
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/
+---
+{{< psd/tize >}}
+## SolidGradient class
+
+Instellingen voor gradientvullingseffect.
+
+```csharp
+public class SolidGradient : BaseGradient
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [SolidGradient](solidgradient/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorPoints](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/) { get; set; } | Haalt of stelt de kleurpunten in. |
+| override [GradientMode](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/) { get; } | Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.gradient/basegradient/gradientname/) { get; set; } | Haalt een waarde op of stelt de naam van de gradient in. |
+| [Interpolation](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/) { get; set; } | Haalt of stelt Interpolatie in. Bepaalt Gladheid, wanneer 'Gradient Type' = 'Solid'. Waardenbereik: 0-4096. |
+| [TransparencyPoints](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/) { get; set; } | Haalt of stelt de transparantiepunten in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AddColorPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/)() | Voegt het kleurpunt toe. |
+| [AddTransparencyPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/)() | Voegt het kleurpunt toe. |
+| [RemoveColorPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/)(IGradientColorPoint) | Verwijdert het kleurpunt. |
+| [RemoveTransparencyPoint](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/)(IGradientTransparencyPoint) | Verwijdert het transparantiepunt. |
+| static [GenerateLfx2ResourceNodes](../../aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/)() | Genereert de LFX2 resourceknooppunten. |
+
+## Voorbeelden
+
+Toont het lezen en aanpassen van noise- en solid-gradientinstellingen in penseelvullingseffecten.
+
+```csharp
+[C#]
+
+string inputFile = "StrokeNoise.psd";
+string outputFile = "output.psd";
+
+var loadOptions = new PsdLoadOptions() { LoadEffectsResource = true };
+
+using (PsdImage image = (PsdImage)Image.Load(inputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(true, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(true, gradientFillSettings.Dither);
+    AssertAreEqual(true, gradientFillSettings.Reverse);
+    AssertAreEqual(116.0, gradientFillSettings.Angle);
+    AssertAreEqual(122, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Angle, gradientFillSettings.GradientType);
+
+    // Controleer Noise-gradienteigenschappen
+    NoiseGradient noiseGradient = gradientFillSettings.Gradient as NoiseGradient;
+    AssertIsNotNull(noiseGradient);
+    AssertAreEqual(GradientKind.Noise, noiseGradient.GradientMode);
+    AssertAreEqual(2107422935, noiseGradient.RndNumberSeed);
+    AssertAreEqual(false, noiseGradient.ShowTransparency);
+    AssertAreEqual(false, noiseGradient.UseVectorColor);
+    AssertAreEqual(2048, noiseGradient.Roughness);
+    AssertAreEqual(NoiseColorModel.RGB, noiseGradient.ColorModel);
+    AssertAreEqual((long)0, noiseGradient.MinimumColor.GetAsLong());
+    AssertAreEqual(28147819798528050, noiseGradient.MaximumColor.GetAsLong());
+
+    // Wijzig gradientinstellingen
+    gradientFillSettings.AlignWithLayer = false;
+    gradientFillSettings.Dither = false;
+    gradientFillSettings.Reverse = false;
+    gradientFillSettings.Angle = 30;
+    gradientFillSettings.Scale = 80;
+    gradientFillSettings.GradientType = GradientType.Linear;
+
+    var solidGradient = new SolidGradient();
+    solidGradient.Interpolation = 2048;
+    solidGradient.ColorPoints[0].RawColor.Components[0].Value = 255; // A
+    solidGradient.ColorPoints[0].RawColor.Components[1].Value = 255; // R 
+    solidGradient.ColorPoints[0].RawColor.Components[2].Value = 0;   // G
+    solidGradient.ColorPoints[0].RawColor.Components[3].Value = 0;   // B
+    solidGradient.TransparencyPoints[1].Opacity = 50;
+    gradientFillSettings.Gradient = solidGradient;
+
+    image.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(outputFile, loadOptions))
+{
+    var gradientStroke = (StrokeEffect)image.Layers[0].BlendingOptions.Effects[0];
+    GradientFillSettings gradientFillSettings = gradientStroke.FillSettings as GradientFillSettings;
+
+    // Controleer gemeenschappelijke eigenschappen van gradientvullinginstellingen
+    AssertIsNotNull(gradientFillSettings);
+    AssertAreEqual(false, gradientFillSettings.AlignWithLayer);
+    AssertAreEqual(false, gradientFillSettings.Dither);
+    AssertAreEqual(false, gradientFillSettings.Reverse);
+    AssertAreEqual(30.0, gradientFillSettings.Angle);
+    AssertAreEqual(80, gradientFillSettings.Scale);
+    AssertAreEqual(GradientType.Linear, gradientFillSettings.GradientType);
+
+    SolidGradient solidGradient = gradientFillSettings.Gradient as SolidGradient;
+    AssertIsNotNull(solidGradient);
+    AssertAreEqual((short)2048, solidGradient.Interpolation);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[0].Value);
+    AssertAreEqual(
+        (ulong)255,
+        solidGradient.ColorPoints[0].RawColor.Components[1].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[2].Value);
+    AssertAreEqual(
+        (ulong)0,
+        solidGradient.ColorPoints[0].RawColor.Components[3].Value);
+    AssertAreEqual(50.0, solidGradient.TransparencyPoints[1].Opacity);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseGradient](../basegradient/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.AddColorPoint"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient methode. Voegt het kleurpunt toe"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addcolorpoint/
+---
+{{< psd/tize >}}
+## SolidGradient.AddColorPoint method
+
+Voegt het kleurpunt toe.
+
+```csharp
+public GradientColorPoint AddColorPoint()
+```
+
+### Retourwaarde
+
+Kleurpunt aangemaakt
+
+### Zie ook
+
+* class [GradientColorPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.AddTransparencyPoint"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient methode. Voegt het kleurpunt toe"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/addtransparencypoint/
+---
+{{< psd/tize >}}
+## SolidGradient.AddTransparencyPoint method
+
+Voegt het kleurpunt toe.
+
+```csharp
+public GradientTransparencyPoint AddTransparencyPoint()
+```
+
+### Retourwaarde
+
+Transparantiepunt aangemaakt
+
+### Zie ook
+
+* class [GradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/gradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "SolidGradient.Color"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient eigenschap. Haalt de kleur op of stelt deze in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/color/
+---
+{{< psd/tize >}}
+## SolidGradient.Color property
+
+Haalt de kleur op of stelt deze in.
+
+```csharp
+[Obsolete("Property is obsolete and will be removed in further release.")]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+De kleur.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/_index.md
@@ -1,0 +1,102 @@
+---
+title: "SolidGradient.ColorPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient eigenschap. Haalt de kleurpunten op of stelt deze in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/colorpoints/
+---
+{{< psd/tize >}}
+## SolidGradient.ColorPoints property
+
+Haalt of stelt de kleurpunten in.
+
+```csharp
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+De kleurpunten.
+
+## Voorbeelden
+
+Het volgende voorbeeld toont ondersteuning voor Gradient FillLayer en bewerkingsopties voor IGradientFillSettings.
+
+```csharp
+[C#]
+
+string sourceFileName = "ComplexGradientFillLayer.psd";
+string outputFile = "ComplexGradientFillLayer_output.psd";
+var im = (PsdImage)Image.Load(sourceFileName);
+using (im)
+{
+    foreach (var layer in im.Layers)
+    {
+        if (layer is FillLayer)
+        {
+            var fillLayer = (FillLayer)layer;
+            if (fillLayer.FillSettings.FillType != FillType.Gradient)
+            {
+                throw new Exception("Wrong Fill Layer");
+            }
+            var settings = (GradientFillSettings)fillLayer.FillSettings;
+            var solidGradient = (SolidGradient)settings.Gradient;
+            if (
+             Math.Abs(settings.Angle - 45) > 0.25 ||
+             settings.Dither != true ||
+             settings.AlignWithLayer != false ||
+             settings.Reverse != false ||
+             Math.Abs(settings.HorizontalOffset - (-39)) > 0.25 ||
+             Math.Abs(settings.VerticalOffset - (-5)) > 0.25 ||
+             solidGradient.TransparencyPoints.Length != 3 ||
+             solidGradient.ColorPoints.Length != 2 ||
+             Math.Abs(100.0 - solidGradient.TransparencyPoints[0].Opacity) > 0.25 ||
+             solidGradient.TransparencyPoints[0].Location != 0 ||
+             solidGradient.TransparencyPoints[0].MedianPointLocation != 50 ||
+             solidGradient.ColorPoints[0].Color != Color.FromArgb(203, 64, 140) ||
+             solidGradient.ColorPoints[0].Location != 0 ||
+             solidGradient.ColorPoints[0].MedianPointLocation != 50)
+            {
+                throw new Exception("Gradient Fill was not read correctly");
+            }
+            settings.Angle = 0.0;
+            settings.Dither = false;
+            settings.AlignWithLayer = true;
+            settings.Reverse = true;
+            settings.HorizontalOffset = 25;
+            settings.VerticalOffset = -15;
+            var colorPoints = new List<IGradientColorPoint>(solidGradient.ColorPoints);
+            var transparencyPoints = new List<IGradientTransparencyPoint>(solidGradient.TransparencyPoints);
+            colorPoints.Add(new GradientColorPoint()
+            {
+                Color = Color.Violet,
+                Location = 4096,
+                MedianPointLocation = 75
+            });
+            colorPoints[1].Location = 3000;
+            transparencyPoints.Add(new GradientTransparencyPoint()
+            {
+                Opacity = 80.0,
+                Location = 4096,
+                MedianPointLocation = 25
+            });
+            transparencyPoints[2].Location = 3000;
+            solidGradient.ColorPoints = colorPoints.ToArray();
+            solidGradient.TransparencyPoints = transparencyPoints.ToArray();
+            fillLayer.Update();
+            im.Save(outputFile, new PsdOptions(im));
+            break;
+        }
+    }
+}
+```
+
+### Zie ook
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.GenerateLfx2ResourceNodes"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient methode. Genereert de LFX2 resourceknooppunten"
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/generatelfx2resourcenodes/
+---
+{{< psd/tize >}}
+## SolidGradient.GenerateLfx2ResourceNodes method
+
+Genereert de LFX2 resourceknooppunten.
+
+```csharp
+public static List<OSTypeStructure> GenerateLfx2ResourceNodes()
+```
+
+### Retourwaarde
+
+Gegenereerde lijst van [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+
+### Zie ook
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/_index.md
@@ -1,0 +1,25 @@
+---
+title: "SolidGradient.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient eigenschap. Haalt de modus voor deze gradient op. Bepaalt Gradient Type Solid/Noise 0/1"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/gradientmode/
+---
+{{< psd/tize >}}
+## SolidGradient.GradientMode property
+
+Haalt de modus voor deze gradient op. Bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public override GradientKind GradientMode { get; }
+```
+
+### Zie ook
+
+* enum [GradientKind](../../gradientkind/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "SolidGradient.Interpolation"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient eigenschap. Haalt Interpolatie op of stelt deze in. Bepaalt de gladheid wanneer Gradient Type Solid is. Waarde bereik 04096"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/interpolation/
+---
+{{< psd/tize >}}
+## SolidGradient.Interpolation property
+
+Haalt of stelt Interpolatie in. Bepaalt Gladheid, wanneer 'Gradient Type' = 'Solid'. Waardenbereik: 0-4096.
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Zie ook
+
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.RemoveColorPoint"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient methode. Verwijdert het kleurpunt"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removecolorpoint/
+---
+{{< psd/tize >}}
+## SolidGradient.RemoveColorPoint method
+
+Verwijdert het kleurpunt.
+
+```csharp
+public void RemoveColorPoint(IGradientColorPoint point)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| punt | IGradientColorPoint | Het punt. |
+
+### Zie ook
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/_index.md
@@ -1,0 +1,29 @@
+---
+title: "SolidGradient.RemoveTransparencyPoint"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient methode. Verwijdert het transparantiepunt"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/removetransparencypoint/
+---
+{{< psd/tize >}}
+## SolidGradient.RemoveTransparencyPoint method
+
+Verwijdert het transparantiepunt.
+
+```csharp
+public void RemoveTransparencyPoint(IGradientTransparencyPoint point)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| punt | IGradientTransparencyPoint | Het punt. |
+
+### Zie ook
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/_index.md
@@ -1,0 +1,24 @@
+---
+title: "SolidGradient.SolidGradient"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/solidgradient/
+---
+{{< psd/tize >}}
+## SolidGradient constructor
+
+De standaardconstructor.
+
+```csharp
+public SolidGradient()
+```
+
+### Zie ook
+
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/_index.md
@@ -1,0 +1,102 @@
+---
+title: "SolidGradient.TransparencyPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SolidGradient eigenschap. Haalt de transparantiepunten op of stelt deze in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.gradient/solidgradient/transparencypoints/
+---
+{{< psd/tize >}}
+## SolidGradient.TransparencyPoints property
+
+Haalt of stelt de transparantiepunten in.
+
+```csharp
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+De transparantiepunten.
+
+## Voorbeelden
+
+Het volgende voorbeeld toont ondersteuning voor Gradient FillLayer en bewerkingsopties voor IGradientFillSettings.
+
+```csharp
+[C#]
+
+string sourceFileName = "ComplexGradientFillLayer.psd";
+string outputFile = "ComplexGradientFillLayer_output.psd";
+var im = (PsdImage)Image.Load(sourceFileName);
+using (im)
+{
+    foreach (var layer in im.Layers)
+    {
+        if (layer is FillLayer)
+        {
+            var fillLayer = (FillLayer)layer;
+            if (fillLayer.FillSettings.FillType != FillType.Gradient)
+            {
+                throw new Exception("Wrong Fill Layer");
+            }
+            var settings = (GradientFillSettings)fillLayer.FillSettings;
+            var solidGradient = (SolidGradient)settings.Gradient;
+            if (
+             Math.Abs(settings.Angle - 45) > 0.25 ||
+             settings.Dither != true ||
+             settings.AlignWithLayer != false ||
+             settings.Reverse != false ||
+             Math.Abs(settings.HorizontalOffset - (-39)) > 0.25 ||
+             Math.Abs(settings.VerticalOffset - (-5)) > 0.25 ||
+             solidGradient.TransparencyPoints.Length != 3 ||
+             solidGradient.ColorPoints.Length != 2 ||
+             Math.Abs(100.0 - solidGradient.TransparencyPoints[0].Opacity) > 0.25 ||
+             solidGradient.TransparencyPoints[0].Location != 0 ||
+             solidGradient.TransparencyPoints[0].MedianPointLocation != 50 ||
+             solidGradient.ColorPoints[0].Color != Color.FromArgb(203, 64, 140) ||
+             solidGradient.ColorPoints[0].Location != 0 ||
+             solidGradient.ColorPoints[0].MedianPointLocation != 50)
+            {
+                throw new Exception("Gradient Fill was not read correctly");
+            }
+            settings.Angle = 0.0;
+            settings.Dither = false;
+            settings.AlignWithLayer = true;
+            settings.Reverse = true;
+            settings.HorizontalOffset = 25;
+            settings.VerticalOffset = -15;
+            var colorPoints = new List<IGradientColorPoint>(solidGradient.ColorPoints);
+            var transparencyPoints = new List<IGradientTransparencyPoint>(solidGradient.TransparencyPoints);
+            colorPoints.Add(new GradientColorPoint()
+            {
+                Color = Color.Violet,
+                Location = 4096,
+                MedianPointLocation = 75
+            });
+            colorPoints[1].Location = 3000;
+            transparencyPoints.Add(new GradientTransparencyPoint()
+            {
+                Opacity = 80.0,
+                Location = 4096,
+                MedianPointLocation = 25
+            });
+            transparencyPoints[2].Location = 3000;
+            solidGradient.ColorPoints = colorPoints.ToArray();
+            solidGradient.TransparencyPoints = transparencyPoints.ToArray();
+            fillLayer.Update();
+            im.Save(outputFile, new PsdOptions(im));
+            break;
+        }
+    }
+}
+```
+
+### Zie ook
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [SolidGradient](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Gradient](../../../aspose.psd.fileformats.psd.layers.gradient/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/_index.md
@@ -1,0 +1,45 @@
+---
+title: "BlendingOptions.AreEffectsEnabled"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BlendingOptions-eigenschap. Haalt op of stelt de zichtbaarheid van alle laageffecten in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/blendingoptions/areeffectsenabled/
+---
+{{< psd/tize >}}
+## BlendingOptions.AreEffectsEnabled property
+
+Haalt op of stelt de zichtbaarheid van alle laageffecten in.
+
+```csharp
+public bool AreEffectsEnabled { get; set; }
+```
+
+## Voorbeelden
+
+Toont hoe laageffecten in of uit te schakelen met de AreEffectsEnabled-eigenschap.
+
+```csharp
+[C#]
+
+string srcFile = "2485.psd";
+string outputOnFile = "on_2485.png";
+string outputOffFile = "off_2485.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    psdImage.Save(outputOnFile);
+
+    psdImage.Layers[1].BlendingOptions.AreEffectsEnabled = false;
+
+    psdImage.Save(outputOffFile);
+}
+```
+
+### Zie ook
+
+* class [BlendingOptions](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "ColorOverlayEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ColorOverlayEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/coloroverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## ColorOverlayEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [ColorOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "DropShadowEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "DropShadowEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 130
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/dropshadoweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## DropShadowEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [DropShadowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "GradientOverlayEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GradientOverlayEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/gradientoverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## GradientOverlayEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [GradientOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/_index.md
@@ -1,0 +1,75 @@
+---
+title: "ILayerEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ILayerEffect method. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/ilayereffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## ILayerEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+## Voorbeelden
+
+Toont hoe je de grenzen van een laag met effecten kunt verkrijgen en deze kunt exporteren met de juiste grootte.
+
+```csharp
+[C#]
+
+string srcFile = "1958.psd";
+string outputFile = "out_1958.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    var layer1 = psdImage.Layers[1];
+
+    var layerBoudns = layer1.Bounds;
+    foreach (var effect in layer1.BlendingOptions.Effects)
+    {
+        layerBoudns = Rectangle.Union(
+            layerBoudns,
+            effect.GetEffectBounds(layer1.Bounds, psdImage.GlobalAngle));
+    }
+
+    Rectangle boundsToExport = Rectangle.Empty; // The default value is to save only the layer with effects.
+                                                // boundsToExport = psdImage.Bounds; // Om op te slaan binnen de PsdImage-grenzen op de oorspronkelijke laaglocatie
+
+    layer1.Save(
+        outputFile,
+        new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha },
+        boundsToExport);
+
+    using (var imgStream = new FileStream(outputFile, FileMode.Open))
+    {
+        var loadedLayer = new Layer(imgStream);
+        if (loadedLayer.Size == layerBoudns.Size)
+        {
+            System.Console.WriteLine("The size is calculated correctly.");
+        }
+    }
+}
+```
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* interface [ILayerEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "InnerShadowEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "InnerShadowEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/innershadoweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## InnerShadowEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [InnerShadowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Enum LayerEffectsTypes"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerEffects.LayerEffectsTypes enum. Laagmengseffecten"
+type: docs
+weight: 2360
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/layereffectstypes/
+---
+{{< psd/tize >}}
+## LayerEffectsTypes enumeration
+
+Laagmengseffecten.
+
+```csharp
+public enum LayerEffectsTypes
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| DropShadow | `0` | De slagschaduw. |
+| OuterGlow | `1` | De buitenste gloed. |
+| PatternOverlay | `2` | De patroonoverlay. |
+| GradientOverlay | `3` | De gradientoverlay. |
+| ColorOverlay | `4` | De kleurenoverlay. |
+| Satin | `5` | Het satijnen Effect Type. |
+| InnerGlow | `6` | De binnenste gloed. |
+| InnerShadow | `7` | De binnenste schaduw. |
+| Stroke | `8` | De lijn. |
+| BevelEmboss | `9` | De bevel emboss. |
+
+## Voorbeelden
+
+De volgende code toont ondersteuning van de ILayerEffect.EffectType-eigenschap.
+
+```csharp
+[C#]
+
+string inputFile = "input.psd";
+string outputWithout = "outputWithout.png";
+string outputWith = "outputWith.png";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(inputFile, new LoadOptions()))
+{
+    psdImage.Save(outputWithout, new PngOptions());
+
+    Layer workLayer = psdImage.Layers[1];
+
+    DropShadowEffect dropShadowEffect = workLayer.BlendingOptions.AddDropShadow();
+    dropShadowEffect.Distance = 0;
+    dropShadowEffect.Size = 8;
+    dropShadowEffect.Opacity = 20;
+
+    foreach (ILayerEffect iEffect in workLayer.BlendingOptions.Effects)
+    {
+        if (iEffect.EffectType == LayerEffectsTypes.DropShadow)
+        {
+            // het werd opgevangen
+            psdImage.Save(outputWith, new PngOptions());
+        }
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "OuterGlowEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "OuterGlowEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 140
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/outergloweffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## OuterGlowEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [OuterGlowEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "PatternOverlayEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PatternOverlayEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/patternoverlayeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## PatternOverlayEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [PatternOverlayEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/_index.md
@@ -1,0 +1,34 @@
+---
+title: "StrokeEffect.GetEffectBounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeEffect-methode. Berekent en haalt de grenzen van effectpixels op basis van de grenzen van invoerlaagpixels"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.layereffects/strokeeffect/geteffectbounds/
+---
+{{< psd/tize >}}
+## StrokeEffect.GetEffectBounds method
+
+Berekent en haalt de grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+```csharp
+public Rectangle GetEffectBounds(Rectangle layerBounds, int globalAngle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| layerBounds | Rechthoek | De grenzen van de laagpixels. |
+| globalAngle | Int32 | De globale hoek om de globale lichthoek te berekenen. |
+
+### Retourwaarde
+
+De grenzen van effectpixels op basis van de grenzen van de invoerlaagpixels.
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [StrokeEffect](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerEffects](../../../aspose.psd.fileformats.psd.layers.layereffects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/_index.md
@@ -1,0 +1,142 @@
+---
+title: "Interface IStrokeSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.IStrokeSettings interface. Stroke-instellingen van vormen"
+type: docs
+weight: 3390
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/
+---
+{{< psd/tize >}}
+## IStrokeSettings interface
+
+Stroke-instellingen van vormen.
+
+```csharp
+public interface IStrokeSettings
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Enabled](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/) { get; set; } | Stroke is ingeschakeld. |
+| [Fill](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/) { get; set; } | Haalt op of stelt de vulinstellingen van de Stroke in. |
+| [LineAlignment](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/) { get; set; } | Haalt op of stelt de uitlijning van de Stroke-stijllijn in. |
+| [LineCap](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/) { get; set; } | Stroke-lijnkaptype. |
+| [LineDashSet](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/) { get; set; } | Haalt op of stelt een array van lijnstreepjes in. |
+| [LineJoin](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/) { get; set; } | Streeklijnverbindingstype. |
+| [Size](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/) { get; set; } | Streeklijndikte. |
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.Enabled"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings eigenschap. Stroke is ingeschakeld"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/enabled/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Enabled property
+
+Stroke is ingeschakeld.
+
+```csharp
+public bool Enabled { get; set; }
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.Fill"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings-eigenschap. Haalt op of stelt de vulinstellingen van de stroke in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/fill/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Fill property
+
+Haalt op of stelt de vulinstellingen van de Stroke in.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Zie ook
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineAlignment"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings eigenschap. Haalt op of stelt de uitlijning van de Stroke-stijl in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linealignment/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineAlignment property
+
+Haalt op of stelt de uitlijning van de Stroke-stijllijn in.
+
+```csharp
+public StrokePosition LineAlignment { get; set; }
+```
+
+### Zie ook
+
+* enum [StrokePosition](../../../aspose.psd.fileformats.psd.layers.layereffects/strokeposition/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineCap"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings-eigenschap. Type van de lijnkap van de stroke"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linecap/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineCap property
+
+Stroke-lijnkaptype.
+
+```csharp
+public LineCapType LineCap { get; set; }
+```
+
+### Zie ook
+
+* enum [LineCapType](../../linecaptype/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.LineDashSet"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings eigenschap. Haalt op of stelt een array van lijnstreepjes in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linedashset/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineDashSet property
+
+Haalt op of stelt een array van lijnstreepjes in.
+
+```csharp
+public double[] LineDashSet { get; set; }
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IStrokeSettings.LineJoin"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings-eigenschap. Type van de lijnverbinding van de stroke"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/linejoin/
+---
+{{< psd/tize >}}
+## IStrokeSettings.LineJoin property
+
+Streeklijnverbindingstype.
+
+```csharp
+public LineJoinType LineJoin { get; set; }
+```
+
+### Zie ook
+
+* enum [LineJoinType](../../linejointype/)
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IStrokeSettings.Size"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IStrokeSettings eigenschap. Stroke-lijndikte"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/size/
+---
+{{< psd/tize >}}
+## IStrokeSettings.Size property
+
+Streeklijndikte.
+
+```csharp
+public double Size { get; set; }
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/_index.md
@@ -1,0 +1,126 @@
+---
+title: "Klasse StrokeSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.StrokeSettings klasse. Stroke settings of Shapes"
+type: docs
+weight: 3420
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/
+---
+{{< psd/tize >}}
+## StrokeSettings class
+
+Stroke-instellingen van vormen.
+
+```csharp
+public class StrokeSettings : IStrokeSettings
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [StrokeSettings](strokesettings/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Enabled](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/) { get; set; } | Geeft of stelt in of Stroke is ingeschakeld. |
+| [Fill](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/) { get; set; } | Haalt op of stelt de vulinstellingen van de Stroke in. |
+| [LineAlignment](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/) { get; set; } | Haalt op of stelt de uitlijning van de Stroke-stijllijn in. |
+| [LineCap](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/) { get; set; } | Geeft of stelt het type Stroke-lijnkap in. |
+| [LineDashSet](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/) { get; set; } | Haalt op of stelt een array van lijnstreepjes in. |
+| [LineJoin](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/) { get; set; } | Geeft of stelt het type Stroke-lijnverbinding in. |
+| [Size](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/) { get; set; } | Geeft of stelt de breedte van de Stroke-lijn in. |
+
+## Voorbeelden
+
+De volgende code demonstreert het renderen van Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Controleer gewijzigde gegevens.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../istrokesettings/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.Enabled"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt in of Stroke is ingeschakeld"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/enabled/
+---
+{{< psd/tize >}}
+## StrokeSettings.Enabled property
+
+Geeft of stelt in of Stroke is ingeschakeld.
+
+```csharp
+public bool Enabled { get; set; }
+```
+
+### Zie ook
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.Fill"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt de vulinstellingen van de Stroke in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/fill/
+---
+{{< psd/tize >}}
+## StrokeSettings.Fill property
+
+Haalt op of stelt de vulinstellingen van de Stroke in.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Zie ook
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineAlignment"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt de lijnuitlijning van de Stroke-stijl in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linealignment/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineAlignment property
+
+Haalt op of stelt de uitlijning van de Stroke-stijllijn in.
+
+```csharp
+public StrokePosition LineAlignment { get; set; }
+```
+
+### Zie ook
+
+* enum [StrokePosition](../../../aspose.psd.fileformats.psd.layers.layereffects/strokeposition/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineCap"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt het type lijnkap van de Stroke in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linecap/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineCap property
+
+Geeft of stelt het type Stroke-lijnkap in.
+
+```csharp
+public LineCapType LineCap { get; set; }
+```
+
+### Zie ook
+
+* enum [LineCapType](../../linecaptype/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.LineDashSet"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt of stelt een array van lijnonderbrekingen in"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linedashset/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineDashSet property
+
+Haalt op of stelt een array van lijnstreepjes in.
+
+```csharp
+public double[] LineDashSet { get; set; }
+```
+
+### Zie ook
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/_index.md
@@ -1,0 +1,25 @@
+---
+title: "StrokeSettings.LineJoin"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt het type lijnverbinding van de Stroke in"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/linejoin/
+---
+{{< psd/tize >}}
+## StrokeSettings.LineJoin property
+
+Geeft of stelt het type Stroke-lijnverbinding in.
+
+```csharp
+public LineJoinType LineJoin { get; set; }
+```
+
+### Zie ook
+
+* enum [LineJoinType](../../linejointype/)
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.Size"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings eigenschap. Haalt op of stelt de lijndikte van de Stroke in"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/size/
+---
+{{< psd/tize >}}
+## StrokeSettings.Size property
+
+Geeft of stelt de breedte van de Stroke-lijn in.
+
+```csharp
+public double Size { get; set; }
+```
+
+### Zie ook
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/_index.md
@@ -1,0 +1,24 @@
+---
+title: "StrokeSettings.StrokeSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StrokeSettings constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/strokesettings/strokesettings/
+---
+{{< psd/tize >}}
+## StrokeSettings constructor
+
+De standaardconstructor.
+
+```csharp
+public StrokeSettings()
+```
+
+### Zie ook
+
+* class [StrokeSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/_index.md
@@ -1,0 +1,101 @@
+---
+title: "Klasse VscgResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources.VscgResource klasse. Vector Stroke Content Data resource"
+type: docs
+weight: 3430
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/
+---
+{{< psd/tize >}}
+## VscgResource class
+
+Vector Stroke Content Data resource.
+
+```csharp
+public class VscgResource : LayerResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [VscgResource](vscgresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/) { get; } | Haalt op of stelt de array van structuuritems in. **Warning:** De `Items` arraywaarden moeten overeenkomen met de `KeyForData` eigenschap, die het type vullingsinstellingen bepaalt dat is opgeslagen in de structuren binnen `Items`. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| [KeyForData](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/) { get; } | Haalt de gehele sleutel op die definieert welk type vullingsinstellingen is opgeslagen in de resource: * Color - 0x536f436f - SoCoResource.TypeToolKey * Gradient - 0x4764466c - GdFlResource.TypeToolKey * Pattern - 0x5074466c - PtFlResource.TypeToolKey Waarschuwing! De waarde van eigenschap KeyForData moet overeenkomen met het type vullingsinstellingen dat is opgeslagen in Items-structuren. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van VscgResource.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeInternalFill_src.psd";
+string outputFile = "StrokeInternalFill_res.psd";
+
+void AreEqual(double expected, double current, double tolerance = 0.1)
+{
+    if (Math.Abs(expected - current) > tolerance)
+    {
+        throw new Exception(
+            $"Values is not equal.\nExpected:{expected}\nResult:{current}\nDifference:{expected - current}");
+    }
+}
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(89.8, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(219.6, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(34.2, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+
+    ((DoubleStructure)rgbColorStructure.Structures[0]).Value = 255d; // Red
+    ((DoubleStructure)rgbColorStructure.Structures[1]).Value = 0d; // Green
+    ((DoubleStructure)rgbColorStructure.Structures[2]).Value = 0d; // Blue
+
+    image.Save(outputFile);
+}
+
+// wijzigingen controleren
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(255, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+}
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/_index.md
@@ -1,0 +1,76 @@
+---
+title: "VscgResource.Items"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-eigenschap. Haalt op of stelt de array van structuuritems in. Waarschuwing De Items-arraywaarden moeten overeenkomen met de KeyForData‑eigenschap die het type vulinstellingen bepaalt dat is opgeslagen in de structuren binnen Items"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/items/
+---
+{{< psd/tize >}}
+## VscgResource.Items property
+
+Haalt op of stelt de array van structuuritems in. **Warning:** De `Items` arraywaarden moeten overeenkomen met de `KeyForData` eigenschap, die het type vullingsinstellingen bepaalt dat is opgeslagen in de structuren binnen `Items`.
+
+```csharp
+public OSTypeStructure[] Items { get; }
+```
+
+### Property Value
+
+De array van [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/) items.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van VscgResource.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeInternalFill_src.psd";
+string outputFile = "StrokeInternalFill_res.psd";
+
+void AreEqual(double expected, double current, double tolerance = 0.1)
+{
+    if (Math.Abs(expected - current) > tolerance)
+    {
+        throw new Exception(
+            $"Values is not equal.\nExpected:{expected}\nResult:{current}\nDifference:{expected - current}");
+    }
+}
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(89.8, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(219.6, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(34.2, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+
+    ((DoubleStructure)rgbColorStructure.Structures[0]).Value = 255d; // Red
+    ((DoubleStructure)rgbColorStructure.Structures[1]).Value = 0d; // Green
+    ((DoubleStructure)rgbColorStructure.Structures[2]).Value = 0d; // Blue
+
+    image.Save(outputFile);
+}
+
+// wijzigingen controleren
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    VscgResource vscgResource = (VscgResource)image.Layers[1].Resources[0];
+    DescriptorStructure rgbColorStructure = (DescriptorStructure)vscgResource.Items[0];
+
+    AreEqual(255, ((DoubleStructure)rgbColorStructure.Structures[0]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[1]).Value);
+    AreEqual(0, ((DoubleStructure)rgbColorStructure.Structures[2]).Value);
+}
+```
+
+### Zie ook
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Key"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-eigenschap. Haalt de sleutel van de laagresource op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/key/
+---
+{{< psd/tize >}}
+## VscgResource.Key property
+
+Haalt de laagresource-sleutel op.
+
+```csharp
+public override int Key { get; }
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.KeyForData"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-eigenschap. Haalt de gehele sleutel op die bepaalt welk type vulinstellingen is opgeslagen in de resource  Color  0x536f436f  SoCoResource.TypeToolKey  Gradient  0x4764466c  GdFlResource.TypeToolKey  Pattern  0x5074466c  PtFlResource.TypeToolKey Waarschuwing De waarde van de eigenschap KeyForData moet overeenkomen met het type vulinstellingen dat is opgeslagen in Items-structuren"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/keyfordata/
+---
+{{< psd/tize >}}
+## VscgResource.KeyForData property
+
+Haalt de gehele sleutel op die definieert welk type vullingsinstellingen is opgeslagen in de resource: * Color - 0x536f436f - SoCoResource.TypeToolKey * Gradient - 0x4764466c - GdFlResource.TypeToolKey * Pattern - 0x5074466c - PtFlResource.TypeToolKey Waarschuwing! De waarde van eigenschap KeyForData moet overeenkomen met het type vullingsinstellingen dat is opgeslagen in Items-structuren.
+
+```csharp
+public int KeyForData { get; }
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-eigenschap. Haalt de lengte van de laagresource op in bytes"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/length/
+---
+{{< psd/tize >}}
+## VscgResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource eigenschap. Haalt de psd-versie op"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/psdversion/
+---
+{{< psd/tize >}}
+## VscgResource.PsdVersion property
+
+Haalt de psd-versie op.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "VscgResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/save/
+---
+{{< psd/tize >}}
+## VscgResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.Signature"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource eigenschap. Haalt de handtekening op"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/signature/
+---
+{{< psd/tize >}}
+## VscgResource.Signature property
+
+Haalt de handtekening op.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource-veld. De type‑tool‑infosleutel"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/typetoolkey/
+---
+{{< psd/tize >}}
+## VscgResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VscgResource.VscgResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VscgResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vscgresource/vscgresource/
+---
+{{< psd/tize >}}
+## VscgResource constructor
+
+De standaardconstructor.
+
+```csharp
+public VscgResource()
+```
+
+### Zie ook
+
+* class [VscgResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/_index.md
@@ -1,0 +1,109 @@
+---
+title: "VstkResource.FillSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VstkResource eigenschap. Haalt of stelt de vulinstellingen van de Stroke in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.strokeresources/vstkresource/fillsettings/
+---
+{{< psd/tize >}}
+## VstkResource.FillSettings property
+
+Haalt op of stelt de vulinstellingen van de Stroke in.
+
+```csharp
+public IFillSettings FillSettings { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert het renderen van Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Controleer gewijzigde gegevens.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [VstkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.StrokeResources](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/_index.md
@@ -1,0 +1,124 @@
+---
+title: "Klasse NameStructure"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures.NameStructure klasse. De Name-structuursleutel 0x6E616D65, die 'name' in ASCII spelt, is een eenvoudige structuur die wordt gebruikt om een Unicode- of Pascal-stijl tekenreeks op te slaan die de naam van een element vertegenwoordigt, zoals een laagpad of aanpassing."
+type: docs
+weight: 3580
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/
+---
+{{< psd/tize >}}
+## NameStructure class
+
+De Name-structuur (sleutel: 0x6E616D65, die "name" in ASCII spelt) is een eenvoudige structuur die wordt gebruikt om een Unicode- of Pascal-stijl tekenreeks op te slaan die de naam van een element vertegenwoordigt, zoals een laag, pad of aanpassing.
+
+```csharp
+public sealed class NameStructure : OSTypeStructure
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [NameStructure](namestructure/)(ClassID) | Initialiseert een nieuw exemplaar van de `NameStructure`-klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Key](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/) { get; } | Haalt de sleutel op. |
+| [KeyName](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/keyname/) { get; set; } | Haalt of stelt de sleutelnaam in. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/) { get; } | Haalt de lengte in bytes op van [`OSTypeStructure`](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/). |
+| [Value](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/) { get; set; } | Haalt of stelt de waarde van een Name-structuur in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| virtual [GetHeaderLength](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/getheaderlength/)() | Haalt de headerlengte op. |
+| [Save](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/save/)(StreamContainer) | Slaat de structuur op in de opgegeven streamcontainer. |
+| [SaveWithoutKeyName](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/savewithoutkeyname/)(StreamContainer) | Slaat de structuur op in de opgegeven streamcontainer. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [StructureKey](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/) | De Name-structuursleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van NameStructure.
+
+```csharp
+[C#]
+
+string inputFile = "Mixer_ipad_Hand_W_crash.psd";
+string outputFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(inputFile, new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    //// Bestand is succesvol geladen
+
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+
+    // Sla het testbestand op zonder wijzigingen
+    psdImage.Save(outputFile);
+
+    //// Bestand moet in PS worden geopend zonder fouten
+}
+
+// Controleer of de structuren van belichtingseffecten correct zijn opgeslagen
+using (var psdImage = (PsdImage)Image.Load(
+           outputFile,
+           new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [OSTypeStructure](../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.Key"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NameStructure-eigenschap. Haalt de sleutel op."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/key/
+---
+{{< psd/tize >}}
+## NameStructure.Key property
+
+Haalt de sleutel op.
+
+```csharp
+public override int Key { get; }
+```
+
+### Zie ook
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NameStructure-eigenschap. Haalt de OSTypeStructure-lengte op in bytes."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/length/
+---
+{{< psd/tize >}}
+## NameStructure.Length property
+
+Haalt de [`OSTypeStructure`](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/) lengte op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/_index.md
@@ -1,0 +1,29 @@
+---
+title: "NameStructure.NameStructure"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NameStructure-constructor. Initialiseert een nieuw exemplaar van de NameStructure-klasse."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/namestructure/
+---
+{{< psd/tize >}}
+## NameStructure constructor
+
+Initialiseert een nieuw exemplaar van de [`NameStructure`](../) klasse.
+
+```csharp
+public NameStructure(ClassID keyName)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| keyName | ClassID | De sleutelnaam. |
+
+### Zie ook
+
+* class [ClassID](../../../aspose.psd.fileformats.psd.layers.layerresources/classid/)
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "NameStructure.StructureKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NameStructure-veld. De sleutel van de Name-structuur."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/structurekey/
+---
+{{< psd/tize >}}
+## NameStructure.StructureKey field
+
+De Name-structuursleutel.
+
+```csharp
+public const int StructureKey;
+```
+
+### Zie ook
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/_index.md
@@ -1,0 +1,95 @@
+---
+title: "NameStructure.Value"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "NameStructure-eigenschap. Haalt of stelt de waarde van een Name-structuur in."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/namestructure/value/
+---
+{{< psd/tize >}}
+## NameStructure.Value property
+
+Haalt of stelt de waarde van een Name-structuur in.
+
+```csharp
+public string Value { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van NameStructure.
+
+```csharp
+[C#]
+
+string inputFile = "Mixer_ipad_Hand_W_crash.psd";
+string outputFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(inputFile, new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    //// Bestand is succesvol geladen
+
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+
+    // Sla het testbestand op zonder wijzigingen
+    psdImage.Save(outputFile);
+
+    //// Bestand moet in PS worden geopend zonder fouten
+}
+
+// Controleer of de structuren van belichtingseffecten correct zijn opgeslagen
+using (var psdImage = (PsdImage)Image.Load(
+           outputFile,
+           new PsdLoadOptions { DataRecoveryMode = DataRecoveryMode.MaximalRecover }))
+{
+    SmartObjectLayer layer = (SmartObjectLayer)psdImage.Layers[3];
+    SoLdResource resource = (SoLdResource)layer.Resources[9];
+
+    DescriptorStructure struct1 = (DescriptorStructure)resource.Items[15];
+    ListStructure struct2 = (ListStructure)struct1.Structures[5];
+    DescriptorStructure struct3 = (DescriptorStructure)struct2.Types[0];
+    DescriptorStructure struct4 = (DescriptorStructure)struct3.Structures[6];
+    ReferenceStructure struct5 = (ReferenceStructure)struct4.Structures[8];
+    NameStructure nameStructure = (NameStructure)struct5.Items[0];
+
+    AssertIsNotNull(nameStructure);
+    AssertAreEqual(37, nameStructure.Length);
+    AssertAreEqual("None\0", nameStructure.Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+void AssertIsNotNull(object actual)
+{
+    if (actual == null)
+    {
+        throw new Exception("Object is null.");
+    }
+}
+```
+
+### Zie ook
+
+* class [NameStructure](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources.TypeToolInfoStructures](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Klasse AbddResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.AbddResource klasse. De Artboard-informatiedata"
+type: docs
+weight: 2490
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/
+---
+{{< psd/tize >}}
+## AbddResource class
+
+De Artboard-informatiedata.
+
+```csharp
+public sealed class AbddResource : BaseArtboardInfoResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AbddResource](abddresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Haalt op of stelt de items van [`OSTypeStructure`](../ostypestructure/) in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "AbddResource.AbddResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AbddResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/abddresource/
+---
+{{< psd/tize >}}
+## AbddResource constructor
+
+De standaardconstructor.
+
+```csharp
+public AbddResource()
+```
+
+### Zie ook
+
+* class [AbddResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "AbddResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "AbddResource veld. De type-tool-infosleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/abddresource/typetoolkey/
+---
+{{< psd/tize >}}
+## AbddResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [AbddResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/_index.md
@@ -1,0 +1,96 @@
+---
+title: "Class ArtBResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ArtBResource class. De artboard-informatiedata voor Resources"
+type: docs
+weight: 2520
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/
+---
+{{< psd/tize >}}
+## ArtBResource class
+
+De artboard-informatiedata voor [`Resources`](../../aspose.psd.fileformats.psd.layers/layer/resources/).
+
+```csharp
+public sealed class ArtBResource : BaseArtboardInfoResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ArtBResource](artbresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ArtboardBackgroundType](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/) { get; set; } | Haalt of stelt de [`ArtboardBackgroundType`](./artboardbackgroundtype/) in. |
+| [Color](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/) { get; set; } | Haalt of stelt de [`Color`](./color/) in. |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Haalt op of stelt de items van [`OSTypeStructure`](../ostypestructure/) in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ArtBResource.ArtboardBackgroundType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtBResource property. Haalt de ArtboardBackgroundType op of stelt deze in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artboardbackgroundtype/
+---
+{{< psd/tize >}}
+## ArtBResource.ArtboardBackgroundType property
+
+Haalt de `ArtboardBackgroundType` op of stelt deze in
+
+```csharp
+public int ArtboardBackgroundType { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning voor het exporteren van ArtboardLayer als afzonderlijke afbeeldingen en als één afbeelding.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Zie ook
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtBResource.ArtBResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtBResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/artbresource/
+---
+{{< psd/tize >}}
+## ArtBResource constructor
+
+De standaardconstructor.
+
+```csharp
+public ArtBResource()
+```
+
+### Zie ook
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ArtBResource.Color"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtBResource property. Haalt de kleur op of stelt deze in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/color/
+---
+{{< psd/tize >}}
+## ArtBResource.Color property
+
+Haalt de `Color` op of stelt deze in
+
+```csharp
+public Color Color { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning voor het exporteren van ArtboardLayer als afzonderlijke afbeeldingen en als één afbeelding.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtBResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtBResource field. De type tool info sleutel"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artbresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ArtBResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [ArtBResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Klasse ArtDResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ArtDResource klasse. De Artboard-informatiedata voor GlobalLayerResources"
+type: docs
+weight: 2530
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/
+---
+{{< psd/tize >}}
+## ArtDResource class
+
+De Artboard-informatiedata voor [`GlobalLayerResources`](../../aspose.psd.fileformats.psd/psdimage/globallayerresources/).
+
+```csharp
+public sealed class ArtDResource : BaseArtboardInfoResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ArtDResource](artdresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Haalt op of stelt de items van [`OSTypeStructure`](../ostypestructure/) in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [BaseArtboardInfoResource](../baseartboardinforesource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtDResource.ArtDResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtDResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/artdresource/
+---
+{{< psd/tize >}}
+## ArtDResource constructor
+
+De standaardconstructor.
+
+```csharp
+public ArtDResource()
+```
+
+### Zie ook
+
+* class [ArtDResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtDResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtDResource-veld. De type tool info-sleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/artdresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ArtDResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [ArtDResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/_index.md
@@ -1,0 +1,82 @@
+---
+title: "Klasse BaseArtboardInfoResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseArtboardInfoResource class. De Artboard-informatiedataresource"
+type: docs
+weight: 2540
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource class
+
+De Artboard-informatiedataresource.
+
+```csharp
+public abstract class BaseArtboardInfoResource : LayerResource
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Items](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/) { get; set; } | Haalt op of stelt de items van [`OSTypeStructure`](../ostypestructure/) in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/_index.md
@@ -1,0 +1,66 @@
+---
+title: "BaseArtboardInfoResource.Items"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseArtboardInfoResource eigenschap. Haalt of stelt de OSTypeStructure-items in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/items/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Items property
+
+Haalt of stelt de [`OSTypeStructure`](../../ostypestructure/) items in.
+
+```csharp
+public OSTypeStructure[] Items { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [OSTypeStructure](../../ostypestructure/)
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/_index.md
@@ -1,0 +1,22 @@
+---
+title: "BaseArtboardInfoResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseArtboardInfoResource eigenschap."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/length/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Length property
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/_index.md
@@ -1,0 +1,22 @@
+---
+title: "BaseArtboardInfoResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseArtboardInfoResource eigenschap."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/psdversion/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.PsdVersion property
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseArtboardInfoResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseArtboardInfoResource methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baseartboardinforesource/save/
+---
+{{< psd/tize >}}
+## BaseArtboardInfoResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseArtboardInfoResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/_index.md
@@ -1,0 +1,88 @@
+---
+title: "Klasse BaseFxResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseFxResource klasse. Basis-effectenresource"
+type: docs
+weight: 2550
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/
+---
+{{< psd/tize >}}
+## BaseFxResource class
+
+Basis-effectenresource
+
+```csharp
+public abstract class BaseFxResource : LayerResource
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Haalt de descriptorversie op. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van een multi-effecten resource.
+
+```csharp
+[C#]
+
+// PSD-afbeelding bevat 2 Drop Shadow-effecten.
+string sourceFile = "MultiExample.psd";
+string outputFile1 = "export1.png";
+string outputFile2 = "export2.png";
+string outputFile3 = "export3.png";
+
+using (PsdImage image = (PsdImage)Aspose.PSD.Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    // Het rendert de PSD-afbeelding met 2 Drop Shadow-effecten.
+    image.Save(outputFile1, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    var blendingOptions = image.Layers[0].BlendingOptions;
+
+    // Het voegt een derde Drop Shadow-effect toe.
+    DropShadowEffect dropShadowEffect3 = blendingOptions.AddDropShadow();
+    dropShadowEffect3.Color = Color.Red;
+    dropShadowEffect3.Distance = 50;
+    dropShadowEffect3.Angle = 0;
+
+    // Het rendert de PSD-afbeelding met 3 Drop Shadow-effecten.
+    image.Save(outputFile2, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // De imfx-resource wordt gebruikt als de laag meerdere effecten van hetzelfde type bevat.
+    var imfx = (ImfxResource)image.Layers[0].Resources[0];
+
+    // Het wist alle effecten.
+    blendingOptions.Effects = new ILayerEffect[0];
+
+    DropShadowEffect dropShadowEffect1 = blendingOptions.AddDropShadow();
+    dropShadowEffect1.Color = Color.Blue;
+    dropShadowEffect1.Distance = 10;
+
+    // Het rendert de PSD-afbeelding met 1 Drop Shadow-effect (andere werden verwijderd).
+    image.Save(outputFile3, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // De lfx2-resource wordt gebruikt als de laag niet meerdere effecten van hetzelfde type bevat.
+    var lfx2 = (Lfx2Resource)image.Layers[0].Resources[14];
+}
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BaseFxResource.DescriptorVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseFxResource eigenschap. Haalt de descriptorversie op"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/
+---
+{{< psd/tize >}}
+## BaseFxResource.DescriptorVersion property
+
+Haalt de descriptorversie op.
+
+```csharp
+public int DescriptorVersion { get; }
+```
+
+### Property Value
+
+De descriptorversie.
+
+### Zie ook
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseFxResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseFxResource eigenschap. Haalt de laagresource‑lengte op in bytes"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/
+---
+{{< psd/tize >}}
+## BaseFxResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseFxResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseFxResource methode. Slaat de resource op naar de opgegeven streamcontainer"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/
+---
+{{< psd/tize >}}
+## BaseFxResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseFxResource.Signature"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseFxResource eigenschap. Haalt de handtekening van de laagresource op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/basefxresource/signature/
+---
+{{< psd/tize >}}
+## BaseFxResource.Signature property
+
+Haalt de handtekening van de laagresource op.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Zie ook
+
+* class [BaseFxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/_index.md
@@ -1,0 +1,93 @@
+---
+title: "Klasse BaseLayerSectionResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.BaseLayerSectionResource class. Basisklasse voor laagsectie-resources"
+type: docs
+weight: 2560
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource class
+
+Basisklasse voor laagsectie-resources
+
+```csharp
+public abstract class BaseLayerSectionResource : LayerResource
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BlendModeKey](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| [SectionType](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/) { get; set; } | Haalt op of stelt het sectietype in. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+| [Subtype](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/) { get; set; } | Haalt op of stelt het subtype in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Voorbeelden
+
+De volgende code toont de klassehiërarchie van laagsectie-resources.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/_index.md
@@ -1,0 +1,110 @@
+---
+title: "BaseLayerSectionResource.BlendModeKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseLayerSectionResource eigenschap. Haalt of stelt de blend-modus sleutel in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.BlendModeKey property
+
+Haalt of stelt de blend mode key in.
+
+```csharp
+public BlendMode BlendModeKey { get; set; }
+```
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | BlendModeKey moet 4 tekens lang zijn. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+De volgende code toont de klassehiërarchie van laagsectie-resources.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Zie ook
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "BaseLayerSectionResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseLayerSectionResource eigenschap. Haalt de lengte van de laagresource op in bytes"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "BaseLayerSectionResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseLayerSectionResource methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/_index.md
@@ -1,0 +1,104 @@
+---
+title: "BaseLayerSectionResource.SectionType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseLayerSectionResource eigenschap. Haalt de sectietype op of stelt deze in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.SectionType property
+
+Haalt op of stelt het sectietype in.
+
+```csharp
+public LayerSectionType SectionType { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+De volgende code toont de klassehiërarchie van laagsectie-resources.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Zie ook
+
+* enum [LayerSectionType](../../layersectiontype/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/_index.md
@@ -1,0 +1,104 @@
+---
+title: "BaseLayerSectionResource.Subtype"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "BaseLayerSectionResource eigenschap. Haalt de subtype op of stelt deze in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/
+---
+{{< psd/tize >}}
+## BaseLayerSectionResource.Subtype property
+
+Haalt op of stelt het subtype in.
+
+```csharp
+public LayerSectionSubtype Subtype { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+De volgende code toont de klassehiërarchie van laagsectie-resources.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as LayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[3].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).SectionType, LayerSectionType.SectionDivider);
+
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Length, 4);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).BlendModeKey, BlendMode.Absent);
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as BaseLayerSectionResource).Subtype, LayerSectionSubtype.NotUsed);
+}
+
+File.Delete(outFile);
+```
+
+### Zie ook
+
+* enum [LayerSectionSubtype](../../layersectionsubtype/)
+* class [BaseLayerSectionResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.ColorModel"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Kleurmodel  RGB/HSB/LAB RGBC/HSBl/LbCl"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/colormodel/
+---
+{{< psd/tize >}}
+## GdFlResource.ColorModel property
+
+Kleurmodel - RGB/HSB/LAB ("RGBC"/"HSBl"/"LbCl").
+
+```csharp
+public string ColorModel { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Modus voor deze gradiënt. Bepaalt het type gradiënt  Solid/Noise  CstS/ClNs"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/gradientmode/
+---
+{{< psd/tize >}}
+## GdFlResource.GradientMode property
+
+Modus voor deze gradient. Bepaalt 'Gradient Type' = 'Solid/Noise' = "CstS"/"ClNs".
+
+```csharp
+public string GradientMode { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GdFlResource.InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Haalt op of stelt de interpolatiemethode voor de gradiënt in."
+type: docs
+weight: 130
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/interpolationmethod/
+---
+{{< psd/tize >}}
+## GdFlResource.InterpolationMethod property
+
+Haalt een waarde op of stelt de interpolatiemethode voor de gradient in.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [InterpolationMethod](../../../aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GdFlResource.MaximumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Maximale kleur van PixelDataFormat"
+type: docs
+weight: 150
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/maximumcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.MaximumColor property
+
+Maximale kleur van PixelDataFormat.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GdFlResource.MinimumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Minimumkleur van PixelDataFormat"
+type: docs
+weight: 160
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/minimumcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.MinimumColor property
+
+Minimumkleur van PixelDataFormat.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.RndNumberSeed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Het willekeurige getalzaad dat wordt gebruikt om kleuren te genereren voor ruisgradiënt."
+type: docs
+weight: 180
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/rndnumberseed/
+---
+{{< psd/tize >}}
+## GdFlResource.RndNumberSeed property
+
+De seed voor willekeurige getallen die wordt gebruikt om kleuren te genereren voor Noise-gradient.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.Roughness"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Ruwheidsfactor"
+type: docs
+weight: 190
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/roughness/
+---
+{{< psd/tize >}}
+## GdFlResource.Roughness property
+
+Ruwheidsfactor.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.ShowTransparency"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Vlag voor het tonen van transparantie"
+type: docs
+weight: 210
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/showtransparency/
+---
+{{< psd/tize >}}
+## GdFlResource.ShowTransparency property
+
+Vlag voor het tonen van transparantie.
+
+```csharp
+public bool ShowTransparency { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GdFlResource.UseVectorColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GdFlResource eigenschap. Vlag voor het gebruik van vectorkleur"
+type: docs
+weight: 230
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/gdflresource/usevectorcolor/
+---
+{{< psd/tize >}}
+## GdFlResource.UseVectorColor property
+
+Vlag voor het gebruiken van vectorkleur.
+
+```csharp
+public bool UseVectorColor { get; set; }
+```
+
+### Zie ook
+
+* class [GdFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/_index.md
@@ -1,0 +1,118 @@
+---
+title: "Klasse GrdmResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.GrdmResource klasse. Klasse GrdmResource. Bevat informatie over de GradientMap-laag."
+type: docs
+weight: 2770
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/
+---
+{{< psd/tize >}}
+## GrdmResource class
+
+Klasse GrdmResource. Bevat informatie over de Gradient-Map-laag.
+
+```csharp
+public class GrdmResource : AdjustmentLayerResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GrdmResource](grdmresource/)(int) | Initialiseert een nieuw exemplaar van de `GrdmResource`-klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorModel](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/) { get; set; } | Kleurmodel. Wanneer 'Gradient type' = 'Noise', kunnen we 'Color Model' toewijzen aan RGB/SHB/LAB (3/4/6). |
+| [ColorPoints](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/) { get; set; } | Haalt of stelt de kleurpunten in. |
+| [Dither](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/) { get; set; } | Is de gradient geditherd. |
+| [ExpansionCount](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/) { get; set; } | Uitbreidingsaantal ( = 2 voor Photoshop 6.0). |
+| [GradientMode](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/) { get; set; } | Modus voor deze gradient bepaalt 'Gradient Type' = 'Solid/Noise' (0/1). |
+| [GradientName](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/) { get; set; } | Naam van de gradient: Unicode‑string, opgevuld. |
+| [Interpolation](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/) { get; set; } | Interpolatie. Bepaalt gladheid, wanneer 'Gradient Type' = 'Solid' (GradientMode = 0). |
+| [InterpolationMethod](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/) { get; set; } | Haalt een waarde op of stelt de interpolatiemethode voor de gradient in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| [MaximumColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/) { get; set; } | Maximumkleur van PixelDataFormat.Rgba64Bpp-formaat. Kleur heeft ARGB-kanalen, elk kanaal is 16‑bit. |
+| [MinimumColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/) { get; set; } | Minkleur van PixelDataFormat.Rgba64Bpp-formaat. Kleur heeft ARGB-kanalen, elk kanaal is 16‑bit. |
+| override [PsdVersion](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor deze resource. Versie 3 is nodig wanneer de interpolatiemethode expliciet wordt opgeslagen. |
+| [Reverse](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/) { get; set; } | Is de gradient omgekeerd. |
+| [RndNumberSeed](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/) { get; set; } | De seed voor willekeurige getallen die wordt gebruikt om kleuren te genereren voor Noise-gradient. |
+| [Roughness](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/) { get; set; } | Ruwheidsfactor Wanneer 'Gradient type' = 'Noise', kunnen we 'Roughness' (0 - 2048) toewijzen. |
+| [ShowTransparency](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/) { get; set; } | Vlag voor het tonen van transparantie Wanneer 'Gradient type' = 'Noise', kunnen we 'Add transparency' op true zetten. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+| [TransparencyPoints](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/) { get; set; } | Haalt of stelt de transparantiepunten in. |
+| [UseVectorColor](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/) { get; set; } | Vlag voor het gebruiken van vectorkleur. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/)(StreamContainer, int) | Slaat resourcegegevens op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [AdjustmentLayerResource](../adjustmentlayerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ColorModel"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Kleurmodel. Wanneer het Gradient type Noise is, kunnen we het kleurmodel toewijzen aan RGB/SHB/LAB 3/4/6"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colormodel/
+---
+{{< psd/tize >}}
+## GrdmResource.ColorModel property
+
+Kleurmodel. Wanneer 'Gradient type' = 'Noise', kunnen we 'Color Model' toewijzen aan RGB/SHB/LAB (3/4/6).
+
+```csharp
+public short ColorModel { get; set; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/_index.md
@@ -1,0 +1,79 @@
+---
+title: "GrdmResource.ColorPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Krijgt of stelt de kleurpunten"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/colorpoints/
+---
+{{< psd/tize >}}
+## GrdmResource.ColorPoints property
+
+Haalt of stelt de kleurpunten in.
+
+```csharp
+public IGradientColorPoint[] ColorPoints { get; set; }
+```
+
+### Property Value
+
+De kleurpunten.
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* interface [IGradientColorPoint](../../../aspose.psd.fileformats.psd.layers/igradientcolorpoint/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Dither"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Is gradient gedithered"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/dither/
+---
+{{< psd/tize >}}
+## GrdmResource.Dither property
+
+Is de gradient geditherd.
+
+```csharp
+public bool Dither { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ExpansionCount"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Expansie‑aantal 2 voor Photoshop 6.0"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/expansioncount/
+---
+{{< psd/tize >}}
+## GrdmResource.ExpansionCount property
+
+Uitbreidingsaantal ( = 2 voor Photoshop 6.0).
+
+```csharp
+public short ExpansionCount { get; set; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/_index.md
@@ -1,0 +1,75 @@
+---
+title: "GrdmResource.GradientMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Modus voor deze gradient Bepaalt Gradient Type Solid/Noise 0/1"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientmode/
+---
+{{< psd/tize >}}
+## GrdmResource.GradientMode property
+
+Modus voor deze gradient bepaalt 'Gradient Type' = 'Solid/Noise' (0/1).
+
+```csharp
+public GradientKind GradientMode { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [GradientKind](../../../aspose.psd.fileformats.psd.layers.gradient/gradientkind/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.GradientName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Naam van de Unicode-tekenreeks van de gradient, opgevuld"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/gradientname/
+---
+{{< psd/tize >}}
+## GrdmResource.GradientName property
+
+Naam van de gradient: Unicode‑string, opgevuld.
+
+```csharp
+public string GradientName { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GrdmResource.GrdmResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource constructor. Initialiseert een nieuw exemplaar van de GrdmResource-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/grdmresource/
+---
+{{< psd/tize >}}
+## GrdmResource constructor
+
+Initialiseert een nieuw exemplaar van de [`GrdmResource`](../) klasse.
+
+```csharp
+public GrdmResource(int psdVersion = 1)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| psdVersion | Int32 | De psd-versie van de resource. |
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Interpolation"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Interpolatie. Bepaalt de gladheid wanneer Gradient Type Solid GradientMode 0"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolation/
+---
+{{< psd/tize >}}
+## GrdmResource.Interpolation property
+
+Interpolatie. Bepaalt gladheid, wanneer 'Gradient Type' = 'Solid' (GradientMode = 0).
+
+```csharp
+public short Interpolation { get; set; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/_index.md
@@ -1,0 +1,76 @@
+---
+title: "GrdmResource.InterpolationMethod"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Krijgt of stelt de interpolatiemethode voor de gradient in"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/interpolationmethod/
+---
+{{< psd/tize >}}
+## GrdmResource.InterpolationMethod property
+
+Haalt een waarde op of stelt de interpolatiemethode voor de gradient in.
+
+```csharp
+public InterpolationMethod InterpolationMethod { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van gradientrendering met de Smooth-methode.
+
+```csharp
+[C#]
+
+string sourceFile = "GradientOverlay.psd";
+string outputFile = "output_GradientOverlay.psd";
+string outputFilePng = "output_GradientOverlay.png";
+
+var srcMethod = InterpolationMethod.Linear;
+var newMethod = InterpolationMethod.Smooth;
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var image = (PsdImage)Image.Load(sourceFile, opt))
+{
+    // Lezen
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+    AssertAreEqual(srcMethod, gradientSettings.InterpolationMethod);
+
+    // Wijzigen
+    gradientSettings.InterpolationMethod = newMethod;
+
+    image.Save(outputFile);
+    image.Save(outputFilePng, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+
+// Controleer opgeslagen gegevens
+using (var image = (PsdImage)Image.Load(outputFile, opt))
+{
+    var effect = image.Layers[1].BlendingOptions.Effects[0] as GradientOverlayEffect;
+    var gradientSettings = effect.Settings;
+
+    AssertAreEqual(newMethod, gradientSettings.InterpolationMethod);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [InterpolationMethod](../../../aspose.psd.fileformats.psd.layers.fillsettings/interpolationmethod/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Key"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Krijgt de laagresource-sleutel"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/key/
+---
+{{< psd/tize >}}
+## GrdmResource.Key property
+
+Haalt de laagresource-sleutel op.
+
+```csharp
+public override int Key { get; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Haalt de lengte van de layerresource op in bytes"
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/length/
+---
+{{< psd/tize >}}
+## GrdmResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GrdmResource.MaximumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Maximale kleur van PixelDataFormat.Rgba64Bpp‑formaat. Kleur heeft ARGB‑kanalen. Elk kanaal is 16‑bit"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/maximumcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.MaximumColor property
+
+Maximumkleur van PixelDataFormat.Rgba64Bpp-formaat. Kleur heeft ARGB-kanalen, elk kanaal is 16‑bit.
+
+```csharp
+public RawColor MaximumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "GrdmResource.MinimumColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Minimumkleur van PixelDataFormat.Rgba64Bpp-formaat. Kleur heeft ARGB-kanalen. Elk kanaal is 16‑bit"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/minimumcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.MinimumColor property
+
+Minkleur van PixelDataFormat.Rgba64Bpp-formaat. Kleur heeft ARGB-kanalen, elk kanaal is 16‑bit.
+
+```csharp
+public RawColor MinimumColor { get; set; }
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Haalt de minimale PSD‑versie op die vereist is voor deze resource. Versie 3 is nodig wanneer interpolatiemethode expliciet wordt opgeslagen"
+type: docs
+weight: 130
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/psdversion/
+---
+{{< psd/tize >}}
+## GrdmResource.PsdVersion property
+
+Haalt de minimale PSD-versie op die vereist is voor deze resource. Versie 3 is nodig wanneer de interpolatiemethode expliciet wordt opgeslagen.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Reverse"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Is gradient omgekeerd"
+type: docs
+weight: 140
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/reverse/
+---
+{{< psd/tize >}}
+## GrdmResource.Reverse property
+
+Is de gradient omgekeerd.
+
+```csharp
+public bool Reverse { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.RndNumberSeed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Het willekeurige getalzaad dat wordt gebruikt om kleuren voor Noise gradient te genereren"
+type: docs
+weight: 150
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/rndnumberseed/
+---
+{{< psd/tize >}}
+## GrdmResource.RndNumberSeed property
+
+De seed voor willekeurige getallen die wordt gebruikt om kleuren te genereren voor Noise-gradient.
+
+```csharp
+public int RndNumberSeed { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/_index.md
@@ -1,0 +1,74 @@
+---
+title: "GrdmResource.Roughness"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Ruwheidsfactor Wanneer Gradient type Noise we kunnen Roughness 0  2048 toewijzen"
+type: docs
+weight: 160
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/roughness/
+---
+{{< psd/tize >}}
+## GrdmResource.Roughness property
+
+Ruwheidsfactor Wanneer 'Gradient type' = 'Noise', kunnen we 'Roughness' (0 - 2048) toewijzen.
+
+```csharp
+public int Roughness { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van de GrdmResource resource.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_default.psd";
+string outputFile = "gradient_map_res.psd";
+
+using (var image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+            
+    // controleer huidige waarden
+    AssertAreEqual(false, grdmResource.Reverse);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)65535, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+            
+            
+    grdmResource.Reverse = true;
+    // Rode kleur voor het tweede kleurpunt van de gradiënt.
+    grdmResource.ColorPoints[1].RawColor.Components[1].Value = ushort.MaxValue;
+    grdmResource.ColorPoints[1].RawColor.Components[2].Value = 0;
+    grdmResource.ColorPoints[1].RawColor.Components[3].Value = 0;
+
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (var image = (PsdImage)Image.Load(outputFile))
+{
+    Layer layer = image.Layers[1];
+    GrdmResource grdmResource = (GrdmResource)layer.Resources[0];
+    
+    // controleer gewijzigde waarden
+    AssertAreEqual(true, grdmResource.Reverse);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[2].Value);
+    AssertAreEqual((ulong)0, grdmResource.ColorPoints[1].RawColor.Components[3].Value);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "GrdmResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource methode. Slaat resourcegegevens op naar de opgegeven streamcontainer"
+type: docs
+weight: 200
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/save/
+---
+{{< psd/tize >}}
+## GrdmResource.Save method
+
+Slaat resourcegegevens op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/_index.md
@@ -1,0 +1,28 @@
+---
+title: "GrdmResource.SetPsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource methode. Stelt de minimale psd-versie in die vereist is voor laagresource. 0 geeft geen beperkingen aan"
+type: docs
+weight: 220
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/setpsdversion/
+---
+{{< psd/tize >}}
+## GrdmResource.SetPsdVersion method
+
+Stelt de minimale psd-versie in die vereist is voor laagresource. 0 geeft geen beperkingen aan.
+
+```csharp
+public void SetPsdVersion(ushort value)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| waarde | UInt16 | Psdversie waarde |
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.ShowTransparency"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Vlag voor het tonen van transparantie Wanneer Gradient type Noise kunnen we Add transparency op true zetten"
+type: docs
+weight: 170
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/showtransparency/
+---
+{{< psd/tize >}}
+## GrdmResource.ShowTransparency property
+
+Vlag voor het tonen van transparantie Wanneer 'Gradient type' = 'Noise', kunnen we 'Add transparency' op true zetten.
+
+```csharp
+public short ShowTransparency { get; set; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.Signature"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Haalt de handtekening op"
+type: docs
+weight: 180
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/signature/
+---
+{{< psd/tize >}}
+## GrdmResource.Signature property
+
+Haalt de handtekening op.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/_index.md
@@ -1,0 +1,29 @@
+---
+title: "GrdmResource.TransparencyPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Krijgt of stelt de transparantiepunten"
+type: docs
+weight: 180
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/transparencypoints/
+---
+{{< psd/tize >}}
+## GrdmResource.TransparencyPoints property
+
+Haalt of stelt de transparantiepunten in.
+
+```csharp
+public IGradientTransparencyPoint[] TransparencyPoints { get; set; }
+```
+
+### Property Value
+
+De transparantiepunten.
+
+### Zie ook
+
+* interface [IGradientTransparencyPoint](../../../aspose.psd.fileformats.psd.layers.fillsettings/igradienttransparencypoint/)
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource veld. De type tool informatiesleutel"
+type: docs
+weight: 210
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/typetoolkey/
+---
+{{< psd/tize >}}
+## GrdmResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "GrdmResource.UseVectorColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "GrdmResource eigenschap. Vlag voor het gebruiken van vectorkleur"
+type: docs
+weight: 190
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/grdmresource/usevectorcolor/
+---
+{{< psd/tize >}}
+## GrdmResource.UseVectorColor property
+
+Vlag voor het gebruiken van vectorkleur.
+
+```csharp
+public short UseVectorColor { get; set; }
+```
+
+### Zie ook
+
+* class [GrdmResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Klasse IfxsResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IfxsResource class. Ifxs resource voor groepslaag-effecten"
+type: docs
+weight: 2840
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/
+---
+{{< psd/tize >}}
+## IfxsResource class
+
+Ifxs resource (resource voor groepslaag-effecten)
+
+```csharp
+public sealed class IfxsResource : BaseFxResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [IfxsResource](ifxsresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Haalt de descriptorversie op. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van IfxsResource.
+
+```csharp
+[C#]
+
+string sourceFile = "example.psd";
+string outputFile = "export.psd";
+
+var loadOptions = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+{
+    // Voorbeeld heeft 2 groepslagen met effecten
+    // Groepslaag met één effect
+    LayerGroup layerGroupOne = (LayerGroup)psdImage.Layers[2];
+
+    // Groepslaag met meerdere effecten
+    LayerGroup layerGroupMany = (LayerGroup)psdImage.Layers[5];
+
+    // Haal het aantal effecten op en controleer hun hoeveelheid
+    int effectCountOne = layerGroupOne.BlendingOptions.Effects.Length;
+    int effectCountMany = layerGroupMany.BlendingOptions.Effects.Length;
+
+    // Eén effect in de groepslaag bevindt zich in resource 'IfxsResource'
+    IfxsResource ifxsResource = (IfxsResource)layerGroupOne.Resources[0];
+
+    // Twee of meer effecten in een groepslaag bevinden zich in resource 'ImfxResource'
+    ImfxResource imfxResource = (ImfxResource)layerGroupMany.Resources[0];
+
+    // Voeg een derde schaduw toe aan een groepslaag met meerdere effecten
+    layerGroupMany.BlendingOptions.AddDropShadow();
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Zie ook
+
+* class [BaseFxResource](../basefxresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IfxsResource.IfxsResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IfxsResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/ifxsresource/
+---
+{{< psd/tize >}}
+## IfxsResource constructor
+
+De standaardconstructor.
+
+```csharp
+public IfxsResource()
+```
+
+### Zie ook
+
+* class [IfxsResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/_index.md
@@ -1,0 +1,65 @@
+---
+title: "IfxsResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IfxsResource veld. De type tool info sleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ifxsresource/typetoolkey/
+---
+{{< psd/tize >}}
+## IfxsResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van IfxsResource.
+
+```csharp
+[C#]
+
+string sourceFile = "example.psd";
+string outputFile = "export.psd";
+
+var loadOptions = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+};
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+{
+    // Voorbeeld heeft 2 groepslagen met effecten
+    // Groepslaag met één effect
+    LayerGroup layerGroupOne = (LayerGroup)psdImage.Layers[2];
+
+    // Groepslaag met meerdere effecten
+    LayerGroup layerGroupMany = (LayerGroup)psdImage.Layers[5];
+
+    // Haal het aantal effecten op en controleer hun hoeveelheid
+    int effectCountOne = layerGroupOne.BlendingOptions.Effects.Length;
+    int effectCountMany = layerGroupMany.BlendingOptions.Effects.Length;
+
+    // Eén effect in de groepslaag bevindt zich in resource 'IfxsResource'
+    IfxsResource ifxsResource = (IfxsResource)layerGroupOne.Resources[0];
+
+    // Twee of meer effecten in een groepslaag bevinden zich in resource 'ImfxResource'
+    ImfxResource imfxResource = (ImfxResource)layerGroupMany.Resources[0];
+
+    // Voeg een derde schaduw toe aan een groepslaag met meerdere effecten
+    layerGroupMany.BlendingOptions.AddDropShadow();
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Zie ook
+
+* class [IfxsResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/_index.md
@@ -1,0 +1,100 @@
+---
+title: "Klasse ImfxResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.ImfxResource class. Imfx resource multi-effectenresource"
+type: docs
+weight: 2850
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/
+---
+{{< psd/tize >}}
+## ImfxResource class
+
+Imfx resource (multi-effectenresource)
+
+```csharp
+public sealed class ImfxResource : BaseFxResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ImfxResource](imfxresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/descriptorversion/) { get; } | Haalt de descriptorversie op. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/basefxresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert ondersteuning van een multi-effecten resource.
+
+```csharp
+[C#]
+
+// PSD-afbeelding bevat 2 Drop Shadow-effecten.
+string sourceFile = "MultiExample.psd";
+string outputFile1 = "export1.png";
+string outputFile2 = "export2.png";
+string outputFile3 = "export3.png";
+
+using (PsdImage image = (PsdImage)Aspose.PSD.Image.Load(sourceFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    // Het rendert de PSD-afbeelding met 2 Drop Shadow-effecten.
+    image.Save(outputFile1, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    var blendingOptions = image.Layers[0].BlendingOptions;
+
+    // Het voegt een derde Drop Shadow-effect toe.
+    DropShadowEffect dropShadowEffect3 = blendingOptions.AddDropShadow();
+    dropShadowEffect3.Color = Color.Red;
+    dropShadowEffect3.Distance = 50;
+    dropShadowEffect3.Angle = 0;
+
+    // Het rendert de PSD-afbeelding met 3 Drop Shadow-effecten.
+    image.Save(outputFile2, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // De imfx-resource wordt gebruikt als de laag meerdere effecten van hetzelfde type bevat.
+    var imfx = (ImfxResource)image.Layers[0].Resources[0];
+
+    // Het wist alle effecten.
+    blendingOptions.Effects = new ILayerEffect[0];
+
+    DropShadowEffect dropShadowEffect1 = blendingOptions.AddDropShadow();
+    dropShadowEffect1.Color = Color.Blue;
+    dropShadowEffect1.Distance = 10;
+
+    // Het rendert de PSD-afbeelding met 1 Drop Shadow-effect (andere werden verwijderd).
+    image.Save(outputFile3, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+
+    // De lfx2-resource wordt gebruikt als de laag niet meerdere effecten van hetzelfde type bevat.
+    var lfx2 = (Lfx2Resource)image.Layers[0].Resources[14];
+}
+```
+
+### Zie ook
+
+* class [BaseFxResource](../basefxresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ImfxResource.ImfxResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ImfxResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/imfxresource/
+---
+{{< psd/tize >}}
+## ImfxResource constructor
+
+De standaardconstructor.
+
+```csharp
+public ImfxResource()
+```
+
+### Zie ook
+
+* class [ImfxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ImfxResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ImfxResource veld. De type tool info sleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/imfxresource/typetoolkey/
+---
+{{< psd/tize >}}
+## ImfxResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [ImfxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/_index.md
@@ -1,0 +1,145 @@
+---
+title: "Interface IPath"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IPath interface. Interface beschrijft de set paden die aanwezig zijn in een vormlaag"
+type: docs
+weight: 2800
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/
+---
+{{< psd/tize >}}
+## IPath interface
+
+Interface beschrijft de set paden die aanwezig zijn in een vormlaag.
+
+```csharp
+public interface IPath
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [IsDisabled](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/) { get; set; } | Is pad uitgeschakeld. |
+| [IsInverted](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/) { get; set; } | Is pad omgekeerd. |
+| [IsNotLinked](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/) { get; set; } | Is pad niet gekoppeld. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/)() | Haalt array van Vormen in een Pad op. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/)(IPathShape[]) | Stelt array van Vormen in een Pad in. |
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPath.GetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPath methode. Haalt een array van Shapes op in een Path"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/getitems/
+---
+{{< psd/tize >}}
+## IPath.GetItems method
+
+Haalt array van Vormen in een Pad op.
+
+```csharp
+public IPathShape[] GetItems()
+```
+
+### Retourwaarde
+
+Array van IPathShape.
+
+### Zie ook
+
+* interface [IPathShape](../../ipathshape/)
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsDisabled"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPath property. Is pad uitgeschakeld"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isdisabled/
+---
+{{< psd/tize >}}
+## IPath.IsDisabled property
+
+Is pad uitgeschakeld.
+
+```csharp
+public bool IsDisabled { get; set; }
+```
+
+### Zie ook
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsInverted"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPath property. Is pad omgekeerd"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isinverted/
+---
+{{< psd/tize >}}
+## IPath.IsInverted property
+
+Is pad omgekeerd.
+
+```csharp
+public bool IsInverted { get; set; }
+```
+
+### Zie ook
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPath.IsNotLinked"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPath eigenschap. Is Path niet gekoppeld"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/isnotlinked/
+---
+{{< psd/tize >}}
+## IPath.IsNotLinked property
+
+Is pad niet gekoppeld.
+
+```csharp
+public bool IsNotLinked { get; set; }
+```
+
+### Zie ook
+
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPath.SetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPath method. Stelt een array van vormen in een pad in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipath/setitems/
+---
+{{< psd/tize >}}
+## IPath.SetItems method
+
+Stelt array van Vormen in een Pad in.
+
+```csharp
+public void SetItems(IPathShape[] shapes)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| vormen | IPathShape[] | Array van IPathShape. |
+
+### Zie ook
+
+* interface [IPathShape](../../ipathshape/)
+* interface [IPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/_index.md
@@ -1,0 +1,144 @@
+---
+title: "Interface IPathShape"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IPathShape interface. De vorm van de knooppunten van de Bézier-curve"
+type: docs
+weight: 2810
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/
+---
+{{< psd/tize >}}
+## IPathShape interface
+
+De vorm van de knooppunten van de Bézier-curve.
+
+```csharp
+public interface IPathShape
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [IsClosed](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/) { get; set; } | Haalt of stelt de eigenschap in die bepaalt of de vorm gesloten is. |
+| [PathOperations](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/) { get; set; } | De bewerkingen voor het combineren van padvormen (Boolean-bewerkingen). |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/)() | Haalt array van Bézier-knopen op. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/)(BezierKnotRecord[]) | Wijst een array van Bexier-knooppunten toe. |
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPathShape.GetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPathShape methode. Haalt een array van Bezier-knopen op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/getitems/
+---
+{{< psd/tize >}}
+## IPathShape.GetItems method
+
+Haalt array van Bézier-knopen op.
+
+```csharp
+public BezierKnotRecord[] GetItems()
+```
+
+### Retourwaarde
+
+Array van BezierKnotRecord.
+
+### Zie ook
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/_index.md
@@ -1,0 +1,24 @@
+---
+title: "IPathShape.IsClosed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPathShape eigenschap. Haalt op of stelt de eigenschap in die bepaalt of Shape gesloten is"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/isclosed/
+---
+{{< psd/tize >}}
+## IPathShape.IsClosed property
+
+Haalt of stelt de eigenschap in die bepaalt of de vorm gesloten is.
+
+```csharp
+public bool IsClosed { get; set; }
+```
+
+### Zie ook
+
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IPathShape.PathOperations"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPathShape eigenschap. De bewerkingen voor de padvormen die Booleaanse bewerkingen combineren"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/pathoperations/
+---
+{{< psd/tize >}}
+## IPathShape.PathOperations property
+
+De bewerkingen voor het combineren van padvormen (Boolean-bewerkingen).
+
+```csharp
+public PathOperations PathOperations { get; set; }
+```
+
+### Zie ook
+
+* enum [PathOperations](../../../aspose.psd.fileformats.core.vectorpaths/pathoperations/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "IPathShape.SetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IPathShape methode. Wijs een array van Bezier-knopen toe"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ipathshape/setitems/
+---
+{{< psd/tize >}}
+## IPathShape.SetItems method
+
+Wijst een array van Bexier-knooppunten toe.
+
+```csharp
+public void SetItems(BezierKnotRecord[] bezierPoints)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bezierPoints | BezierKnotRecord[] | Array van bezier-knooppunten |
+
+### Zie ook
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* interface [IPathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/_index.md
@@ -1,0 +1,130 @@
+---
+title: "Interface IStrokeSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.IStrokeSettings interface. Lijninstellingen van vormen"
+type: docs
+weight: 2670
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/istrokesettings/
+---
+{{< psd/tize >}}
+## IStrokeSettings interface
+
+Stroke-instellingen van vormen.
+
+```csharp
+public interface IStrokeSettings
+```
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "BlendMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode/
+---
+## Lfx2Resource.BlendMode property
+
+Haalt de mengmodus op.
+
+```csharp
+public BlendMode BlendMode { get; }
+```
+
+### Property Value
+
+De mengmodus.
+
+### Zie ook
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode)
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Data"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data/
+---
+## Lfx2Resource.Data property
+
+Haalt de gegevens op of stelt ze in.
+
+```csharp
+public byte[] Data { get; set; }
+```
+
+### Property Value
+
+De gegevens.
+
+### Zie ook
+
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/_index.md
@@ -1,0 +1,28 @@
+---
+title: "EffectColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor/
+---
+## Lfx2Resource.EffectColor property
+
+Haalt de kleur van het effect op.
+
+```csharp
+public Color EffectColor { get; }
+```
+
+### Property Value
+
+De kleur van het effect.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color)
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/_index.md
@@ -1,0 +1,27 @@
+---
+title: "Opacity"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity/
+---
+## Lfx2Resource.Opacity property
+
+Haalt de dekking op.
+
+```csharp
+public double Opacity { get; }
+```
+
+### Property Value
+
+De opacity.
+
+### Zie ook
+
+* class [Lfx2Resource](../../lfx2resource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../lfx2resource)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/_index.md
@@ -1,0 +1,56 @@
+---
+title: "Lfx2Resource test"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 2570
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/test/
+---
+## Lfx2Resource class
+
+Lfx2 resource (effectenresource)
+
+```csharp
+public sealed class Lfx2Resource : LayerResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Lfx2Resource](lfx2resource)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BlendMode](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/blendmode) { get; } | Haalt de mengmodus op. |
+| [Data](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/data) { get; set; } | Haalt de gegevens op of stelt ze in. |
+| [DescriptorVersion](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/descriptorversion) { get; } | Haalt de descriptorversie op. |
+| [EffectColor](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/effectcolor) { get; } | Haalt de kleur van het effect op. |
+| override [Key](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/key) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/length) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/opacity) { get; } | Haalt de dekking op. |
+| override [PsdVersion](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/psdversion) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| override [Signature](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/signature) { get; } | Haalt de handtekening van de laagresource op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lfx2resource/save)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Andere leden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](typetoolkey) | De type-tool-informatiesleutel. |
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources)
+* assembly [Aspose.PSD](../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/_index.md
@@ -1,0 +1,116 @@
+---
+title: "Klasse LmskResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LmskResource klasse. De LMsk-resource"
+type: docs
+weight: 3020
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/
+---
+{{< psd/tize >}}
+## LmskResource class
+
+De LMsk-resource.
+
+```csharp
+public class LmskResource : LayerResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [LmskResource](lmskresource/)() | Initialiseert een nieuw exemplaar van de `LmskResource`-klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ColorComponent1](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/) { get; set; } | Haalt de kleurcomponent 1 op. |
+| [ColorComponent2](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/) { get; set; } | Haalt de kleurcomponent 2 op. |
+| [ColorComponent3](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/) { get; set; } | Haalt de kleurcomponent 3 op. |
+| [ColorComponent4](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/) { get; set; } | Haalt de kleurcomponent 4 op. |
+| [ColorSpace](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/) { get; set; } | Haalt de kleurenruimte op. |
+| [Flag](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/) { get; } | Haalt de vlag op. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/) { get; set; } | Haalt de dekking op. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Opmerkingen
+
+Deze resource bevat een kleurenruimte-ID, die verwijst naar een specifiek type kleurenruimte, en 4 kleurcomponenten. Afhankelijk van de ID hebben de kleurcomponenten verschillende betekenissen. Als het type kleurenruimte geen vier waarden vereist, zijn de extra componenten ongedefinieerd en worden ze altijd als nullen geschreven. Kleurcomponenten per type kleurenruimte: RGB - de eerste drie componenten zijn rood, groen en blauw. HSB - de eerste drie componenten zijn tint, verzadiging en helderheid. CMYK - de vier componenten zijn cyaan, magenta, geel en zwart. Lab - de eerste drie componenten zijn lichtheid, a-chrominantie en b-chrominantie. Grijswaarden - de eerste component is de grijswaarde, van 0...10000.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent1"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt kleurcomponent 1 op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent1/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent1 property
+
+Haalt de kleurcomponent 1 op.
+
+```csharp
+public ushort ColorComponent1 { get; set; }
+```
+
+### Property Value
+
+De kleurcomponent 1.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent2"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de kleurcomponent 2 op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent2/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent2 property
+
+Haalt de kleurcomponent 2 op.
+
+```csharp
+public ushort ColorComponent2 { get; set; }
+```
+
+### Property Value
+
+De kleurcomponent 2.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent3"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de kleurcomponent 3 op"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent3/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent3 property
+
+Haalt de kleurcomponent 3 op.
+
+```csharp
+public ushort ColorComponent3 { get; set; }
+```
+
+### Property Value
+
+De kleurcomponent 3.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.ColorComponent4"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de kleurcomponent 4 op"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorcomponent4/
+---
+{{< psd/tize >}}
+## LmskResource.ColorComponent4 property
+
+Haalt de kleurcomponent 4 op.
+
+```csharp
+public ushort ColorComponent4 { get; set; }
+```
+
+### Property Value
+
+De kleurcomponent 4.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/_index.md
@@ -1,0 +1,82 @@
+---
+title: "LmskResource.ColorSpace"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de kleurenruimte op"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/colorspace/
+---
+{{< psd/tize >}}
+## LmskResource.ColorSpace property
+
+Haalt de kleurenruimte op.
+
+```csharp
+public ColorSpace ColorSpace { get; set; }
+```
+
+### Property Value
+
+De kleurenruimte.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* enum [ColorSpace](../../../aspose.psd.fileformats.psd.resources.enums/colorspace/)
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.Flag"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de vlag op"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/flag/
+---
+{{< psd/tize >}}
+## LmskResource.Flag property
+
+Haalt de vlag op.
+
+```csharp
+public byte Flag { get; }
+```
+
+### Property Value
+
+De vlag.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Key"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de laagresource-sleutel op"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/key/
+---
+{{< psd/tize >}}
+## LmskResource.Key property
+
+Haalt de laagresource-sleutel op.
+
+```csharp
+public override int Key { get; }
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de lengte van de laagresource op in bytes"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/length/
+---
+{{< psd/tize >}}
+## LmskResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.LmskResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource constructor. Initialiseert een nieuw exemplaar van de LmskResource-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/lmskresource/
+---
+{{< psd/tize >}}
+## LmskResource constructor
+
+Initialiseert een nieuw exemplaar van de [`LmskResource`](../) klasse.
+
+```csharp
+public LmskResource()
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/_index.md
@@ -1,0 +1,81 @@
+---
+title: "LmskResource.Opacity"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de opaciteit op"
+type: docs
+weight: 90
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/opacity/
+---
+{{< psd/tize >}}
+## LmskResource.Opacity property
+
+Haalt de dekking op.
+
+```csharp
+public short Opacity { get; set; }
+```
+
+### Property Value
+
+De opacity.
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de psd-versie op"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/psdversion/
+---
+{{< psd/tize >}}
+## LmskResource.PsdVersion property
+
+Haalt de psd-versie op.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LmskResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 100
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/save/
+---
+{{< psd/tize >}}
+## LmskResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.Signature"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource eigenschap. Haalt de handtekening op"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/signature/
+---
+{{< psd/tize >}}
+## LmskResource.Signature property
+
+Haalt de handtekening op.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LmskResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LmskResource veld. De type tool info-sleutel"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lmskresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LmskResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [LmskResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/_index.md
@@ -1,0 +1,41 @@
+---
+title: "Klasse LrXxResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LrXxResource klasse. De lrXX-resource"
+type: docs
+weight: 3100
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/
+---
+{{< psd/tize >}}
+## LrXxResource class
+
+De lrXX-resource.
+
+```csharp
+public abstract class LrXxResource : LayerResource
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| [Layers](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/) { get; set; } | Haalt op of stelt de lagen in. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/) { get; } | Haalt de resource-lengte op voor de PSD-headerversie van de afbeelding. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/)(StreamContainer, int) | Slaat het laagrecord op. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Key"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource eigenschap. Haalt de laagresource-sleutel op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/key/
+---
+{{< psd/tize >}}
+## LrXxResource.Key property
+
+Haalt de laagresource-sleutel op.
+
+```csharp
+public override int Key { get; }
+```
+
+### Zie ook
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/_index.md
@@ -1,0 +1,29 @@
+---
+title: "LrXxResource.Layers"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource eigenschap. Haalt of stelt de lagen in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/layers/
+---
+{{< psd/tize >}}
+## LrXxResource.Layers property
+
+Haalt op of stelt de lagen in.
+
+```csharp
+public Layer[] Layers { get; set; }
+```
+
+### Property Value
+
+De lagen.
+
+### Zie ook
+
+* class [Layer](../../../aspose.psd.fileformats.psd.layers/layer/)
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource eigenschap. Haalt de resource-lengte op voor de PSD-headerversie van de afbeelding"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/length/
+---
+{{< psd/tize >}}
+## LrXxResource.Length property
+
+Haalt de resource-lengte op voor de PSD-headerversie van de afbeelding.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.LrXxResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource constructor. Initialiseert een nieuw exemplaar van de LrXxResource-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/lrxxresource/
+---
+{{< psd/tize >}}
+## LrXxResource constructor
+
+Initialiseert een nieuw exemplaar van de [`LrXxResource`](../) klasse.
+
+```csharp
+public LrXxResource()
+```
+
+### Zie ook
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource eigenschap. Haalt de PSD-versie op"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/psdversion/
+---
+{{< psd/tize >}}
+## LrXxResource.PsdVersion property
+
+Haalt de psd-versie op.
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/_index.md
@@ -1,0 +1,36 @@
+---
+title: "LrXxResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource-methode. Slaat het laagrecord op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/save/
+---
+{{< psd/tize >}}
+## LrXxResource.Save method
+
+Slaat het laagrecord op.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| NotImplementedException | Opslaan van XX-bit kanalen is niet geïmplementeerd |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LrXxResource.Signature"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LrXxResource eigenschap. Haalt de handtekening op"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lrxxresource/signature/
+---
+{{< psd/tize >}}
+## LrXxResource.Signature property
+
+Haalt de handtekening op.
+
+```csharp
+public override int Signature { get; }
+```
+
+### Zie ook
+
+* class [LrXxResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/_index.md
@@ -1,0 +1,86 @@
+---
+title: "Klasse LsdkResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LsdkResource klasse. De lsdk-laagresource geneste laagsectie-resource"
+type: docs
+weight: 3110
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/
+---
+{{< psd/tize >}}
+## LsdkResource class
+
+De lsdk-laagresource (geneste laagsectie-resource).
+
+```csharp
+public class LsdkResource : BaseLayerSectionResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [LsdkResource](lsdkresource/)() | Initialiseert een nieuwe instantie van de `LsdkResource` klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BlendModeKey](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/length/) { get; } | Haalt de lengte van de laagresource op in bytes. |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| [SectionType](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/sectiontype/) { get; set; } | Haalt op of stelt het sectietype in. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+| [Subtype](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/subtype/) { get; set; } | Haalt op of stelt het subtype in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/baselayersectionresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van LsdkResource.
+
+```csharp
+[C#]
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new FormatException(message ?? "Objects are not equal.");
+    }
+}
+
+string srcFile = "123 1.psd";
+string outFile = "output.psd";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+    psdImage.Save(outFile);
+}
+
+// controleer na het opslaan
+using (var psdImage = (PsdImage)Image.Load(outFile, new PsdLoadOptions() { LoadEffectsResource = true }))
+{
+    AssertAreEqual((psdImage.Layers[8].Resources[3] as LsdkResource).Length, 4);
+}
+```
+
+### Zie ook
+
+* class [BaseLayerSectionResource](../baselayersectionresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/_index.md
@@ -1,0 +1,31 @@
+---
+title: "LsdkResource.BlendModeKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource eigenschap. Haalt of stelt de blend mode-sleutel in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/blendmodekey/
+---
+{{< psd/tize >}}
+## LsdkResource.BlendModeKey property
+
+Haalt of stelt de blend mode key in.
+
+```csharp
+public BlendMode BlendModeKey { get; set; }
+```
+
+### Uitzonderingen
+
+| uitzondering | conditie |
+| --- | --- |
+| [PsdImageArgumentException](../../../aspose.psd.coreexceptions.imageformats/psdimageargumentexception/) | BlendModeKey moet 4 tekens lang zijn. |
+
+### Zie ook
+
+* enum [BlendMode](../../../aspose.psd.fileformats.core.blending/blendmode/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource property. Haalt de lengte van de laagresource op in bytes"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/length/
+---
+{{< psd/tize >}}
+## LsdkResource.Length property
+
+Haalt de lengte van de laagresource op in bytes.
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.LsdkResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource constructor. Initialiseert een nieuw exemplaar van de LsdkResource-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/lsdkresource/
+---
+{{< psd/tize >}}
+## LsdkResource constructor
+
+Initialiseert een nieuw exemplaar van de [`LsdkResource`](../) klasse.
+
+```csharp
+public LsdkResource()
+```
+
+### Zie ook
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LsdkResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource-methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/save/
+---
+{{< psd/tize >}}
+## LsdkResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "LsdkResource.SectionType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource property. Haalt of stelt het sectietype in"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/sectiontype/
+---
+{{< psd/tize >}}
+## LsdkResource.SectionType property
+
+Haalt op of stelt het sectietype in.
+
+```csharp
+public LayerSectionType SectionType { get; set; }
+```
+
+### Zie ook
+
+* enum [LayerSectionType](../../layersectiontype/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/_index.md
@@ -1,0 +1,25 @@
+---
+title: "LsdkResource.Subtype"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource property. Haalt of stelt de subtype in"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/subtype/
+---
+{{< psd/tize >}}
+## LsdkResource.Subtype property
+
+Haalt op of stelt het subtype in.
+
+```csharp
+public LayerSectionSubtype Subtype { get; set; }
+```
+
+### Zie ook
+
+* enum [LayerSectionSubtype](../../layersectionsubtype/)
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LsdkResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LsdkResource field. De type-tool-informatiesleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lsdkresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LsdkResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [LsdkResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Klasse LyvrResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.LyvrResource class. De resource die de Photoshop-versie van een laag vertegenwoordigt"
+type: docs
+weight: 3150
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/
+---
+{{< psd/tize >}}
+## LyvrResource class
+
+De resource die de Photoshop-versie van een laag vertegenwoordigt.
+
+```csharp
+public sealed class LyvrResource : LayerResource
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [LyvrResource](lyvrresource/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Key](../../aspose.psd.fileformats.psd.layers/layerresource/key/) { get; } | Haalt de laagresource-sleutel op. |
+| override [Length](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/) { get; } |  |
+| virtual [PsdVersion](../../aspose.psd.fileformats.psd.layers/layerresource/psdversion/) { get; } | Haalt de minimale PSD-versie op die vereist is voor laagresource. 0 geeft geen beperkingen aan. |
+| virtual [Signature](../../aspose.psd.fileformats.psd.layers/layerresource/signature/) { get; } | Haalt de handtekening op. |
+| [Version](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/) { get; set; } | Haalt op of stelt de Photoshop-versie van een laag in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| override [Save](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/)(StreamContainer, int) | Slaat de resource op in de opgegeven streamcontainer. |
+| override [ToString](../../aspose.psd.fileformats.psd.layers/layerresource/tostring/)() | Retourneert een String die deze instantie vertegenwoordigt. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [TypeToolKey](../../aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/) | De type-tool-informatiesleutel. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [LayerResource](../../aspose.psd.fileformats.psd.layers/layerresource/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/_index.md
@@ -1,0 +1,22 @@
+---
+title: "LyvrResource.Length"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource eigenschap."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/length/
+---
+{{< psd/tize >}}
+## LyvrResource.Length property
+
+```csharp
+public override int Length { get; }
+```
+
+### Zie ook
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LyvrResource.LyvrResource"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/lyvrresource/
+---
+{{< psd/tize >}}
+## LyvrResource constructor
+
+De standaardconstructor.
+
+```csharp
+public LyvrResource()
+```
+
+### Zie ook
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/_index.md
@@ -1,0 +1,22 @@
+---
+title: "LyvrResource.PsdVersion"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource eigenschap."
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/psdversion/
+---
+{{< psd/tize >}}
+## LyvrResource.PsdVersion property
+
+```csharp
+public override int PsdVersion { get; }
+```
+
+### Zie ook
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/_index.md
@@ -1,0 +1,30 @@
+---
+title: "LyvrResource.Save"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource methode. Slaat de resource op in de opgegeven streamcontainer"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/save/
+---
+{{< psd/tize >}}
+## LyvrResource.Save method
+
+Slaat de resource op in de opgegeven streamcontainer.
+
+```csharp
+public override void Save(StreamContainer streamContainer, int psdVersion)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| streamContainer | StreamContainer | De streamcontainer waarin opgeslagen moet worden. |
+| psdVersion | Int32 | De PSD-versie. |
+
+### Zie ook
+
+* class [StreamContainer](../../../aspose.psd/streamcontainer/)
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/_index.md
@@ -1,0 +1,24 @@
+---
+title: "LyvrResource.TypeToolKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource veld. De type tool-informatiesleutel"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/typetoolkey/
+---
+{{< psd/tize >}}
+## LyvrResource.TypeToolKey field
+
+De type-tool-informatiesleutel.
+
+```csharp
+public const int TypeToolKey;
+```
+
+### Zie ook
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/_index.md
@@ -1,0 +1,65 @@
+---
+title: "LyvrResource.Version"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "LyvrResource eigenschap. Haalt de Photoshop-versie van de laag op of stelt deze in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/lyvrresource/version/
+---
+{{< psd/tize >}}
+## LyvrResource.Version property
+
+Haalt op of stelt de Photoshop-versie van een laag in.
+
+```csharp
+public int Version { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van Artboard-resources.
+
+```csharp
+[C#]
+
+string srcFile = "artboard1.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtDResource artDResource = (ArtDResource)psdImage.GlobalLayerResources[2];
+
+    ArtBResource artBResource1 = (ArtBResource)psdImage.Layers[2].Resources[7];
+    ArtBResource artBResource2 = (ArtBResource)psdImage.Layers[5].Resources[7];
+
+    LyvrResource lyvrResource1 = (LyvrResource)psdImage.Layers[2].Resources[9];
+    LyvrResource lyvrResource2 = (LyvrResource)psdImage.Layers[5].Resources[9];
+
+    var countStruct = (IntegerStructure)artDResource.Items[0];
+    AssertAreEqual(2, countStruct.Value);
+
+    var presetNameStruct1 = (StringStructure)artBResource1.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct1.Value);
+
+    var presetNameStruct2 = (StringStructure)artBResource2.Items[2];
+    AssertAreEqual("iPhone X\0", presetNameStruct2.Value);
+
+    AssertAreEqual(160, lyvrResource1.Version);
+    AssertAreEqual(160, lyvrResource2.Version);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [LyvrResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/_index.md
@@ -1,0 +1,154 @@
+---
+title: "Klasse PathShape"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.PathShape klasse. De figuur van de knopen van de Bézier-curve"
+type: docs
+weight: 3210
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/
+---
+{{< psd/tize >}}
+## PathShape class
+
+De figuur van de knopen van de Bézier-curve.
+
+```csharp
+public class PathShape : IPathShape
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [PathShape](pathshape/#constructor)() | Initialiseert een nieuw exemplaar van de `PathShape` klasse. |
+| [PathShape](pathshape/#constructor_1)(LengthRecord, BezierKnotRecord[]) | Initialiseert een nieuw exemplaar van de `PathShape` klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [IsClosed](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of dit exemplaar gesloten is. |
+| [PathOperations](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/) { get; set; } | Haalt op of stelt de padbewerkingen (Boolean-bewerkingen) in. |
+| [ShapeIndex](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/) { get; set; } | Haalt op of stelt de index van de huidige padvorm in de laag in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/)() | Haalt array van Bézier-knopen op. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/)(BezierKnotRecord[]) | Wijst array van Bézier-knopen toe. |
+| [ToVectorPathRecords](../../aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/)() | Maakt de [`VectorPathRecord`](../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/) records aan op basis van dit exemplaar. |
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* interface [IPathShape](../ipathshape/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.GetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape-methode. Haalt een array met Bezier-knopen op"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/getitems/
+---
+{{< psd/tize >}}
+## PathShape.GetItems method
+
+Haalt array van Bézier-knopen op.
+
+```csharp
+public BezierKnotRecord[] GetItems()
+```
+
+### Retourwaarde
+
+Array van BezierKnotRecord
+
+### Zie ook
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PathShape.IsClosed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape-eigenschap. Geeft een waarde terug of stelt een waarde in die aangeeft of dit exemplaar gesloten is"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/isclosed/
+---
+{{< psd/tize >}}
+## PathShape.IsClosed property
+
+Haalt op of stelt een waarde in die aangeeft of dit exemplaar gesloten is.
+
+```csharp
+public bool IsClosed { get; set; }
+```
+
+### Property Value
+
+`true` als dit exemplaar gesloten is; anders `false`.
+
+### Zie ook
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/_index.md
@@ -1,0 +1,25 @@
+---
+title: "PathShape.PathOperations"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape-eigenschap. Haalt de Booleaanse padbewerkingen op of stelt ze in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathoperations/
+---
+{{< psd/tize >}}
+## PathShape.PathOperations property
+
+Haalt op of stelt de padbewerkingen (Boolean-bewerkingen) in.
+
+```csharp
+public PathOperations PathOperations { get; set; }
+```
+
+### Zie ook
+
+* enum [PathOperations](../../../aspose.psd.fileformats.core.vectorpaths/pathoperations/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/_index.md
@@ -1,0 +1,47 @@
+---
+title: "PathShape.PathShape"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape constructor. Initialiseert een nieuw exemplaar van de PathShape-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/pathshape/
+---
+{{< psd/tize >}}
+## PathShape() {#constructor}
+
+Initialiseert een nieuw exemplaar van de [`PathShape`](../) klasse.
+
+```csharp
+public PathShape()
+```
+
+### Zie ook
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## PathShape(LengthRecord, BezierKnotRecord[]) {#constructor_1}
+
+Initialiseert een nieuw exemplaar van de [`PathShape`](../) klasse.
+
+```csharp
+public PathShape(LengthRecord lengthRecord, BezierKnotRecord[] bezierKnotRecords)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| lengthRecord | LengthRecord | Het lengte-record. |
+| bezierKnotRecords | BezierKnotRecord[] | De bezier-knoop-records. |
+
+### Zie ook
+
+* class [LengthRecord](../../../aspose.psd.fileformats.core.vectorpaths/lengthrecord/)
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.SetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape-methode. Wijs een array van bezier-knooppunten toe."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/setitems/
+---
+{{< psd/tize >}}
+## PathShape.SetItems method
+
+Wijst array van Bézier-knopen toe.
+
+```csharp
+public void SetItems(BezierKnotRecord[] bezierPoints)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| bezierPoints | BezierKnotRecord[] | Array van bezier-knooppunten |
+
+### Zie ook
+
+* class [BezierKnotRecord](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PathShape.ShapeIndex"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape eigenschap. Haalt op of stelt de index van de huidige padvorm in de laag in."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/shapeindex/
+---
+{{< psd/tize >}}
+## PathShape.ShapeIndex property
+
+Haalt op of stelt de index van de huidige padvorm in de laag in.
+
+```csharp
+public ushort ShapeIndex { get; set; }
+```
+
+### Zie ook
+
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PathShape.ToVectorPathRecords"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PathShape-methode. Maakt de VectorPathRecord-records aan op basis van dit exemplaar"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/pathshape/tovectorpathrecords/
+---
+{{< psd/tize >}}
+## PathShape.ToVectorPathRecords method
+
+Maakt de [`VectorPathRecord`](../../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/) records aan op basis van dit exemplaar.
+
+```csharp
+public IEnumerable<VectorPathRecord> ToVectorPathRecords()
+```
+
+### Retourwaarde
+
+Retourneert één [`LengthRecord`](../../../aspose.psd.fileformats.core.vectorpaths/lengthrecord/) en één [`BezierKnotRecord`](../../../aspose.psd.fileformats.core.vectorpaths/bezierknotrecord/) voor elk punt in dit exemplaar.
+
+### Zie ook
+
+* class [VectorPathRecord](../../../aspose.psd.fileformats.core.vectorpaths/vectorpathrecord/)
+* class [PathShape](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PtFlResource.Angle"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PtFlResource eigenschap. Haalt de hoek op of stelt deze in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/ptflresource/angle/
+---
+{{< psd/tize >}}
+## PtFlResource.Angle property
+
+Haalt een waarde op of stelt de hoek in.
+
+```csharp
+public double Angle { get; set; }
+```
+
+### Property Value
+
+De hoek.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Angle-eigenschap in PtFlResource.
+
+```csharp
+[C#]
+
+string sourceFile = "PatternFillLayerWide_0.psd";
+string outputFile = "PatternFillLayerWide_0_output.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    FillLayer fillLayer = (FillLayer)image.Layers[1];
+    PatternFillSettings fillSettings = (PatternFillSettings)fillLayer.FillSettings;
+    fillSettings.Angle = 70;
+    fillLayer.Update();
+    image.Save(outputFile, new PsdOptions());
+}
+
+using (PsdImage image = (PsdImage)Image.Load(outputFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    FillLayer fillLayer = (FillLayer)image.Layers[1];
+    PatternFillSettings fillSettings = (PatternFillSettings)fillLayer.FillSettings;
+
+    Assert.AreEqual(70, fillSettings.Angle);
+}
+```
+
+### Zie ook
+
+* class [PtFlResource](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/_index.md
@@ -1,0 +1,154 @@
+---
+title: "Klasse VectorPath"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.LayerResources.VectorPath klasse. De klasse die vectorpaden bevat"
+type: docs
+weight: 3730
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/
+---
+{{< psd/tize >}}
+## VectorPath class
+
+De klasse die vectorpaden bevat.
+
+```csharp
+public class VectorPath : IPath
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [VectorPath](vectorpath/)() | Initialiseert een nieuw exemplaar van de `VectorPath` klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [IsDisabled](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of dit exemplaar uitgeschakeld is. |
+| [IsFillStartsWithAllPixels](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of de vulling begint met alle pixels. |
+| [IsInverted](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of dit exemplaar omgekeerd is. |
+| [IsNotLinked](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/) { get; set; } | Haalt op of stelt een waarde in die aangeeft of dit exemplaar niet gekoppeld is. |
+| [Version](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/) { get; set; } | Haalt op of stelt de versie in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [GetItems](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/)() | Haalt array van Vormen in een Pad op. |
+| [SetItems](../../aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/)(IPathShape[]) | Stelt array van Vormen in een Pad in. |
+
+## Voorbeelden
+
+De volgende code demonstreert padobjecten van vsms- of vmsk-resources voor ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+    srcFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Verwijder één vorm
+    shapes.RemoveAt(1);
+
+    // Sla gewijzigde gegevens op in resource
+    List<VectorPathRecord> path = new List<VectorPathRecord>();
+    path.Add(new PathFillRuleRecord(null));
+    path.Add(new InitialFillRuleRecord(isFillStartsWithAllPixels));
+
+    for (ushort i = 0; i < shapes.Count; i++)
+    {
+        PathShape shape = (PathShape)shapes[i];
+        shape.ShapeIndex = i;
+        path.AddRange(shape.ToVectorPathRecords());
+    }
+
+    vectorPathDataResource.Paths = path.ToArray();
+
+    image.Save(outFile);
+}
+
+// Controleer gewijzigde waarden in opgeslagen bestand
+using (PsdImage image = (PsdImage)Image.Load(
+    outFile,
+    new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    Layer shapeLayer = image.Layers[1];
+    VectorPathDataResource vectorPathDataResource = (VectorPathDataResource)shapeLayer.Resources[1];
+
+    bool isFillStartsWithAllPixels;
+    List<IPathShape> shapes = GetShapesFromResource(vectorPathDataResource, out isFillStartsWithAllPixels);
+
+    // Opgeslagen bestand moet 1 vorm bevatten
+    AssertAreEqual(1, shapes.Count);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+
+List<IPathShape> GetShapesFromResource(
+    VectorPathDataResource vectorPathDataResource,
+    out bool isFillStartsWithAllPixels)
+{
+    List<IPathShape> shapes = new List<IPathShape>();
+    LengthRecord lengthRecord = null;
+    isFillStartsWithAllPixels = false;
+    List<BezierKnotRecord> bezierKnotRecords = new List<BezierKnotRecord>();
+
+    foreach (var pathRecord in vectorPathDataResource.Paths)
+    {
+        if (pathRecord is LengthRecord)
+        {
+            if (bezierKnotRecords.Count > 0)
+            {
+                shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+                lengthRecord = null;
+                bezierKnotRecords.Clear();
+            }
+
+            lengthRecord = (LengthRecord)pathRecord;
+        }
+        else if (pathRecord is BezierKnotRecord)
+        {
+            bezierKnotRecords.Add((BezierKnotRecord)pathRecord);
+        }
+        else if (pathRecord is InitialFillRuleRecord)
+        {
+            InitialFillRuleRecord initialFillRuleRecord = (InitialFillRuleRecord)pathRecord;
+            isFillStartsWithAllPixels = initialFillRuleRecord.IsFillStartsWithAllPixels;
+        }
+    }
+
+    if (bezierKnotRecords.Count > 0)
+    {
+        shapes.Add(new PathShape(lengthRecord, bezierKnotRecords.ToArray()));
+        lengthRecord = null;
+        bezierKnotRecords.Clear();
+    }
+
+    return shapes;
+}
+```
+
+### Zie ook
+
+* interface [IPath](../ipath/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/_index.md
@@ -1,0 +1,25 @@
+---
+title: "VectorPath.FillColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt of stelt de vullingkleur van het vectorpad in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/fillcolor/
+---
+{{< psd/tize >}}
+## VectorPath.FillColor property
+
+Haalt of stelt de vullingkleur van het vectorpad in.
+
+```csharp
+public Color FillColor { get; set; }
+```
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "VectorPath.GetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath methode. Haalt een array van Shapes in een Path op"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/getitems/
+---
+{{< psd/tize >}}
+## VectorPath.GetItems method
+
+Haalt array van Vormen in een Pad op.
+
+```csharp
+public IPathShape[] GetItems()
+```
+
+### Retourwaarde
+
+Array van IPathShape.
+
+### Zie ook
+
+* interface [IPathShape](../../ipathshape/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsDisabled"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt een waarde op of stelt deze in die aangeeft of deze instantie is uitgeschakeld"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isdisabled/
+---
+{{< psd/tize >}}
+## VectorPath.IsDisabled property
+
+Haalt op of stelt een waarde in die aangeeft of dit exemplaar uitgeschakeld is.
+
+```csharp
+public bool IsDisabled { get; set; }
+```
+
+### Property Value
+
+`true` als deze instantie is uitgeschakeld; anders `false`.
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsFillStartsWithAllPixels"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt een waarde op of stelt deze in die aangeeft of de vulling start met alle pixels"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isfillstartswithallpixels/
+---
+{{< psd/tize >}}
+## VectorPath.IsFillStartsWithAllPixels property
+
+Haalt op of stelt een waarde in die aangeeft of de vulling begint met alle pixels.
+
+```csharp
+public bool IsFillStartsWithAllPixels { get; set; }
+```
+
+### Property Value
+
+De vulling start met alle pixels.
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsInverted"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt een waarde op of stelt deze in die aangeeft of dit exemplaar omgekeerd is"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isinverted/
+---
+{{< psd/tize >}}
+## VectorPath.IsInverted property
+
+Haalt op of stelt een waarde in die aangeeft of dit exemplaar omgekeerd is.
+
+```csharp
+public bool IsInverted { get; set; }
+```
+
+### Property Value
+
+`true` als dit exemplaar omgekeerd is; anders `false`.
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.IsNotLinked"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt een waarde op of stelt deze in die aangeeft of dit exemplaar niet gekoppeld is"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/isnotlinked/
+---
+{{< psd/tize >}}
+## VectorPath.IsNotLinked property
+
+Haalt op of stelt een waarde in die aangeeft of dit exemplaar niet gekoppeld is.
+
+```csharp
+public bool IsNotLinked { get; set; }
+```
+
+### Property Value
+
+`true` als dit exemplaar niet gekoppeld is; anders `false`.
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/_index.md
@@ -1,0 +1,29 @@
+---
+title: "VectorPath.SetItems"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath methode. Stelt een array van Shapes in een Path in"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/setitems/
+---
+{{< psd/tize >}}
+## VectorPath.SetItems method
+
+Stelt array van Vormen in een Pad in.
+
+```csharp
+public void SetItems(IPathShape[] shapes)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| vormen | IPathShape[] | Array van IPathShape. |
+
+### Zie ook
+
+* interface [IPathShape](../../ipathshape/)
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/_index.md
@@ -1,0 +1,24 @@
+---
+title: "VectorPath.VectorPath"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath constructor. Initialiseert een nieuw exemplaar van de VectorPath klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/vectorpath/
+---
+{{< psd/tize >}}
+## VectorPath constructor
+
+Initialiseert een nieuw exemplaar van de [`VectorPath`](../) klasse.
+
+```csharp
+public VectorPath()
+```
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/_index.md
@@ -1,0 +1,28 @@
+---
+title: "VectorPath.Version"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "VectorPath eigenschap. Haalt de versie op of stelt deze in"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.layerresources/vectorpath/version/
+---
+{{< psd/tize >}}
+## VectorPath.Version property
+
+Haalt op of stelt de versie in.
+
+```csharp
+public int Version { get; set; }
+```
+
+### Property Value
+
+De versie.
+
+### Zie ook
+
+* class [VectorPath](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.LayerResources](../../../aspose.psd.fileformats.psd.layers.layerresources/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/_index.md
@@ -1,0 +1,106 @@
+---
+title: "Class SharpenSmartFilter"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.SmartFilters.SharpenSmartFilter class. De Sharpen smart filter"
+type: docs
+weight: 3870
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter class
+
+De Sharpen smart filter.
+
+```csharp
+public sealed class SharpenSmartFilter : SmartFilter
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [SharpenSmartFilter](sharpensmartfilter/#constructor)() | Initialiseert een nieuw exemplaar van de `SharpenSmartFilter` class. |
+| [SharpenSmartFilter](sharpensmartfilter/#constructor_1)(DescriptorStructure) | Initialiseert een nieuw exemplaar van de `SharpenSmartFilter` class. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BlendMode](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/blendmode/) { get; set; } | Haalt op of stelt de mengmodus in. |
+| override [FilterId](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/) { get; } | Haalt de type‑identificatie van de smart filter op. |
+| [IsEnabled](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/isenabled/) { get; set; } | Haalt op of stelt de ingeschakelde status van de smart filter in. |
+| override [Name](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/) { get; } | Haalt de naam van de smart filter op. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/opacity/) { get; set; } | Haalt op of stelt de opaciteitswaarde van de smart filter in. |
+| [SourceDescriptor](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/sourcedescriptor/) { get; } | De bron‑descriptorstructuur met smart filter‑gegevens. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Apply](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/apply/)(RasterImage) | Past het huidige filter toe op de invoer‑[`RasterImage`](../../aspose.psd/rasterimage/) afbeelding. |
+| [ApplyToMask](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/applytomask/)(Layer) | Past het huidige filter toe op de invoer‑[`Layer`](../../aspose.psd.fileformats.psd.layers/layer/) maskergegevens. |
+| [Clone](../../aspose.psd.fileformats.psd.layers.smartfilters/smartfilter/clone/)() | Maakt de lid‑voor‑lid kloon van de huidige instantie van het type. |
+
+## Velden
+
+| Naam | Beschrijving |
+| --- | --- |
+| const [FilterType](../../aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/) | De identificatie van de huidige smart filter. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // bewerk smart filters
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controleer filterwaarden
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // werk filterwaarden bij
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // voeg nieuwe filteritems toe
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // pas wijzigingen toe
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SmartFilter](../smartfilter/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.FilterId"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SharpenSmartFilter eigenschap. Haalt de type-identificatie van de slimme filter op"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filterid/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.FilterId property
+
+Haalt de type‑identificatie van de smart filter op.
+
+```csharp
+public override int FilterId { get; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // bewerk smart filters
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controleer filterwaarden
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // werk filterwaarden bij
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // voeg nieuwe filteritems toe
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // pas wijzigingen toe
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.FilterType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SharpenSmartFilter veld. De identificatie van de huidige slimme filter"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/filtertype/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.FilterType field
+
+De identificatie van de huidige smart filter.
+
+```csharp
+public const int FilterType;
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // bewerk smart filters
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controleer filterwaarden
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // werk filterwaarden bij
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // voeg nieuwe filteritems toe
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // pas wijzigingen toe
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/_index.md
@@ -1,0 +1,74 @@
+---
+title: "SharpenSmartFilter.Name"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SharpenSmartFilter eigenschap. Haalt de naam van de slimme filter op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/name/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter.Name property
+
+Haalt de naam van de smart filter op.
+
+```csharp
+public override string Name { get; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // bewerk smart filters
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controleer filterwaarden
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // werk filterwaarden bij
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // voeg nieuwe filteritems toe
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // pas wijzigingen toe
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/_index.md
@@ -1,0 +1,95 @@
+---
+title: "SharpenSmartFilter.SharpenSmartFilter"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SharpenSmartFilter-constructeur. Initialiseert een nieuw exemplaar van de SharpenSmartFilter-klasse."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartfilters/sharpensmartfilter/sharpensmartfilter/
+---
+{{< psd/tize >}}
+## SharpenSmartFilter() {#constructor}
+
+Initialiseert een nieuw exemplaar van de [`SharpenSmartFilter`](../) klasse.
+
+```csharp
+public SharpenSmartFilter()
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van SharpenSmartFilter.
+
+```csharp
+[C#]
+
+string sourceFile = "sharpen_source.psd";
+string outputPsd = "sharpen_output.psd";
+string outputPng = "sharpen_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    SmartObjectLayer smartObj = (SmartObjectLayer)image.Layers[1];
+
+    // bewerk smart filters
+    SharpenSmartFilter sharpen = (SharpenSmartFilter)smartObj.SmartFilters.Filters[0];
+
+    // controleer filterwaarden
+    AssertAreEqual(BlendMode.Normal, sharpen.BlendMode);
+    AssertAreEqual(100d, sharpen.Opacity);
+    AssertAreEqual(true, sharpen.IsEnabled);
+
+    // werk filterwaarden bij
+    sharpen.BlendMode = BlendMode.Divide;
+    sharpen.Opacity = 75;
+    sharpen.IsEnabled = false;
+
+    // voeg nieuwe filteritems toe
+    var filters = new List<SmartFilter>(smartObj.SmartFilters.Filters);
+    filters.Add(new SharpenSmartFilter());
+    smartObj.SmartFilters.Filters = filters.ToArray();
+
+    // pas wijzigingen toe
+    smartObj.SmartFilters.UpdateResourceValues();
+    smartObj.UpdateModifiedContent();
+
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## SharpenSmartFilter(DescriptorStructure) {#constructor_1}
+
+Initialiseert een nieuw exemplaar van de [`SharpenSmartFilter`](../) klasse.
+
+```csharp
+public SharpenSmartFilter(DescriptorStructure sourceDescriptor)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| sourceDescriptor | DescriptorStructure | De descriptorstructuur met informatie over slimme filters. |
+
+### Zie ook
+
+* class [DescriptorStructure](../../../aspose.psd.fileformats.psd.layers.layerresources.typetoolinfostructures/descriptorstructure/)
+* class [SharpenSmartFilter](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartFilters](../../../aspose.psd.fileformats.psd.layers.smartfilters/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/_index.md
@@ -1,0 +1,28 @@
+---
+title: "SmartObjectLayer.SmartObjectLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SmartObjectLayer constructor. Initialiseert een nieuw exemplaar van de SmartObjectLayer-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/smartobjectlayer/
+---
+{{< psd/tize >}}
+## SmartObjectLayer constructor
+
+Initialiseert een nieuw exemplaar van de [`SmartObjectLayer`](../) klasse.
+
+```csharp
+public SmartObjectLayer(Stream stream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| stroom | Stroom | De stroom van items |
+
+### Zie ook
+
+* class [SmartObjectLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartObjects](../../../aspose.psd.fileformats.psd.layers.smartobjects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/_index.md
@@ -1,0 +1,108 @@
+---
+title: "SmartObjectLayer.WarpSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "SmartObjectLayer eigenschap. Haalt op of stelt Warp-parameters in die van de resource-standaard zijn ingesteld of opgehaald."
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.smartobjects/smartobjectlayer/warpsettings/
+---
+{{< psd/tize >}}
+## SmartObjectLayer.WarpSettings property
+
+Haalt op of stelt Warp-parameters in die van de resource (standaard) zijn ingesteld of opgehaald
+
+```csharp
+public WarpSettings WarpSettings { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* class [WarpSettings](../../../aspose.psd.fileformats.psd.layers.warp/warpsettings/)
+* class [SmartObjectLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.SmartObjects](../../../aspose.psd.fileformats.psd.layers.smartobjects/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/_index.md
@@ -1,0 +1,25 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Layers.Warp"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "De namespace bevat API om tekstlaaggegevens te manipuleren"
+type: docs
+weight: 370
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/
+---
+{{< psd/tize >}}
+De namespace bevat API om de gegevens van tekstlagen te manipuleren
+
+## Klassen
+
+| Klasse | Beschrijving |
+| --- | --- |
+| [WarpSettings](./warpsettings/) | Parameters van laag met warp |
+## Enumeratie
+
+| Enumeratie | Beschrijving |
+| --- | --- |
+| [RenderQuality](./renderquality/) | Het beschrijft de renderkwaliteit van Warp. |
+| [WarpRotates](./warprotates/) | Typen van warprotatie |
+| [WarpStyles](./warpstyles/) | Typen van ondersteunde warpstijlen |
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/renderquality/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/renderquality/_index.md
@@ -1,0 +1,68 @@
+---
+title: "Enum RenderQuality"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.RenderQuality enum. Het beschrijft de renderkwaliteit van Warp"
+type: docs
+weight: 3990
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/renderquality/
+---
+{{< psd/tize >}}
+## RenderQuality enumeration
+
+Het beschrijft de renderkwaliteit van Warp.
+
+```csharp
+public enum RenderQuality
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Turbo | `4` | De snelste optie, maar de kwaliteit lijdt eronder. |
+| VeryFast | `18` | Als je het snel nodig hebt, kan het geschikt zijn voor kleine krommingen. |
+| Fast | `35` | Staat je toe om het renderen sneller te maken met een kleine kwaliteitsvermindering. |
+| Normal | `60` | Aanbevolen waarde voor de meeste krommingen |
+| Good | `130` | Hoger dan standaardkwaliteit, tragere snelheid. Aanbevolen voor sterke vervormingen. |
+| Excellent | `260` | De langzaamste optie. Aanbevolen voor sterke vervormingen en hoge resoluties. |
+
+## Voorbeelden
+
+De volgende code toont de WarpSettings.RenderQuality-eigenschap om warp-deformatie te configureren.
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+RenderQuality[] qualityValues = { RenderQuality.Turbo, RenderQuality.Fast, RenderQuality.Normal, RenderQuality.Excellent };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Het haalt WarpSettings op van de Smart Layer
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Het stelt de grootte van het warp-verwerkingsgebied in
+        warpSettings.RenderQuality = qualityValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + qualityValues[i].ToString() + ".png";
+        outputFiles.Add(outputFile);
+
+        // Er zou hier geen fout moeten zijn
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warprotates/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warprotates/_index.md
@@ -1,0 +1,113 @@
+---
+title: "Enum WarpRotates"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpRotates enum. Typen van warp rotatie"
+type: docs
+weight: 4000
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warprotates/
+---
+{{< psd/tize >}}
+## WarpRotates enumeration
+
+Typen van warprotatie
+
+```csharp
+public enum WarpRotates
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Horizontal | `0` | Horizontale warp richting |
+| Vertical | `1` | Verticale warp richting |
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/_index.md
@@ -1,0 +1,127 @@
+---
+title: "Klasse WarpSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpSettings klasse. Parameters van laag met warp"
+type: docs
+weight: 4010
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/
+---
+{{< psd/tize >}}
+## WarpSettings class
+
+Parameters van laag met warp
+
+```csharp
+public class WarpSettings
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [WarpSettings](warpsettings/#constructor_1)(PlacedResource) | Initialiseert een nieuw exemplaar van de `WarpSettings` klasse. |
+| [WarpSettings](warpsettings/#constructor)(OSTypeStructure[], Rectangle) | Initialiseert een nieuw exemplaar van de `WarpSettings` klasse. |
+| [WarpSettings](warpsettings/#constructor_2)(PointF[], Rectangle) | Initialiseert een nieuw exemplaar van de `WarpSettings` klasse. |
+| [WarpSettings](warpsettings/#constructor_3)(PointF[], Rectangle, WarpStyles) | Initialiseert een nieuw exemplaar van de `WarpSettings` klasse. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Bounds](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/) { get; } | Haalt op of stelt de grenzen van de warp-afbeelding in |
+| [GridSize](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/) { get; set; } | Haalt op of stelt de grootte van het warp-rooster in. Standaard is 1. |
+| [MeshPoints](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/) { get; set; } | Photoshop-meshpunten |
+| [RenderQuality](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/) { get; set; } | Haalt op of stelt de waarde van warp-renderkwaliteit in - tussen snelheid en kwaliteit |
+| [Rotate](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/) { get; set; } | Haalt op of stelt de rotatiewaarde in |
+| [Style](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/style/) { get; set; } | Haalt op of stelt de stijl van warp in |
+| [Value](../../aspose.psd.fileformats.psd.layers.warp/warpsettings/value/) { get; set; } | Haalt op of stelt de waarde van warp in |
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/_index.md
@@ -1,0 +1,25 @@
+---
+title: "WarpSettings.Bounds"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de grenzen van de warp-afbeelding op of stelt deze in"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/bounds/
+---
+{{< psd/tize >}}
+## WarpSettings.Bounds property
+
+Haalt op of stelt de grenzen van de warp-afbeelding in
+
+```csharp
+public Rectangle Bounds { get; }
+```
+
+### Zie ook
+
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/_index.md
@@ -1,0 +1,55 @@
+---
+title: "WarpSettings.GridSize"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de grootte van het warp-raster op of stelt deze in. Standaard is 1"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/gridsize/
+---
+{{< psd/tize >}}
+## WarpSettings.GridSize property
+
+Haalt op of stelt de grootte van het warp-rooster in. Standaard is 1.
+
+```csharp
+public Size GridSize { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de WarpSettings.GridSize eigenschap.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Warp-instellingen ophalen
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Nieuwe grootte instellen
+    // Voor Photoshop kan de waarde tussen 1 en 50 liggen en kun je een PSD-bestand niet correct opslaan.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Geldige waarde instellen
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Voorbeeldbestand renderen met x3 raster
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Zie ook
+
+* struct [Size](../../../aspose.psd/size/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/_index.md
@@ -1,0 +1,25 @@
+---
+title: "WarpSettings.MeshPoints"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings property. Photoshop-meshpunten"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/meshpoints/
+---
+{{< psd/tize >}}
+## WarpSettings.MeshPoints property
+
+Photoshop-meshpunten
+
+```csharp
+public PointF[] MeshPoints { get; set; }
+```
+
+### Zie ook
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/_index.md
@@ -1,0 +1,58 @@
+---
+title: "WarpSettings.ProcessingArea"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings property. Haalt of stelt de waarde van de grootte van het verwerkingsgebied in. Standaardwaarde is 10. Bereik is 240"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/processingarea/
+---
+{{< psd/tize >}}
+## WarpSettings.ProcessingArea property
+
+Haalt of stelt de waarde van de grootte van het verwerkingsgebied in. Standaardwaarde is 10. Bereik is [2;40]
+
+```csharp
+public int ProcessingArea { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont WarpSettings.ProcessingArea property om warp-deformatie te configureren.
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+int[] areaValues = { 5, 10, 25, 40 };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Het haalt WarpSettings op van de Smart Layer
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Het stelt de grootte van het warp-verwerkingsgebied in
+        warpSettings.ProcessingArea = areaValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + areaValues[i] + ".png";
+        outputFiles.Add(outputFile);
+
+        // Er zou hier geen fout moeten zijn
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Zie ook
+
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/_index.md
@@ -1,0 +1,59 @@
+---
+title: "WarpSettings.RenderQuality"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de waarde van warp-renderkwaliteit op of stelt deze in, tussen snelheid en kwaliteit"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/renderquality/
+---
+{{< psd/tize >}}
+## WarpSettings.RenderQuality property
+
+Haalt op of stelt de waarde van warp-renderkwaliteit in - tussen snelheid en kwaliteit
+
+```csharp
+public RenderQuality RenderQuality { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont de WarpSettings.RenderQuality-eigenschap om warp-deformatie te configureren.
+
+```csharp
+[C#]
+
+string sourceFile = "Warping.psd";
+List<string> outputFiles = new List<string>();
+
+PsdLoadOptions loadOptions = new PsdLoadOptions() { LoadEffectsResource = true, AllowWarpRepaint = true };
+
+RenderQuality[] qualityValues = { RenderQuality.Turbo, RenderQuality.Fast, RenderQuality.Normal, RenderQuality.Excellent };
+
+for (int i = 0; i < 4; i++)
+{
+    using (var psdImage = (PsdImage)Image.Load(sourceFile, loadOptions))
+    {
+        // Het haalt WarpSettings op van de Smart Layer
+        WarpSettings warpSettings = ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings;
+
+        // Het stelt de grootte van het warp-verwerkingsgebied in
+        warpSettings.RenderQuality = qualityValues[i];
+        ((SmartObjectLayer)psdImage.Layers[1]).WarpSettings = warpSettings;
+
+        string outputFile = "export" + qualityValues[i].ToString() + ".png";
+        outputFiles.Add(outputFile);
+
+        // Er zou hier geen fout moeten zijn
+        psdImage.Save(outputFile, new PngOptions { ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+```
+
+### Zie ook
+
+* enum [RenderQuality](../../renderquality/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/_index.md
@@ -1,0 +1,108 @@
+---
+title: "WarpSettings.Rotate"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de rotatiewaarde op of stelt deze in"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/rotate/
+---
+{{< psd/tize >}}
+## WarpSettings.Rotate property
+
+Haalt op of stelt de rotatiewaarde in
+
+```csharp
+public WarpRotates Rotate { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* enum [WarpRotates](../../warprotates/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/_index.md
@@ -1,0 +1,108 @@
+---
+title: "WarpSettings.Style"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de stijl van warp op of stelt deze in"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/style/
+---
+{{< psd/tize >}}
+## WarpSettings.Style property
+
+Haalt op of stelt de stijl van warp in
+
+```csharp
+public WarpStyles Style { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* enum [WarpStyles](../../warpstyles/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/_index.md
@@ -1,0 +1,24 @@
+---
+title: "WarpSettings.Value"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings eigenschap. Haalt de waarde van warp op of stelt deze in"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/value/
+---
+{{< psd/tize >}}
+## WarpSettings.Value property
+
+Haalt op of stelt de waarde van warp in
+
+```csharp
+public double Value { get; set; }
+```
+
+### Zie ook
+
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/_index.md
@@ -1,0 +1,160 @@
+---
+title: "WarpSettings.WarpSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "WarpSettings constructor. Initialiseert een nieuw exemplaar van de WarpSettings-klasse"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpsettings/warpsettings/
+---
+{{< psd/tize >}}
+## WarpSettings(PointF[], Rectangle) {#constructor_2}
+
+Initialiseert een nieuw exemplaar van de [`WarpSettings`](../) klasse.
+
+```csharp
+public WarpSettings(PointF[] meshPoints, Rectangle bounds)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| meshPoints | PointF[] | De mesh-punten van warp |
+| bounds | Rechthoek | De grenzen van warp-afbeelding |
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de WarpSettings.GridSize eigenschap.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Warp-instellingen ophalen
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Nieuwe grootte instellen
+    // Voor Photoshop kan de waarde tussen 1 en 50 liggen en kun je een PSD-bestand niet correct opslaan.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Geldige waarde instellen
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Voorbeeldbestand renderen met x3 raster
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Zie ook
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(PointF[], Rectangle, WarpStyles) {#constructor_3}
+
+Initialiseert een nieuw exemplaar van de [`WarpSettings`](../) klasse.
+
+```csharp
+public WarpSettings(PointF[] meshPoints, Rectangle bounds, WarpStyles style)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| meshPoints | PointF[] | De mesh-punten van warp |
+| bounds | Rechthoek | De grenzen van warp-afbeelding |
+| stijl | WarpStyles | De stijl van warp |
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de WarpSettings.GridSize eigenschap.
+
+```csharp
+[C#]
+
+string sourceFile = "pirate_x3.psd";
+string outputFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions() { AllowWarpRepaint = true, LoadEffectsResource = true }))
+{
+    // Warp-instellingen ophalen
+    WarpSettings warpSettings = ((SmartObjectLayer)(psdImage.Layers[0])).WarpSettings;
+
+    // Nieuwe grootte instellen
+    // Voor Photoshop kan de waarde tussen 1 en 50 liggen en kun je een PSD-bestand niet correct opslaan.
+    warpSettings.GridSize = new Size(100, 100);
+
+    // Geldige waarde instellen
+    warpSettings.GridSize = new Size(3, 3);
+
+    // Voorbeeldbestand renderen met x3 raster
+    psdImage.Save(outputFile, new PngOptions
+    {
+        ColorType = PngColorType.TruecolorWithAlpha
+    });
+}
+```
+
+### Zie ook
+
+* struct [PointF](../../../aspose.psd/pointf/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* enum [WarpStyles](../../warpstyles/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(OSTypeStructure[], Rectangle) {#constructor}
+
+Initialiseert een nieuw exemplaar van de [`WarpSettings`](../) klasse.
+
+```csharp
+public WarpSettings(OSTypeStructure[] warpItems, Rectangle bounds)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| warpItems | OSTypeStructure[] | PS-items met warp-instellingen |
+| bounds | Rechthoek | De grenzen van warp-afbeelding |
+
+### Zie ook
+
+* class [OSTypeStructure](../../../aspose.psd.fileformats.psd.layers.layerresources/ostypestructure/)
+* struct [Rectangle](../../../aspose.psd/rectangle/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## WarpSettings(PlacedResource) {#constructor_1}
+
+Initialiseert een nieuw exemplaar van de [`WarpSettings`](../) klasse.
+
+```csharp
+public WarpSettings(PlacedResource placedResource)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| placedResource | PlacedResource | De bron met warp-instellingen |
+
+### Zie ook
+
+* class [PlacedResource](../../../aspose.psd.fileformats.psd.layers.layerresources/placedresource/)
+* class [WarpSettings](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/_index.md
@@ -1,0 +1,125 @@
+---
+title: "Enum WarpStyles"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.Warp.WarpStyles enum. Typen van ondersteunde warp-stijlen"
+type: docs
+weight: 4020
+url: /nl/net/aspose.psd.fileformats.psd.layers.warp/warpstyles/
+---
+{{< psd/tize >}}
+## WarpStyles enumeration
+
+Typen van ondersteunde warpstijlen
+
+```csharp
+public enum WarpStyles
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| None | `0` | De stijl wordt ingesteld wanneer de laag zonder vervorming is. |
+| Custom | `1` | Stijl met willekeurige verplaatsing van punten |
+| Arc | `2` | Boogstijl van warp |
+| ArcUpper | `3` | Bovenboogstijl van warp |
+| ArcLower | `4` | Onderboogstijl van warp |
+| Arch | `5` | Arch-stijl van warp |
+| Bulge | `6` | Bultstijl van warp |
+| Flag | `7` | Vlagstijl van warp |
+| Fish | `8` | Vissestijl van warp |
+| Rise | `9` | Stijgende stijl van warp |
+| Wave | `10` | Golfstijl van warp |
+| Twist | `11` | Draai-type van warp |
+| Squeeze | `12` | Pers-type van warp |
+| Inflate | `13` | Opblazen-type van warp |
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers.Warp](../../aspose.psd.fileformats.psd.layers.warp/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/_index.md
@@ -1,0 +1,211 @@
+---
+title: "Klasse ArtboardLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.ArtboardLayer klasse. De artboard-laagklasse"
+type: docs
+weight: 1990
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/
+---
+{{< psd/tize >}}
+## ArtboardLayer class
+
+De artboard-laagklasse.
+
+```csharp
+public sealed class ArtboardLayer : LayerGroup
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de palette automatisch wordt aangepast. |
+| override [BackgroundColor](../../aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/) { get; set; } | Haalt of stelt de artboard-achtergrondkleur in. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Haalt het aantal bits per pixel van de afbeelding op. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Haalt of stelt de mengmodus van het bijgesneden element in. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Haalt de mengopties op. |
+| override [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layergroup/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Haalt de blend-modus handtekening op. |
+| override [Bottom](../../aspose.psd.fileformats.psd.layers/artboardlayer/bottom/) { get; set; } |  |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Haalt de afbeeldinggrenzen op. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Haalt of stelt de kanaalinformatie in. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Haalt het aantal kanalen van de laag op. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Haalt of stelt de laagclip in. 0 = basis, 1 = niet-basis. |
+| [Container](../../aspose.psd/image/container/) { get; } | Haalt de [`Image`](../../aspose.psd/image/) container op. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Haalt de gegevensstroom van het object op. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Haalt of stelt de weergavenaam van de laag in. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Haalt een waarde op die aangeeft of deze instantie is vrijgegeven. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Haalt de lengte van extra laaginformatie op in bytes. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Haalt een bestandsformaatwaarde op. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Haalt of stelt de laagvuller in. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Haalt of stelt de vulopaciteit in. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Haalt of stelt de laagvlaggen in. bit 0 = transparantie beschermd; bit 1 = zichtbaar; bit 2 = verouderd; bit 3 = 1 voor Photoshop 5.0 en later, geeft aan of bit 4 nuttige informatie bevat; bit 4 = pixelgegevens irrelevant voor het uiterlijk van het document. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Haalt een waarde op die aangeeft of deze instantie een alfa-kanaal heeft. |
+| override [HasBackgroundColor](../../aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/) { get; } | Haalt of stelt een waarde in die aangeeft of `ArtboardLayer` de achtergrondkleur heeft. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Haalt een waarde op die aangeeft of de afbeelding een transparante kleur heeft. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/artboardlayer/height/) { get; } |  |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Haalt of stelt de horizontale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) in. |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Haalt de opaciteit van deze afbeelding op. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Haalt of stelt de interruptmonitor in. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Haalt een waarde op die aangeeft of afbeeldingsgegevens momenteel in de cache staan. |
+| [IsOpen](../../aspose.psd.fileformats.psd.layers/layergroup/isopen/) { get; set; } | Haalt of stelt in of de map geopend is; indien ingesteld op `true` zal de groep bij opstarten in de geopende toestand zijn, anders in geminimaliseerde toestand. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Haalt een waarde op die aangeeft of het laden van ruwe gegevens beschikbaar is. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de laag zichtbaar is |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Haalt een waarde op die aangeeft of deze instantie zichtbaar is in de groep (Als de laag niet in een groep zit, betekent dit de hoofdgroep). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Haalt de gegevens van de laagmengbereiken op of stelt deze in. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Haalt de aanmaakdatum en -tijd van de laag op of stelt deze in. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Haalt de vergrendeling van de laag op of stelt deze in. Merk op dat als de vlag LayerFlags.TransparencyProtected is ingesteld, deze wordt overschreven door de vergrendelingsvlag van de laag. Om de vlag LayerFlags.TransparencyProtected terug te geven, moet de laagoptie layer.Flags &#x7C;= LayerFlags.TransparencyProtected worden toegepast |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Haalt de maskergegevens van de laag op of stelt deze in. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Haalt de laagopties op. |
+| [Layers](../../aspose.psd.fileformats.psd.layers/layergroup/layers/) { get; } | Haalt de lagen op in de laaggroep |
+| override [Left](../../aspose.psd.fileformats.psd.layers/artboardlayer/left/) { get; set; } |  |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Haalt de totale laaglengte in bytes op. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Haalt de laagnaam op of stelt deze in. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Haalt de laagopaciteit op of stelt deze in. 0 = transparant, 255 = ondoorzichtig. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Haalt het kleurenpalet op of stelt dit in. Het kleurenpalet wordt niet gebruikt wanneer pixels direct worden weergegeven. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de afbeeldingscomponenten voorvermenigvuldigd moeten worden. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Haalt de aangepaste kleuromschakelaar op of stelt deze in. |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Haalt het ruwe gegevensformaat op. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Haalt de huidige ruwe gegevensinstellingen op. Merk op dat bij het gebruik van deze instellingen de gegevens zonder conversie worden geladen. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Haalt de fallback-index op of stelt deze in die moet worden gebruikt wanneer de paletindex buiten de grenzen valt |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Haalt de geïndexeerde kleuromschakelaar op of stelt deze in |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Haalt de ruwe regelgrootte in bytes op. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Haalt de laagbronnen op of stelt deze in. |
+| override [Right](../../aspose.psd.fileformats.psd.layers/artboardlayer/right/) { get; set; } |  |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Haalt de decoratieve bladkleurmarkering in de lagenlijst op of stelt deze in |
+| [Size](../../aspose.psd/image/size/) { get; } | Haalt de afbeeldingsgrootte op. |
+| override [Top](../../aspose.psd.fileformats.psd.layers/artboardlayer/top/) { get; set; } |  |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Haalt de transparante kleur van de afbeelding op. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de XMP-metadata moet worden bijgewerkt. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of ruwe gegevens moeten worden geladen wanneer het laden van ruwe gegevens beschikbaar is. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Haalt de verticale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) op of stelt deze in. |
+| override [Width](../../aspose.psd.fileformats.psd.layers/artboardlayer/width/) { get; } |  |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Haalt de XMP-metadata op of stelt deze in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AddLayer](../../aspose.psd.fileformats.psd.layers/layergroup/addlayer/)(Layer) | Voegt de laag toe aan de laaggroep. |
+| [AddLayerGroup](../../aspose.psd.fileformats.psd.layers/layergroup/addlayergroup/)(string, int) | Voegt de laaggroep toe. |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Voegt het masker toe aan de huidige laag. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Past de helderheid van de afbeelding aan. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Afbeeldingscontrast |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Gamma-correctie van een afbeelding. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Gamma-correctie van een afbeelding. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Past het laagmasker toe op de laag en verwijdert vervolgens het masker. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarisatie van een afbeelding met een vooraf gedefinieerde drempel. |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarisatie van een afbeelding met Otsu-drempeling. |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Cachet de gegevens en zorgt ervoor dat er geen extra gegevens worden geladen vanuit de onderliggende [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/). |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Bepaalt of de afbeelding kan worden opgeslagen in het opgegeven bestandsformaat dat wordt vertegenwoordigd door de meegegeven opslagopties. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Bijsnijden van de afbeelding. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Afbeelding bijsnijden met verschuivingen. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Disposeert de huidige instantie. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Voert dithering uit op de huidige afbeelding. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Voert dithering uit op de huidige afbeelding. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Tekent de afbeelding op de laag. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtert de opgegeven rechthoek. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Haalt een 32-bit ARGB-pixel van de afbeelding op. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Haalt de standaard 32-bit ARGB-pixelarray op. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Haalt de standaardopties op. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Haalt de standaardpixelarray op met behulp van de gedeeltelijke pixelloader. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Haalt de standaard ruwe gegevensarray op. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Haalt de standaard ruwe gegevensarray op met behulp van de gedeeltelijke pixelloader. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Retourneert een hashcode voor deze instantie. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Haalt de datum en tijd op waarop de bronafbeelding voor het laatst is gewijzigd. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Haalt de opties op op basis van de oorspronkelijke bestandsinstellingen. Dit kan handig zijn om de bitsdiepte en andere parameters van de oorspronkelijke afbeelding ongewijzigd te houden. Bijvoorbeeld, als we een zwart-wit PNG-afbeelding met 1 bit per pixel laden en deze vervolgens opslaan met de [`Save`](../../aspose.psd/datastreamsupporter/save/) methode, wordt een PNG-afbeelding met 8-bit per pixel gegenereerd. Om dit te voorkomen en een PNG-afbeelding met 1-bit per pixel op te slaan, gebruik deze methode om de bijbehorende opslagopties te verkrijgen en geef ze door aan de [`Save`](../../aspose.psd/image/save/) methode als tweede parameter. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Haalt een afbeeldingspixel op. Prestatiewaarschuwing: Vermijd het gebruik van deze methode om over alle afbeeldingspixels te itereren, omdat dit kan leiden tot aanzienlijke prestatieproblemen. Voor efficiëntere pixelmanipulatie, gebruik de `LoadArgb32Pixels` methode om de volledige pixelarray in één keer op te halen. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Haalt de scheefstandhoek op. Deze methode is toepasbaar op gescande tekstdocumenten om de scheefstandhoek bij het scannen te bepalen. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Transformatie van een afbeelding naar zijn grijswaardenrepresentatie |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Laadt 32-bit ARGB-pixels. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Laadt 64-bit ARGB-pixels. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Laadt pixels in CMYK-formaat. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Laadt pixels in CMYK-formaat. Deze methode is verouderd. Gebruik alstublieft de effectievere [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/) methode. |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Laadt 32-bit ARGB-pixels gedeeltelijk per pakketten. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Laadt pixels gedeeltelijk per pakketten. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Laadt pixels. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| virtual [MergeLayerTo](../../aspose.psd.fileformats.psd.layers/layer/mergelayerto/)(Layer) | Voegt de laag samen met de opgegeven laag |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Wijzigt de grootte van de afbeelding. De standaard NearestNeighbourResample wordt gebruikt. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Wijzigt de grootte van de afbeelding. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Wijzigt de grootte van de afbeelding. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Wijzigt de hoogte proportioneel. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Wijzigt de breedte proportioneel. De standaard NearestNeighbourResample wordt gebruikt. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Wijzigt de breedte proportioneel. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Wijzigt de breedte proportioneel. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Roteer de afbeelding rond het centrum. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Roteer de afbeelding rond het centrum. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Roteert, spiegelt of roteert en spiegelt de afbeelding. |
+| [Save](../../aspose.psd/image/save/)() | Slaat de afbeeldingsgegevens op in de onderliggende stream. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Slaat de gegevens van het object op in de opgegeven stream. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Slaat de 32-bit ARGB-pixels op. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Slaat de pixels op. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Slaat de pixels op. Deze methode is verouderd. Gebruik alstublieft de meer effectieve [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/) methode. |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Slaat de pixels op. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Slaat de ruwe gegevens op. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Stelt een 32-bit ARGB-pixel van de afbeelding in voor de opgegeven positie. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Stelt het kleurenpalet van de afbeelding in. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Stelt een afbeeldingspixel in voor de opgegeven positie. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Stelt de resolutie in voor deze [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Maakt een ondiepe kopie van de huidige laag. Zie [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) voor uitleg. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converteert rasterafbeelding naar de bitmap. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning voor het exporteren van ArtboardLayer als afzonderlijke afbeeldingen en als één afbeelding.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Zie ook
+
+* class [LayerGroup](../layergroup/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ArtboardLayer.BackgroundColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap. Krijgt of stelt de achtergrondkleur van het artboard in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/backgroundcolor/
+---
+{{< psd/tize >}}
+## ArtboardLayer.BackgroundColor property
+
+Haalt of stelt de artboard-achtergrondkleur in.
+
+```csharp
+public override Color BackgroundColor { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning voor het exporteren van ArtboardLayer als afzonderlijke afbeeldingen en als één afbeelding.
+
+```csharp
+[C#]
+
+string srcFile = "artboard2.psd";
+
+string outFilePng0 = "art0.png";
+string outFilePng1 = "art1.png";
+string outFilePng2 = "art2.png";
+string outFilePng3 = "art3.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile))
+{
+    ArtboardLayer art1 = (ArtboardLayer)psdImage.Layers[4];
+    ArtboardLayer art2 = (ArtboardLayer)psdImage.Layers[9];
+    ArtboardLayer art3 = (ArtboardLayer)psdImage.Layers[14];
+
+    var pngSaveOptions = new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha };
+    art1.Save(outFilePng1, pngSaveOptions);
+    art2.Save(outFilePng2, pngSaveOptions);
+    art3.Save(outFilePng3, pngSaveOptions);
+
+    psdImage.Save(outFilePng0, pngSaveOptions);
+}
+```
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Bottom"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/bottom/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Bottom property
+
+```csharp
+public override int Bottom { get; set; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/_index.md
@@ -1,0 +1,24 @@
+---
+title: "ArtboardLayer.HasBackgroundColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap. Krijgt of stelt een waarde in die aangeeft of ArtboardLayer de achtergrondkleur heeft"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/hasbackgroundcolor/
+---
+{{< psd/tize >}}
+## ArtboardLayer.HasBackgroundColor property
+
+Krijgt of stelt een waarde in die aangeeft of [`ArtboardLayer`](../) de achtergrondkleur heeft.
+
+```csharp
+public override bool HasBackgroundColor { get; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Height"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/height/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Height property
+
+```csharp
+public override int Height { get; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Left"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/left/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Left property
+
+```csharp
+public override int Left { get; set; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Right"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/right/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Right property
+
+```csharp
+public override int Right { get; set; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Top"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/top/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Top property
+
+```csharp
+public override int Top { get; set; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/_index.md
@@ -1,0 +1,22 @@
+---
+title: "ArtboardLayer.Width"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ArtboardLayer eigenschap."
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers/artboardlayer/width/
+---
+{{< psd/tize >}}
+## ArtboardLayer.Width property
+
+```csharp
+public override int Width { get; }
+```
+
+### Zie ook
+
+* class [ArtboardLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/_index.md
@@ -1,0 +1,30 @@
+---
+title: "IGradientColorPoint.Color"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IGradientColorPoint eigenschap. Haalt de kleur op of stelt deze in"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers/igradientcolorpoint/color/
+---
+{{< psd/tize >}}
+## IGradientColorPoint.Color property
+
+Haalt de kleur op of stelt deze in.
+
+```csharp
+[Obsolete]
+public Color Color { get; set; }
+```
+
+### Property Value
+
+De kleur.
+
+### Zie ook
+
+* struct [Color](../../../aspose.psd/color/)
+* interface [IGradientColorPoint](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/_index.md
@@ -1,0 +1,115 @@
+---
+title: "Interface IShapeLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.IShapeLayer interface. Beschrijft de eigenschappen van een Shape‑laag."
+type: docs
+weight: 2260
+url: /nl/net/aspose.psd.fileformats.psd.layers/ishapelayer/
+---
+{{< psd/tize >}}
+## IShapeLayer interface
+
+Beschrijft de eigenschappen van een Shape‑laag.
+
+```csharp
+public interface IShapeLayer
+```
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [Fill](../../aspose.psd.fileformats.psd.layers/ishapelayer/fill/) { get; set; } | Vulinstellingen die worden gebruikt om het interne gebied van Shapes te vullen. |
+| [Path](../../aspose.psd.fileformats.psd.layers/ishapelayer/path/) { get; } | De verzameling paden die aanwezig zijn in een Shape‑laag. |
+| [Stroke](../../aspose.psd.fileformats.psd.layers/ishapelayer/stroke/) { get; set; } | Stroke-instellingen van vormen. |
+
+## Voorbeelden
+
+De volgende code demonstreert het renderen van Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Controleer gewijzigde gegevens.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Fill"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IShapeLayer eigenschap. Vullingsinstellingen die worden gebruikt om het interne gebied van Shapes te vullen"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers/ishapelayer/fill/
+---
+{{< psd/tize >}}
+## IShapeLayer.Fill property
+
+Vulinstellingen die worden gebruikt om het interne gebied van Shapes te vullen.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+### Zie ook
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Path"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IShapeLayer eigenschap. De verzameling paden die aanwezig zijn in een Shape‑laag"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers/ishapelayer/path/
+---
+{{< psd/tize >}}
+## IShapeLayer.Path property
+
+De verzameling paden die aanwezig zijn in een Shape‑laag.
+
+```csharp
+public IPath Path { get; }
+```
+
+### Zie ook
+
+* interface [IPath](../../../aspose.psd.fileformats.psd.layers.layerresources/ipath/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/_index.md
@@ -1,0 +1,25 @@
+---
+title: "IShapeLayer.Stroke"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "IShapeLayer eigenschap. Lijninstellingen van Shapes"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers/ishapelayer/stroke/
+---
+{{< psd/tize >}}
+## IShapeLayer.Stroke property
+
+Stroke-instellingen van vormen.
+
+```csharp
+public IStrokeSettings Stroke { get; set; }
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/)
+* interface [IShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Layer.ApplyLayerMask"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Layer-methode. Past het laagmasker toe op de laag en verwijdert vervolgens het masker"
+type: docs
+weight: 350
+url: /nl/net/aspose.psd.fileformats.psd.layers/layer/applylayermask/
+---
+{{< psd/tize >}}
+## Layer.ApplyLayerMask method
+
+Past het laagmasker toe op de laag en verwijdert vervolgens het masker.
+
+```csharp
+public void ApplyLayerMask()
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de functionaliteit om een masker op de laag toe te passen.
+
+```csharp
+[C#]
+
+var sourceFile = "example.psd";
+var outFile = "export.png";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile, new PsdLoadOptions()))
+{
+    psdImage.Layers[1].ApplyLayerMask();
+
+    psdImage.Save(outFile, new PngOptions() { ColorType = PngColorType.TruecolorWithAlpha });
+}
+```
+
+### Zie ook
+
+* class [Layer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Layer.BlendClippedElements"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Layer eigenschap. Krijgt of stelt de menging van het bijgesneden element in"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers/layer/blendclippedelements/
+---
+{{< psd/tize >}}
+## Layer.BlendClippedElements property
+
+Haalt of stelt de mengmodus van het bijgesneden element in.
+
+```csharp
+public bool BlendClippedElements { get; set; }
+```
+
+### Property Value
+
+De menging van het bijgesneden element.
+
+## Voorbeelden
+
+De volgende code toont de ondersteuning van de BlendClippedElements-eigenschap.
+
+```csharp
+[C#]
+
+string sourceFile = "example_source.psd";
+string outputPsd = "example_output.psd";
+string outputPng = "example_output.png";
+
+using (var image = (PsdImage)Image.Load(sourceFile))
+{
+    image.Layers[1].BlendClippedElements = false;
+    image.Save(outputPsd);
+    image.Save(outputPng, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [Layer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/layer/equals/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/layer/equals/_index.md
@@ -1,0 +1,31 @@
+---
+title: "Gelijk"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 350
+url: /nl/net/aspose.psd.fileformats.psd.layers/layer/equals/
+---
+## Layer.Equals method
+
+Bepaalt of het opgegeven Object gelijk is aan deze instantie.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | Object | Het Object om te vergelijken met deze instantie. |
+
+## Retourwaarde
+
+`true` als het opgegeven Object gelijk is aan deze instantie; anders `false`.
+
+### Zie ook
+
+* class [Layer](../../layer)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../layer)
+* assembly [Aspose.PSD](../../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/_index.md
@@ -1,0 +1,219 @@
+---
+title: "Class ShapeLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Layers.ShapeLayer class. Shape‑laag. Omvat de logica voor het werken met de Shape‑laag en gerelateerde resources."
+type: docs
+weight: 3820
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/
+---
+{{< psd/tize >}}
+## ShapeLayer class
+
+Shape‑laag. Omvat de logica voor het werken met de Shape‑laag en gerelateerde resources.
+
+```csharp
+public class ShapeLayer : Layer, IShapeLayer
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [ShapeLayer](shapelayer/)() | Initialiseert een nieuw exemplaar van de `ShapeLayer`‑klasse. Alle resources worden in hun standaardstatus aangemaakt. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [AutoAdjustPalette](../../aspose.psd/image/autoadjustpalette/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de palette automatisch wordt aangepast. |
+| virtual [BackgroundColor](../../aspose.psd/image/backgroundcolor/) { get; set; } | Haalt of stelt een waarde in voor de achtergrondkleur. |
+| override [BitsPerPixel](../../aspose.psd.fileformats.psd.layers/layer/bitsperpixel/) { get; } | Haalt het aantal bits per pixel van de afbeelding op. |
+| [BlendClippedElements](../../aspose.psd.fileformats.psd.layers/layer/blendclippedelements/) { get; set; } | Haalt of stelt de mengmodus van het bijgesneden element in. |
+| [BlendingOptions](../../aspose.psd.fileformats.psd.layers/layer/blendingoptions/) { get; } | Haalt de mengopties op. |
+| virtual [BlendModeKey](../../aspose.psd.fileformats.psd.layers/layer/blendmodekey/) { get; set; } | Haalt of stelt de blend mode key in. |
+| [BlendModeSignature](../../aspose.psd.fileformats.psd.layers/layer/blendmodesignature/) { get; } | Haalt de blend-modus handtekening op. |
+| virtual [Bottom](../../aspose.psd.fileformats.psd.layers/layer/bottom/) { get; set; } | Haalt of stelt de positie van de onderste laag in. |
+| [Bounds](../../aspose.psd/image/bounds/) { get; } | Haalt de afbeeldinggrenzen op. |
+| [BufferSizeHint](../../aspose.psd/image/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [ChannelInformation](../../aspose.psd.fileformats.psd.layers/layer/channelinformation/) { get; set; } | Haalt of stelt de kanaalinformatie in. |
+| [ChannelsCount](../../aspose.psd.fileformats.psd.layers/layer/channelscount/) { get; } | Haalt het aantal kanalen van de laag op. |
+| [Clipping](../../aspose.psd.fileformats.psd.layers/layer/clipping/) { get; set; } | Haalt of stelt de laagclip in. 0 = basis, 1 = niet-basis. |
+| [Container](../../aspose.psd/image/container/) { get; } | Haalt de [`Image`](../../aspose.psd/image/) container op. |
+| [DataStreamContainer](../../aspose.psd/datastreamsupporter/datastreamcontainer/) { get; } | Haalt de gegevensstroom van het object op. |
+| [DisplayName](../../aspose.psd.fileformats.psd.layers/layer/displayname/) { get; set; } | Haalt of stelt de weergavenaam van de laag in. |
+| [Disposed](../../aspose.psd/disposableobject/disposed/) { get; } | Haalt een waarde op die aangeeft of deze instantie is vrijgegeven. |
+| [ExtraLength](../../aspose.psd.fileformats.psd.layers/layer/extralength/) { get; } | Haalt de lengte van extra laaginformatie op in bytes. |
+| virtual [FileFormat](../../aspose.psd/image/fileformat/) { get; } | Haalt een bestandsformaatwaarde op. |
+| [Fill](../../aspose.psd.fileformats.psd.layers/shapelayer/fill/) { get; set; } | Haalt of stelt de vulinstellingen voor het interne gebied van vormen in de vormlaag in. |
+| [Filler](../../aspose.psd.fileformats.psd.layers/layer/filler/) { get; set; } | Haalt of stelt de laagvuller in. |
+| [FillOpacity](../../aspose.psd.fileformats.psd.layers/layer/fillopacity/) { get; set; } | Haalt of stelt de vulopaciteit in. |
+| [Flags](../../aspose.psd.fileformats.psd.layers/layer/flags/) { get; set; } | Haalt of stelt de laagvlaggen in. bit 0 = transparantie beschermd; bit 1 = zichtbaar; bit 2 = verouderd; bit 3 = 1 voor Photoshop 5.0 en later, geeft aan of bit 4 nuttige informatie bevat; bit 4 = pixelgegevens irrelevant voor het uiterlijk van het document. |
+| override [HasAlpha](../../aspose.psd.fileformats.psd.layers/layer/hasalpha/) { get; } | Haalt een waarde op die aangeeft of deze instantie een alfa-kanaal heeft. |
+| virtual [HasBackgroundColor](../../aspose.psd/image/hasbackgroundcolor/) { get; set; } | Haalt of stelt een waarde in die aangeeft of de afbeelding een achtergrondkleur heeft. |
+| virtual [HasTransparentColor](../../aspose.psd/rasterimage/hastransparentcolor/) { get; set; } | Haalt een waarde op die aangeeft of de afbeelding een transparante kleur heeft. |
+| override [Height](../../aspose.psd.fileformats.psd.layers/layer/height/) { get; } | Haalt de afbeeldinghoogte op. |
+| virtual [HorizontalResolution](../../aspose.psd/rasterimage/horizontalresolution/) { get; set; } | Haalt of stelt de horizontale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) in. |
+| virtual [ImageOpacity](../../aspose.psd/rasterimage/imageopacity/) { get; } | Haalt de opaciteit van deze afbeelding op. |
+| [InterruptMonitor](../../aspose.psd/image/interruptmonitor/) { get; set; } | Haalt of stelt de interruptmonitor in. |
+| override [IsCached](../../aspose.psd/rastercachedimage/iscached/) { get; } | Haalt een waarde op die aangeeft of afbeeldingsgegevens momenteel in de cache staan. |
+| [IsRawDataAvailable](../../aspose.psd/rasterimage/israwdataavailable/) { get; } | Haalt een waarde op die aangeeft of het laden van ruwe gegevens beschikbaar is. |
+| [IsVisible](../../aspose.psd.fileformats.psd.layers/layer/isvisible/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de laag zichtbaar is |
+| virtual [IsVisibleInGroup](../../aspose.psd.fileformats.psd.layers/layer/isvisibleingroup/) { get; } | Haalt een waarde op die aangeeft of deze instantie zichtbaar is in de groep (Als de laag niet in een groep zit, betekent dit de hoofdgroep). |
+| [LayerBlendingRangesData](../../aspose.psd.fileformats.psd.layers/layer/layerblendingrangesdata/) { get; set; } | Haalt de gegevens van de laagmengbereiken op of stelt deze in. |
+| [LayerCreationDateTime](../../aspose.psd.fileformats.psd.layers/layer/layercreationdatetime/) { get; set; } | Haalt de aanmaakdatum en -tijd van de laag op of stelt deze in. |
+| [LayerLock](../../aspose.psd.fileformats.psd.layers/layer/layerlock/) { get; set; } | Haalt de vergrendeling van de laag op of stelt deze in. Merk op dat als de vlag LayerFlags.TransparencyProtected is ingesteld, deze wordt overschreven door de vergrendelingsvlag van de laag. Om de vlag LayerFlags.TransparencyProtected terug te geven, moet de laagoptie layer.Flags &#x7C;= LayerFlags.TransparencyProtected worden toegepast |
+| [LayerMaskData](../../aspose.psd.fileformats.psd.layers/layer/layermaskdata/) { get; set; } | Haalt de maskergegevens van de laag op of stelt deze in. |
+| [LayerOptions](../../aspose.psd.fileformats.psd.layers/layer/layeroptions/) { get; } | Haalt de laagopties op. |
+| virtual [Left](../../aspose.psd.fileformats.psd.layers/layer/left/) { get; set; } | Haalt de positie van de linkse laag op of stelt deze in. |
+| [Length](../../aspose.psd.fileformats.psd.layers/layer/length/) { get; } | Haalt de totale laaglengte in bytes op. |
+| [Name](../../aspose.psd.fileformats.psd.layers/layer/name/) { get; set; } | Haalt de laagnaam op of stelt deze in. |
+| [Opacity](../../aspose.psd.fileformats.psd.layers/layer/opacity/) { get; set; } | Haalt de laagopaciteit op of stelt deze in. 0 = transparant, 255 = ondoorzichtig. |
+| [Palette](../../aspose.psd/image/palette/) { get; set; } | Haalt het kleurenpalet op of stelt dit in. Het kleurenpalet wordt niet gebruikt wanneer pixels direct worden weergegeven. |
+| [Path](../../aspose.psd.fileformats.psd.layers/shapelayer/path/) { get; } | Haalt de verzameling paden op die aanwezig zijn in een vormlaag. |
+| virtual [PremultiplyComponents](../../aspose.psd/rasterimage/premultiplycomponents/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de afbeeldingscomponenten voorvermenigvuldigd moeten worden. |
+| [RawCustomColorConverter](../../aspose.psd/rasterimage/rawcustomcolorconverter/) { get; set; } | Haalt de aangepaste kleuromschakelaar op of stelt deze in. |
+| virtual [RawDataFormat](../../aspose.psd/rasterimage/rawdataformat/) { get; } | Haalt het ruwe gegevensformaat op. |
+| [RawDataSettings](../../aspose.psd/rasterimage/rawdatasettings/) { get; } | Haalt de huidige ruwe gegevensinstellingen op. Merk op dat bij het gebruik van deze instellingen de gegevens zonder conversie worden geladen. |
+| [RawFallbackIndex](../../aspose.psd/rasterimage/rawfallbackindex/) { get; set; } | Haalt de fallback-index op of stelt deze in die moet worden gebruikt wanneer de paletindex buiten de grenzen valt |
+| [RawIndexedColorConverter](../../aspose.psd/rasterimage/rawindexedcolorconverter/) { get; set; } | Haalt de geïndexeerde kleuromschakelaar op of stelt deze in |
+| virtual [RawLineSize](../../aspose.psd/rasterimage/rawlinesize/) { get; } | Haalt de ruwe regelgrootte in bytes op. |
+| [Resources](../../aspose.psd.fileformats.psd.layers/layer/resources/) { get; set; } | Haalt de laagbronnen op of stelt deze in. |
+| virtual [Right](../../aspose.psd.fileformats.psd.layers/layer/right/) { get; set; } | Haalt de positie van de rechter laag op of stelt deze in. |
+| [SheetColorHighlight](../../aspose.psd.fileformats.psd.layers/layer/sheetcolorhighlight/) { get; set; } | Haalt de decoratieve bladkleurmarkering in de lagenlijst op of stelt deze in |
+| [Size](../../aspose.psd/image/size/) { get; } | Haalt de afbeeldingsgrootte op. |
+| [Stroke](../../aspose.psd.fileformats.psd.layers/shapelayer/stroke/) { get; set; } | Haalt de Stroke-instellingen van Shapes op of stelt ze in. |
+| virtual [Top](../../aspose.psd.fileformats.psd.layers/layer/top/) { get; set; } | Haalt de positie van de bovenste laag op of stelt deze in. |
+| virtual [TransparentColor](../../aspose.psd/rasterimage/transparentcolor/) { get; set; } | Haalt de transparante kleur van de afbeelding op. |
+| virtual [UpdateXmpData](../../aspose.psd/rasterimage/updatexmpdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of de XMP-metadata moet worden bijgewerkt. |
+| virtual [UsePalette](../../aspose.psd/image/usepalette/) { get; } | Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt. |
+| virtual [UseRawData](../../aspose.psd/rasterimage/userawdata/) { get; set; } | Haalt een waarde op of stelt deze in die aangeeft of ruwe gegevens moeten worden geladen wanneer het laden van ruwe gegevens beschikbaar is. |
+| virtual [VerticalResolution](../../aspose.psd/rasterimage/verticalresolution/) { get; set; } | Haalt de verticale resolutie, in pixels per inch, van deze [`RasterImage`](../../aspose.psd/rasterimage/) op of stelt deze in. |
+| override [Width](../../aspose.psd.fileformats.psd.layers/layer/width/) { get; } | Haalt de breedte van de afbeelding op. |
+| virtual [XmpData](../../aspose.psd/rasterimage/xmpdata/) { get; set; } | Haalt de XMP-metadata op of stelt deze in. |
+
+## Methoden
+
+| Naam | Beschrijving |
+| --- | --- |
+| static [CreateInstance](../../aspose.psd.fileformats.psd.layers/shapelayer/createinstance/)() | Maakt een nieuw exemplaar van de `ShapeLayer`-klasse. |
+| [AddLayerMask](../../aspose.psd.fileformats.psd.layers/layer/addlayermask/)(LayerMaskData) | Voegt het masker toe aan de huidige laag. |
+| override [AdjustBrightness](../../aspose.psd/rastercachedimage/adjustbrightness/)(int) | Past de helderheid van de afbeelding aan. |
+| override [AdjustContrast](../../aspose.psd/rastercachedimage/adjustcontrast/)(float) | Afbeeldingscontrast |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float) | Gamma-correctie van een afbeelding. |
+| override [AdjustGamma](../../aspose.psd/rastercachedimage/adjustgamma/)(float, float, float) | Gamma-correctie van een afbeelding. |
+| [ApplyLayerMask](../../aspose.psd.fileformats.psd.layers/layer/applylayermask/)() | Past het laagmasker toe op de laag en verwijdert vervolgens het masker. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeBradley](../../aspose.psd/rastercachedimage/binarizebradley/)(double, int) | Binarisatie van een afbeelding met behulp van Bradleys adaptieve drempelalgoritme met integrale afbeeldingsdrempeling. |
+| override [BinarizeFixed](../../aspose.psd/rastercachedimage/binarizefixed/)(byte) | Binarisatie van een afbeelding met een vooraf gedefinieerde drempel. |
+| override [BinarizeOtsu](../../aspose.psd/rastercachedimage/binarizeotsu/)() | Binarisatie van een afbeelding met Otsu-drempeling. |
+| override [CacheData](../../aspose.psd/rastercachedimage/cachedata/)() | Cachet de gegevens en zorgt ervoor dat er geen extra gegevens worden geladen vanuit de onderliggende [`DataStreamContainer`](../../aspose.psd/datastreamsupporter/datastreamcontainer/). |
+| [CanSave](../../aspose.psd/image/cansave/)(ImageOptionsBase) | Bepaalt of de afbeelding kan worden opgeslagen in het opgegeven bestandsformaat dat wordt vertegenwoordigd door de meegegeven opslagopties. |
+| override [Crop](../../aspose.psd/rastercachedimage/crop/)(Rectangle) | Bijsnijden van de afbeelding. |
+| virtual [Crop](../../aspose.psd/rasterimage/crop/)(int, int, int, int) | Afbeelding bijsnijden met verschuivingen. |
+| [Dispose](../../aspose.psd/disposableobject/dispose/)() | Disposeert de huidige instantie. |
+| [Dither](../../aspose.psd/rasterimage/dither/)(DitheringMethod, int) | Voert dithering uit op de huidige afbeelding. |
+| override [Dither](../../aspose.psd/rastercachedimage/dither/)(DitheringMethod, int, IColorPalette) | Voert dithering uit op de huidige afbeelding. |
+| [DrawImage](../../aspose.psd.fileformats.psd.layers/layer/drawimage/)(Point, RasterImage) | Tekent de afbeelding op de laag. |
+| virtual [Filter](../../aspose.psd/rasterimage/filter/)(Rectangle, FilterOptionsBase) | Filtert de opgegeven rechthoek. |
+| [GetArgb32Pixel](../../aspose.psd/rasterimage/getargb32pixel/)(int, int) | Haalt een 32-bit ARGB-pixel van de afbeelding op. |
+| [GetDefaultArgb32Pixels](../../aspose.psd/rasterimage/getdefaultargb32pixels/)(Rectangle) | Haalt de standaard 32-bit ARGB-pixelarray op. |
+| virtual [GetDefaultOptions](../../aspose.psd/image/getdefaultoptions/)(object[]) | Haalt de standaardopties op. |
+| [GetDefaultPixels](../../aspose.psd/rasterimage/getdefaultpixels/)(Rectangle, IPartialArgb32PixelLoader) | Haalt de standaardpixelarray op met behulp van de gedeeltelijke pixelloader. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, RawDataSettings) | Haalt de standaard ruwe gegevensarray op. |
+| [GetDefaultRawData](../../aspose.psd/rasterimage/getdefaultrawdata/)(Rectangle, IPartialRawDataLoader, RawDataSettings) | Haalt de standaard ruwe gegevensarray op met behulp van de gedeeltelijke pixelloader. |
+| override [GetHashCode](../../aspose.psd.fileformats.psd.layers/layer/gethashcode/)() | Retourneert een hashcode voor deze instantie. |
+| virtual [GetModifyDate](../../aspose.psd/rasterimage/getmodifydate/)(bool) | Haalt de datum en tijd op waarop de bronafbeelding voor het laatst is gewijzigd. |
+| virtual [GetOriginalOptions](../../aspose.psd/image/getoriginaloptions/)() | Haalt de opties op op basis van de oorspronkelijke bestandsinstellingen. Dit kan handig zijn om de bitsdiepte en andere parameters van de oorspronkelijke afbeelding ongewijzigd te houden. Bijvoorbeeld, als we een zwart-wit PNG-afbeelding met 1 bit per pixel laden en deze vervolgens opslaan met de [`Save`](../../aspose.psd/datastreamsupporter/save/) methode, wordt een PNG-afbeelding met 8-bit per pixel gegenereerd. Om dit te voorkomen en een PNG-afbeelding met 1-bit per pixel op te slaan, gebruik deze methode om de bijbehorende opslagopties te verkrijgen en geef ze door aan de [`Save`](../../aspose.psd/image/save/) methode als tweede parameter. |
+| [GetPixel](../../aspose.psd/rasterimage/getpixel/)(int, int) | Haalt een afbeeldingspixel op. Prestatiewaarschuwing: Vermijd het gebruik van deze methode om over alle afbeeldingspixels te itereren, omdat dit kan leiden tot aanzienlijke prestatieproblemen. Voor efficiëntere pixelmanipulatie, gebruik de `LoadArgb32Pixels` methode om de volledige pixelarray in één keer op te halen. |
+| [GetSkewAngle](../../aspose.psd/rasterimage/getskewangle/)() | Haalt de scheefstandhoek op. Deze methode is toepasbaar op gescande tekstdocumenten om de scheefstandhoek bij het scannen te bepalen. |
+| override [Grayscale](../../aspose.psd/rastercachedimage/grayscale/)() | Transformatie van een afbeelding naar zijn grijswaardenrepresentatie |
+| [LoadArgb32Pixels](../../aspose.psd/rasterimage/loadargb32pixels/)(Rectangle) | Laadt 32-bit ARGB-pixels. |
+| [LoadArgb64Pixels](../../aspose.psd/rasterimage/loadargb64pixels/)(Rectangle) | Laadt 64-bit ARGB-pixels. |
+| [LoadCmyk32Pixels](../../aspose.psd/rasterimage/loadcmyk32pixels/)(Rectangle) | Laadt pixels in CMYK-formaat. |
+| [LoadCmykPixels](../../aspose.psd/rasterimage/loadcmykpixels/)(Rectangle) | Laadt pixels in CMYK-formaat. Deze methode is verouderd. Gebruik alstublieft de effectievere [`LoadCmyk32Pixels`](../../aspose.psd/rasterimage/loadcmyk32pixels/) methode. |
+| [LoadPartialArgb32Pixels](../../aspose.psd/rasterimage/loadpartialargb32pixels/)(Rectangle, IPartialArgb32PixelLoader) | Laadt 32-bit ARGB-pixels gedeeltelijk per pakketten. |
+| [LoadPartialPixels](../../aspose.psd/rasterimage/loadpartialpixels/)(Rectangle, IPartialPixelLoader) | Laadt pixels gedeeltelijk per pakketten. |
+| [LoadPixels](../../aspose.psd/rasterimage/loadpixels/)(Rectangle) | Laadt pixels. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| [LoadRawData](../../aspose.psd/rasterimage/loadrawdata/)(Rectangle, Rectangle, RawDataSettings, IPartialRawDataLoader) | Laadt ruwe gegevens. |
+| virtual [MergeLayerTo](../../aspose.psd.fileformats.psd.layers/layer/mergelayerto/)(Layer) | Voegt de laag samen met de opgegeven laag |
+| [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)() | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| virtual [NormalizeAngle](../../aspose.psd/rasterimage/normalizeangle/)(bool, Color) | Normaliseert de hoek. Deze methode is toepasbaar op gescande tekstdocumenten om een scheve scan te verwijderen. Deze methode gebruikt de [`GetSkewAngle`](../../aspose.psd/rasterimage/getskewangle/) en [`Rotate`](../../aspose.psd/rasterimage/rotate/) methoden. |
+| [ReadArgb32ScanLine](../../aspose.psd/rasterimage/readargb32scanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReadScanLine](../../aspose.psd/rasterimage/readscanline/)(int) | Leest de volledige scanlijn op basis van de opgegeven scanlijnindex. |
+| [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(Color, byte, Color) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| virtual [ReplaceColor](../../aspose.psd/rasterimage/replacecolor/)(int, byte, int) | Vervangt één kleur door een andere met toegestane afwijking en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. |
+| [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(Color) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| virtual [ReplaceNonTransparentColors](../../aspose.psd/rasterimage/replacenontransparentcolors/)(int) | Vervangt alle niet-transparante kleuren door een nieuwe kleur en behoudt de oorspronkelijke alfa-waarde om vloeiende randen te behouden. Opmerking: als je het toepast op afbeeldingen zonder transparantie, worden alle kleuren vervangen door één enkele kleur. |
+| [Resize](../../aspose.psd/image/resize/)(int, int) | Wijzigt de grootte van de afbeelding. De standaard NearestNeighbourResample wordt gebruikt. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ImageResizeSettings) | Wijzigt de grootte van de afbeelding. |
+| override [Resize](../../aspose.psd/rastercachedimage/resize/)(int, int, ResizeType) | Wijzigt de grootte van de afbeelding. |
+| [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ImageResizeSettings) | Wijzigt de hoogte proportioneel. |
+| virtual [ResizeHeightProportionally](../../aspose.psd/image/resizeheightproportionally/)(int, ResizeType) | Wijzigt de hoogte proportioneel. |
+| [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int) | Wijzigt de breedte proportioneel. De standaard NearestNeighbourResample wordt gebruikt. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ImageResizeSettings) | Wijzigt de breedte proportioneel. |
+| virtual [ResizeWidthProportionally](../../aspose.psd/image/resizewidthproportionally/)(int, ResizeType) | Wijzigt de breedte proportioneel. |
+| virtual [Rotate](../../aspose.psd/rasterimage/rotate/)(float) | Roteer de afbeelding rond het centrum. |
+| override [Rotate](../../aspose.psd/rastercachedimage/rotate/)(float, bool, Color) | Roteer de afbeelding rond het centrum. |
+| override [RotateFlip](../../aspose.psd/rastercachedimage/rotateflip/)(RotateFlipType) | Roteert, spiegelt of roteert en spiegelt de afbeelding. |
+| [Save](../../aspose.psd/image/save/)() | Slaat de afbeeldingsgegevens op in de onderliggende stream. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream) | Slaat de gegevens van het object op in de opgegeven stream. |
+| [Save](../../aspose.psd/datastreamsupporter/save/)(string) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| [Save](../../aspose.psd/image/save/)(Stream, ImageOptionsBase) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, bool) | Slaat de gegevens van het object op op de opgegeven bestandslocatie. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(Stream, ImageOptionsBase, Rectangle) | Slaat de gegevens van de afbeelding op in de opgegeven stream in het opgegeven bestandsformaat volgens de opslagopties. |
+| override [Save](../../aspose.psd.fileformats.psd.layers/layer/save/)(string, ImageOptionsBase, Rectangle) | Slaat de gegevens van het object op op de opgegeven bestandslocatie in het opgegeven bestandsformaat volgens de opslagopties. |
+| [SaveArgb32Pixels](../../aspose.psd/rasterimage/saveargb32pixels/)(Rectangle, int[]) | Slaat de 32-bit ARGB-pixels op. |
+| [SaveCmyk32Pixels](../../aspose.psd/rasterimage/savecmyk32pixels/)(Rectangle, int[]) | Slaat de pixels op. |
+| [SaveCmykPixels](../../aspose.psd/rasterimage/savecmykpixels/)(Rectangle, CmykColor[]) | Slaat de pixels op. Deze methode is verouderd. Gebruik alstublieft de meer effectieve [`SaveCmyk32Pixels`](../../aspose.psd/rasterimage/savecmyk32pixels/) methode. |
+| [SavePixels](../../aspose.psd/rasterimage/savepixels/)(Rectangle, Color[]) | Slaat de pixels op. |
+| [SaveRawData](../../aspose.psd/rasterimage/saverawdata/)(byte[], int, Rectangle, RawDataSettings) | Slaat de ruwe gegevens op. |
+| [SetArgb32Pixel](../../aspose.psd/rasterimage/setargb32pixel/)(int, int, int) | Stelt een 32-bit ARGB-pixel van de afbeelding in voor de opgegeven positie. |
+| override [SetPalette](../../aspose.psd/rasterimage/setpalette/)(IColorPalette, bool) | Stelt het kleurenpalet van de afbeelding in. |
+| [SetPixel](../../aspose.psd/rasterimage/setpixel/)(int, int, Color) | Stelt een afbeeldingspixel in voor de opgegeven positie. |
+| virtual [SetResolution](../../aspose.psd/rasterimage/setresolution/)(double, double) | Stelt de resolutie in voor deze [`RasterImage`](../../aspose.psd/rasterimage/). |
+| [ShallowCopy](../../aspose.psd.fileformats.psd.layers/layer/shallowcopy/)() | Maakt een ondiepe kopie van de huidige laag. Zie [https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx](https://msdn.microsoft.com/ru-ru/library/system.object.memberwiseclone(v=vs.110).aspx) voor uitleg. |
+| virtual [ToBitmap](../../aspose.psd/rasterimage/tobitmap/)() | Converteert rasterafbeelding naar de bitmap. |
+| [Update](../../aspose.psd.fileformats.psd.layers/shapelayer/update/)() | Werk resources bij vanuit de eigenschappen van de Shape-laag. |
+| [WriteArgb32ScanLine](../../aspose.psd/rasterimage/writeargb32scanline/)(int, int[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+| [WriteScanLine](../../aspose.psd/rasterimage/writescanline/)(int, Color[]) | Schrijft de volledige scanregel naar de opgegeven scanregelindex. |
+
+## Voorbeelden
+
+De volgende code toont ondersteuning voor de ShapeLayer-laag.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Bronbestand bevat 2 figuren. Verwijder de tweede.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Zie ook
+
+* class [Layer](../layer/)
+* interface [IShapeLayer](../ishapelayer/)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/_index.md
@@ -1,0 +1,57 @@
+---
+title: "ShapeLayer.CreateInstance"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer methode. Maakt een nieuw exemplaar van de ShapeLayer-klasse"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/createinstance/
+---
+{{< psd/tize >}}
+## ShapeLayer.CreateInstance method
+
+Maakt een nieuw exemplaar van de [`ShapeLayer`](../) klasse.
+
+```csharp
+public static ShapeLayer CreateInstance()
+```
+
+### Retourwaarde
+
+Retourneert het nieuwe exemplaar van de [`ShapeLayer`](../) klasse.
+
+## Voorbeelden
+
+De volgende code toont ondersteuning voor de ShapeLayer-laag.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Bronbestand bevat 2 figuren. Verwijder de tweede.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Zie ook
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/_index.md
@@ -1,0 +1,70 @@
+---
+title: "ShapeLayer.Fill"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer eigenschap. Krijgt of stelt Fill-instellingen in voor het interne gebied van Shapes in de Shape-laag"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/fill/
+---
+{{< psd/tize >}}
+## ShapeLayer.Fill property
+
+Haalt of stelt de vulinstellingen voor het interne gebied van vormen in de vormlaag in.
+
+```csharp
+public IFillSettings Fill { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont de Fill-eigenschap van ShapeLayer.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeInternalSolid.psd";
+string outFile = "ShapeInternalSolid.psd.out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(
+           srcFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.Red;
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(
+           outFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+
+    AssertAreEqual(Color.Red, fillSettings.Color);
+
+    image.Save(outFile);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* interface [IFillSettings](../../../aspose.psd.fileformats.psd.layers.fillsettings/ifillsettings/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/path/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/path/_index.md
@@ -1,0 +1,54 @@
+---
+title: "ShapeLayer.Path"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer eigenschap. Haalt de verzameling paden op die aanwezig zijn in een Shape‑laag"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/path/
+---
+{{< psd/tize >}}
+## ShapeLayer.Path property
+
+Haalt de verzameling paden op die aanwezig zijn in een vormlaag.
+
+```csharp
+public IPath Path { get; }
+```
+
+## Voorbeelden
+
+De volgende code toont ondersteuning voor de ShapeLayer-laag.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Bronbestand bevat 2 figuren. Verwijder de tweede.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Zie ook
+
+* interface [IPath](../../../aspose.psd.fileformats.psd.layers.layerresources/ipath/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ShapeLayer.ShapeLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer constructor. Initialiseert een nieuw exemplaar van de ShapeLayer‑klasse. Alle bronnen worden in hun standaardstatus aangemaakt"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/shapelayer/
+---
+{{< psd/tize >}}
+## ShapeLayer constructor
+
+Initialiseert een nieuw exemplaar van de [`ShapeLayer`](../) klasse. Alle bronnen worden in hun standaardstatus aangemaakt.
+
+```csharp
+public ShapeLayer()
+```
+
+## Voorbeelden
+
+De volgende code toont ondersteuning voor de ShapeLayer-laag.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Bronbestand bevat 2 figuren. Verwijder de tweede.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Zie ook
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/_index.md
@@ -1,0 +1,109 @@
+---
+title: "ShapeLayer.Stroke"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer eigenschap. Krijgt of stelt Stroke-instellingen in van Shapes"
+type: docs
+weight: 50
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/stroke/
+---
+{{< psd/tize >}}
+## ShapeLayer.Stroke property
+
+Haalt de Stroke-instellingen van Shapes op of stelt ze in.
+
+```csharp
+public IStrokeSettings Stroke { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert het renderen van Shape Stroke.
+
+```csharp
+[C#]
+
+string sourceFile = "StrokeShapeTest.psd";
+string outputFilePsd = "StrokeShapeTest.out.psd";
+string outputFilePng = "StrokeShapeTest.out.png";
+
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    Layer layer = image.Layers[1];
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    fillSettings.Color = Color.GreenYellow;
+    shapeLayer.Update();
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    gradientSettings.Dither = true;
+    gradientSettings.Reverse = true;
+    gradientSettings.AlignWithLayer = false;
+    gradientSettings.Angle = 20;
+    gradientSettings.Scale = 50;
+    solidGradient.ColorPoints[0].Location = 100;
+    solidGradient.ColorPoints[1].Location = 4000;
+    solidGradient.TransparencyPoints[0].Location = 200;
+    solidGradient.TransparencyPoints[1].Location = 3800;
+    solidGradient.TransparencyPoints[0].Opacity = 90;
+    solidGradient.TransparencyPoints[1].Opacity = 10;
+    shapeLayer2.Update();
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    strokeSettings.Size = 15;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    strokeFillSettings.Color = Color.GreenYellow;
+    shapeLayer3.Update();
+
+    image.Save(outputFilePsd);
+    image.Save(outputFilePng, new PngOptions());
+}
+
+// Controleer gewijzigde gegevens.
+using (PsdImage image = (PsdImage)Image.Load(outputFilePsd))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    ColorFillSettings fillSettings = (ColorFillSettings)shapeLayer.Fill;
+    AssertAreEqual(Color.GreenYellow, fillSettings.Color);
+
+    ShapeLayer shapeLayer2 = (ShapeLayer)image.Layers[3];
+    GradientFillSettings gradientSettings = (GradientFillSettings)shapeLayer2.Fill;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+    AssertAreEqual(true, gradientSettings.Dither);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.AlignWithLayer);
+    AssertAreEqual(20.0, gradientSettings.Angle);
+    AssertAreEqual(50, gradientSettings.Scale);
+    AssertAreEqual(100, solidGradient.ColorPoints[0].Location);
+    AssertAreEqual(4000, solidGradient.ColorPoints[1].Location);
+    AssertAreEqual(200, solidGradient.TransparencyPoints[0].Location);
+    AssertAreEqual(3800, solidGradient.TransparencyPoints[1].Location);
+    AssertAreEqual(90.0, solidGradient.TransparencyPoints[0].Opacity);
+    AssertAreEqual(10.0, solidGradient.TransparencyPoints[1].Opacity);
+
+    ShapeLayer shapeLayer3 = (ShapeLayer)image.Layers[5];
+    StrokeSettings strokeSettings = (StrokeSettings)shapeLayer3.Stroke;
+    ColorFillSettings strokeFillSettings = (ColorFillSettings)strokeSettings.Fill;
+    AssertAreEqual(15.0, strokeSettings.Size);
+    AssertAreEqual(Color.GreenYellow, strokeFillSettings.Color);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* interface [IStrokeSettings](../../../aspose.psd.fileformats.psd.layers.layerresources.strokeresources/istrokesettings/)
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/update/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/shapelayer/update/_index.md
@@ -1,0 +1,53 @@
+---
+title: "ShapeLayer.Update"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "ShapeLayer methode. Werkt bronnen bij op basis van de eigenschappen van de Shape‑laag"
+type: docs
+weight: 60
+url: /nl/net/aspose.psd.fileformats.psd.layers/shapelayer/update/
+---
+{{< psd/tize >}}
+## ShapeLayer.Update method
+
+Werk resources bij vanuit de eigenschappen van de Shape-laag.
+
+```csharp
+public void Update()
+```
+
+## Voorbeelden
+
+De volgende code toont ondersteuning voor de ShapeLayer-laag.
+
+```csharp
+[C#]
+
+string srcFile = "ShapeLayerTest.psd";
+string outFile = "ShapeLayerTest-out.psd";
+
+using (PsdImage image = (PsdImage)Image.Load(srcFile, new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    ShapeLayer shapeLayer = (ShapeLayer)image.Layers[1];
+    IPath layerPath = shapeLayer.Path;
+
+    IPathShape[] pathShapeSource = layerPath.GetItems();
+    List<IPathShape> pathShapesDest = new List<IPathShape>(pathShapeSource);
+
+    // Bronbestand bevat 2 figuren. Verwijder de tweede.
+    pathShapesDest.RemoveAt(1);
+
+    layerPath.SetItems(pathShapesDest.ToArray());
+
+    shapeLayer.Update();
+
+    image.Save(outFile);
+}
+```
+
+### Zie ook
+
+* class [ShapeLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/_index.md
@@ -1,0 +1,108 @@
+---
+title: "TextLayer.WarpSettings"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "TextLayer-eigenschap. Haalt of stelt Warp-parameters in die zijn ingesteld of opgehaald van de standaardresource."
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.fileformats.psd.layers/textlayer/warpsettings/
+---
+{{< psd/tize >}}
+## TextLayer.WarpSettings property
+
+Haalt op of stelt Warp-parameters in die van de resource (standaard) zijn ingesteld of opgehaald
+
+```csharp
+public WarpSettings WarpSettings { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code toont hoe je WarpSettings kunt manipuleren om een warp-transformatie uit te voeren op SmartObjectLayer en TexLayer.
+
+```csharp
+[C#]
+
+string sourceFile = "smart_without_warp.psd";
+
+var opt = new PsdLoadOptions()
+{
+    LoadEffectsResource = true,
+    AllowWarpRepaint = true
+};
+
+string[] outputImageFile = new string[4];
+string[] outputPsdFile = new string[4];
+
+for (int caseIndex = 0; caseIndex < outputImageFile.Length; caseIndex++)
+{
+    outputImageFile[caseIndex] = "export_" + caseIndex + ".png";
+    outputPsdFile[caseIndex] = "export_" + caseIndex + ".psd";
+
+    using (PsdImage img = (PsdImage)Image.Load(sourceFile, opt))
+    {
+        foreach (Layer layer in img.Layers)
+        {
+            if (layer is SmartObjectLayer)
+            {
+                var smartLayer = (SmartObjectLayer)layer;
+                smartLayer.WarpSettings = GetWarpSettingsByIndex(smartLayer.WarpSettings, caseIndex);
+            }
+
+            if (layer is TextLayer)
+            {
+                var textLayer = (TextLayer)layer;
+
+                if (caseIndex != 3)
+                {
+                    textLayer.WarpSettings = GetWarpSettingsByIndex(textLayer.WarpSettings, caseIndex);
+                }
+            }
+        }
+
+        img.Save(outputPsdFile[caseIndex], new PsdOptions());
+    }
+
+    using (PsdImage img = (PsdImage)Image.Load(outputPsdFile[caseIndex], opt))
+    {
+        img.Save(outputImageFile[caseIndex],
+            new PngOptions() { CompressionLevel = 9, ColorType = PngColorType.TruecolorWithAlpha });
+    }
+}
+
+WarpSettings GetWarpSettingsByIndex(WarpSettings warpParams, int caseIndex)
+{
+    switch (caseIndex)
+    {
+        case 0:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 20;
+            break;
+        case 1:
+            warpParams.Style = WarpStyles.Rise;
+            warpParams.Rotate = WarpRotates.Vertical;
+            warpParams.Value = 10;
+            break;
+        case 2:
+            warpParams.Style = WarpStyles.Flag;
+            warpParams.Rotate = WarpRotates.Horizontal;
+            warpParams.Value = 30;
+            break;
+        case 3:
+            warpParams.Style = WarpStyles.Custom;
+            warpParams.MeshPoints[2].Y += 70;
+            break;
+    }
+
+    return warpParams;
+}
+```
+
+### Zie ook
+
+* class [WarpSettings](../../../aspose.psd.fileformats.psd.layers.warp/warpsettings/)
+* class [TextLayer](../)
+* namespace [Aspose.PSD.FileFormats.Psd.Layers](../../../aspose.psd.fileformats.psd.layers/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.resources.enums/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.resources.enums/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Aspose.PSD.FileFormats.Psd.Resources.Enums"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "De namespace verwerkt Psd resources enumeraties"
+type: docs
+weight: 390
+url: /nl/net/aspose.psd.fileformats.psd.resources.enums/
+---
+{{< psd/tize >}}
+De namespace verwerkt Psd resources enumeraties.
+
+## Enumeratie
+
+| Enumeratie | Beschrijving |
+| --- | --- |
+| [ColorSpace](./colorspace/) | De kleurruimtetypen. |
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd.resources.enums/colorspace/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd.resources.enums/colorspace/_index.md
@@ -1,0 +1,86 @@
+---
+title: "Enum ColorSpace"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.FileFormats.Psd.Resources.Enums.ColorSpace enum. De typen kleurruimtes."
+type: docs
+weight: 4160
+url: /nl/net/aspose.psd.fileformats.psd.resources.enums/colorspace/
+---
+{{< psd/tize >}}
+## ColorSpace enumeration
+
+De kleurruimtetypen.
+
+```csharp
+public enum ColorSpace : ushort
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| RGB | `0` | De RGB-kleurruimte. |
+| HSB | `1` | De HSB-kleurruimte. |
+| CMYK | `2` | De CMYK-kleurruimte. |
+| Lab | `7` | De Lab-kleurruimte. |
+| GrayScale | `8` | De Grijswaarden-kleurruimte. |
+
+## Voorbeelden
+
+De volgende code demonstreert hoe je de weergaveopties van Layer Mask kunt wijzigen op 16-bit afbeeldingen door LmskResource-eigenschappen te wijzigen.
+
+```csharp
+[C#]
+
+string sourceFile = "sourceFile.psd";
+string outputPsd = "sourceFile_output.psd";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Laad 16-bit afbeelding.
+using (PsdImage image = (PsdImage)Image.Load(sourceFile))
+{
+    // Zoek LmskResource.
+    LmskResource lmskResource = new LmskResource();
+    foreach (var res in image.GlobalLayerResources)
+    {
+        if (res is LmskResource)
+        {
+            lmskResource = (LmskResource)res;
+            break;
+        }
+    }
+
+    // Controleer LmskResource-eigenschappen.
+    AssertAreEqual(lmskResource.ColorSpace, ColorSpace.RGB);
+    AssertAreEqual(lmskResource.ColorComponent1, (ushort)65535);
+    AssertAreEqual(lmskResource.ColorComponent2, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent3, (ushort)0);
+    AssertAreEqual(lmskResource.ColorComponent4, (ushort)0);
+    AssertAreEqual(lmskResource.Opacity, (short)45);
+    AssertAreEqual(lmskResource.Flag, (byte)128);
+
+    // Wijzig LmskResource-eigenschappen.
+    lmskResource.ColorSpace = ColorSpace.HSB;
+    lmskResource.ColorComponent1 = 7854;
+    lmskResource.ColorComponent2 = 10;
+    lmskResource.ColorComponent3 = 15484;
+    lmskResource.Opacity = 85;
+
+    // Sla de afbeelding op.
+    image.Save(outputPsd);
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd.Resources.Enums](../../aspose.psd.fileformats.psd.resources.enums/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/leadingmode/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/leadingmode/_index.md
@@ -1,0 +1,29 @@
+---
+title: "LeadingMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: 
+type: docs
+weight: 3440
+url: /nl/net/aspose.psd.fileformats.psd/leadingmode/
+---
+## LeadingMode enumeration
+
+Photoshop-leadingmodus (afstand tussen regels)
+
+```csharp
+public enum LeadingMode
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| Auto | `0` | Automatische leading-modus |
+| Manual | `1` | Handmatige leading-modus |
+
+### Zie ook
+
+* namespace [Aspose.PSD.FileFormats.Psd](../../aspose.psd.fileformats.psd)
+* assembly [Aspose.PSD](../../)
+
+<!-- NIET BEWERKEN: gegenereerd door xmldocmd voor Aspose.PSD.dll -->

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/_index.md
@@ -1,0 +1,71 @@
+---
+title: "PsdImage.AddGradientMapAdjustmentLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Voegt een GradientMap-aanpassingslaag toe"
+type: docs
+weight: 360
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/addgradientmapadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddGradientMapAdjustmentLayer method
+
+Voegt een GradientMap-aanpassingslaag toe.
+
+```csharp
+public GradientMapLayer AddGradientMapAdjustmentLayer()
+```
+
+### Retourwaarde
+
+GradientMap-instantie.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de Gradient map-laag.
+
+```csharp
+[C#]
+
+string sourceFile = "gradient_map_src.psd";
+string outputFile = "gradient_map_src_output.psd";
+
+using (PsdImage im = (PsdImage)Image.Load(sourceFile))
+{
+    // Voeg Gradient map-aanpassingslaag toe.
+    GradientMapLayer layer = im.AddGradientMapAdjustmentLayer();
+    layer.GradientSettings.Reverse = true;
+    layer.Update();
+
+    im.Save(outputFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage im = (PsdImage)Image.Load(outputFile))
+{
+    GradientMapLayer gradientMapLayer = im.Layers[1] as GradientMapLayer;
+    var gradientSettings = gradientMapLayer.GradientSettings;
+    SolidGradient solidGradient = (SolidGradient)gradientSettings.Gradient;
+
+    AssertAreEqual((short)4096, solidGradient.Interpolation);
+    AssertAreEqual(true, gradientSettings.Reverse);
+    AssertAreEqual(false, gradientSettings.Dither);
+    AssertAreEqual("Custom", solidGradient.GradientName);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [GradientMapLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/gradientmaplayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/_index.md
@@ -1,0 +1,66 @@
+---
+title: "PsdImage.AddPosterizeAdjustmentLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Voegt Posterize Adjustment-laag toe."
+type: docs
+weight: 430
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/addposterizeadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddPosterizeAdjustmentLayer method
+
+Voegt Posterize Adjustment-laag toe.
+
+```csharp
+public PosterizeLayer AddPosterizeAdjustmentLayer()
+```
+
+### Retourwaarde
+
+PosterizeLayer-instantie.
+
+## Voorbeelden
+
+De volgende code toont de mogelijkheid om PosterizeAdjustmentLayer via PsdImage toe te voegen.
+
+```csharp
+[C#]
+
+string srcFile = "zendeya.psd";
+string outFile = "zendeya.psd.out.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(srcFile))
+{
+    psdImage.AddPosterizeAdjustmentLayer();
+    psdImage.Save(outFile);
+}
+
+// Controleer opgeslagen wijzigingen
+using (PsdImage image = (PsdImage)Image.Load(
+           outFile,
+           new PsdLoadOptions { LoadEffectsResource = true }))
+{
+    AssertAreEqual(2, image.Layers.Length);
+
+    PosterizeLayer posterizeLayer = (PosterizeLayer)image.Layers[1];
+
+    AssertAreEqual(true, posterizeLayer is PosterizeLayer);
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [PosterizeLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/posterizelayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/_index.md
@@ -1,0 +1,124 @@
+---
+title: "PsdImage.AddSelectiveColorAdjustmentLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Voegt de selective color adjustment-laag toe."
+type: docs
+weight: 450
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/addselectivecoloradjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddSelectiveColorAdjustmentLayer method
+
+Voegt de selective color adjustment-laag toe.
+
+```csharp
+public SelectiveColorLayer AddSelectiveColorAdjustmentLayer()
+```
+
+### Retourwaarde
+
+De aangemaakte selective color adjustment-laag.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de SelectiveColorLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithSelectiveColorLayer = "houses_selectiveColor_source.psd";
+string outputPsdWithSelectiveColorLayer = "houses_selectiveColor_output.psd";
+string outputPngWithSelectiveColorLayer = "houses_selectiveColor_output.png";
+
+string sourceFileWithoutSelectiveColorLayer = "houses_source.psd";
+string outputPsdWithoutSelectiveColorLayer = "houses_output.psd";
+string outputPngWithoutSelectiveColorLayer = "houses_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Selective Color-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithSelectiveColorLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is SelectiveColorLayer)
+        {
+            // Haal Selective Color-aanpassingslaag op.
+            SelectiveColorLayer selcLayer = (SelectiveColorLayer)layer;
+            var redCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Reds);
+            var yellowCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Yellows);
+            var greenCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Greens);
+            var blueCorrection = selcLayer.GetCmykCorrection(SelectiveColorsTypes.Blues);
+
+            // Controleer laagparameters.
+            AssertAreEqual(CorrectionMethodTypes.Absolute, selcLayer.CorrectionMethod);
+
+            AssertAreEqual(redCorrection.Cyan, (short)-31);
+            AssertAreEqual(redCorrection.Magenta, (short)-12);
+            AssertAreEqual(redCorrection.Yellow, (short)27);
+            AssertAreEqual(redCorrection.Black, (short)33);
+
+            AssertAreEqual(yellowCorrection.Cyan, (short)-22);
+            AssertAreEqual(yellowCorrection.Magenta, (short)-19);
+            AssertAreEqual(yellowCorrection.Yellow, (short)8);
+            AssertAreEqual(yellowCorrection.Black, (short)0);
+
+            AssertAreEqual(greenCorrection.Cyan, (short)0);
+            AssertAreEqual(greenCorrection.Magenta, (short)0);
+            AssertAreEqual(greenCorrection.Yellow, (short)0);
+            AssertAreEqual(greenCorrection.Black, (short)0);
+
+            AssertAreEqual(blueCorrection.Cyan, (short)58);
+            AssertAreEqual(blueCorrection.Magenta, (short)18);
+            AssertAreEqual(blueCorrection.Yellow, (short)1);
+            AssertAreEqual(blueCorrection.Black, (short)7);
+
+            // Wijzig laagparameters.
+            selcLayer.CorrectionMethod = CorrectionMethodTypes.Relative;
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Reds,
+                new CmykCorrection { Cyan = 12, Magenta = -20, Yellow = 10, Black = -15 });
+            selcLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+                new CmykCorrection { Cyan = 15, Magenta = 20, Yellow = -75, Black = 42 });
+
+            image.Save(outputPsdWithSelectiveColorLayer);
+            image.Save(outputPngWithSelectiveColorLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Selective color-aanpassingslaag toe aan de afbeelding en stel deze in.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutSelectiveColorLayer))
+{
+    // Voeg Selective Color Adjustment layer toe.
+    SelectiveColorLayer selectiveColorLayer = image.AddSelectiveColorAdjustmentLayer();
+
+    // Stel laagparameters in.
+    selectiveColorLayer.CorrectionMethod = CorrectionMethodTypes.Absolute;
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Whites,
+        new CmykCorrection { Cyan = 100, Magenta = -100, Yellow = 100, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Blacks,
+        new CmykCorrection { Cyan = 10, Magenta = 15, Yellow = 17, Black = -3 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Neutrals,
+        new CmykCorrection { Cyan = 45, Magenta = 21, Yellow = -14, Black = 0 });
+    selectiveColorLayer.SetCmykCorrection(SelectiveColorsTypes.Magentas,
+        new CmykCorrection { Cyan = 8, Magenta = -10, Yellow = -14, Black = 25 });
+
+    image.Save(outputPsdWithoutSelectiveColorLayer);
+    image.Save(outputPngWithoutSelectiveColorLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [SelectiveColorLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/selectivecolorlayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/_index.md
@@ -1,0 +1,139 @@
+---
+title: "PsdImage.AddShapeLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Voeg een lege Shape-laag toe. Zonder paden. Ze moeten aan de shape-laag worden toegevoegd vóór het opslaan."
+type: docs
+weight: 460
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/addshapelayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddShapeLayer method
+
+Voeg een lege Shape-laag toe. Zonder paden. Ze moeten aan de shape-laag worden toegevoegd vóór het opslaan.
+
+```csharp
+public ShapeLayer AddShapeLayer()
+```
+
+### Retourwaarde
+
+ShapeLayer-instantie.
+
+## Voorbeelden
+
+De volgende code toont hoe je ShapeLayer kunt toevoegen.
+
+```csharp
+[C#]
+
+string outputFile = "AddShapeLayer_output.psd";
+
+const int ImgToPsdRatio = 256 * 65535;
+
+using (PsdImage newPsd = new PsdImage(600, 400))
+{
+    ShapeLayer layer = newPsd.AddShapeLayer();
+
+    var newShape = GenerateNewShape(newPsd.Size);
+    List<IPathShape> newShapes = new List<IPathShape>();
+    newShapes.Add(newShape);
+    layer.Path.SetItems(newShapes.ToArray());
+
+    layer.Update();
+
+    newPsd.Save(outputFile);
+}
+
+using (PsdImage image = (PsdImage)Image.Load(outputFile))
+{
+    AssertAreEqual(2, image.Layers.Length);
+
+    ShapeLayer shapeLayer = image.Layers[1] as ShapeLayer;
+    ColorFillSettings internalFill = shapeLayer.Fill as ColorFillSettings;
+    IStrokeSettings strokeSettings = shapeLayer.Stroke;
+    ColorFillSettings strokeFill = shapeLayer.Stroke.Fill as ColorFillSettings;
+
+    AssertAreEqual(1, shapeLayer.Path.GetItems().Length); // 1 Shape
+    AssertAreEqual(3, shapeLayer.Path.GetItems()[0].GetItems().Length); // 3 knots in a shape
+
+    AssertAreEqual(-16127182, internalFill.Color.ToArgb()); // ff09eb32
+
+    AssertAreEqual(7.41, strokeSettings.Size);
+    AssertAreEqual(false, strokeSettings.Enabled);
+    AssertAreEqual(StrokePosition.Center, strokeSettings.LineAlignment);
+    AssertAreEqual(LineCapType.ButtCap, strokeSettings.LineCap);
+    AssertAreEqual(LineJoinType.MiterJoin, strokeSettings.LineJoin);
+    AssertAreEqual(-16777216, strokeFill.Color.ToArgb()); // ff000000
+}
+
+PathShape GenerateNewShape(Size imageSize)
+{
+    var newShape = new PathShape();
+
+    PointF point1 = new PointF(20, 100);
+    PointF point2 = new PointF(200, 100);
+    PointF point3 = new PointF(300, 10);
+
+    BezierKnotRecord[] bezierKnots = new BezierKnotRecord[]
+    {
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point1, imageSize),
+                          PointFToResourcePoint(point1, imageSize),
+                          PointFToResourcePoint(point1, imageSize),
+                      }
+         },
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point2, imageSize),
+                          PointFToResourcePoint(point2, imageSize),
+                          PointFToResourcePoint(point2, imageSize),
+                      }
+         },
+         new BezierKnotRecord()
+         {
+             IsLinked = true,
+             Points = new Point[3]
+                      {
+                          PointFToResourcePoint(point3, imageSize),
+                          PointFToResourcePoint(point3, imageSize),
+                          PointFToResourcePoint(point3, imageSize),
+                      }
+         },
+    };
+
+    newShape.SetItems(bezierKnots);
+
+    return newShape;
+}
+
+Point PointFToResourcePoint(PointF point, Size imageSize)
+{
+    return new Point(
+        (int)Math.Round(point.Y * (ImgToPsdRatio / imageSize.Height)),
+        (int)Math.Round(point.X * (ImgToPsdRatio / imageSize.Width)));
+}
+
+void AssertAreEqual(object expected, object actual, string message = null)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception(message ?? "Objects are not equal.");
+    }
+}
+```
+
+### Zie ook
+
+* class [ShapeLayer](../../../aspose.psd.fileformats.psd.layers/shapelayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/_index.md
@@ -1,0 +1,89 @@
+---
+title: "PsdImage.AddThresholdAdjustmentLayer"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Voegt de Threshold adjustment-laag toe."
+type: docs
+weight: 480
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/addthresholdadjustmentlayer/
+---
+{{< psd/tize >}}
+## PsdImage.AddThresholdAdjustmentLayer method
+
+Voegt de Threshold adjustment-laag toe.
+
+```csharp
+public ThresholdLayer AddThresholdAdjustmentLayer()
+```
+
+### Retourwaarde
+
+De aangemaakte Threshold adjustment-laag.
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de ThresholdLayer-aanpassingslaag.
+
+```csharp
+[C#]
+
+string sourceFileWithThresholdLayer = "flowers_threshold_source.psd";
+string outputPsdWithThresholdLayer = "flowers_threshold_output.psd";
+string outputPngWithThresholdLayer = "flowers_threshold_output.png";
+
+string sourceFileWithoutThresholdLayer = "flowers_source.psd";
+string outputPsdWithoutThresholdLayer = "flowers_output.psd";
+string outputPngWithoutThresholdLayer = "flowers_output.png";
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects are not equal.");
+    }
+}
+
+// Haal, controleer en wijzig de Threshold-aanpassingslaag van de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithThresholdLayer))
+{
+    foreach (var layer in image.Layers)
+    {
+        if (layer is ThresholdLayer)
+        {
+            // Haal Threshold-aanpassingslaag op.
+            ThresholdLayer thrsLayer = (ThresholdLayer)layer;
+            var level = thrsLayer.Level;
+
+            // Controleer laagparameters.
+            AssertAreEqual(level, (short)115);
+
+            // Stel laagparameters in.
+            thrsLayer.Level = 50;
+
+            image.Save(outputPsdWithThresholdLayer);
+            image.Save(outputPngWithThresholdLayer, new PngOptions());
+        }
+    }
+}
+
+// Voeg de Threshold-aanpassingslaag toe en stel deze in op de afbeelding.
+using (var image = (PsdImage)Image.Load(sourceFileWithoutThresholdLayer))
+{
+    // Voeg Threshold-aanpassingslaag toe.
+    ThresholdLayer thresholdLayer = image.AddThresholdAdjustmentLayer();
+
+    // Stel laagparameters in.
+    thresholdLayer.Level = 115;
+
+    image.Save(outputPsdWithoutThresholdLayer);
+    image.Save(outputPngWithoutThresholdLayer, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [ThresholdLayer](../../../aspose.psd.fileformats.psd.layers.adjustmentlayers/thresholdlayer/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/setresolution/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/setresolution/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PsdImage.SetResolution"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-methode. Stelt de resolutie in voor deze PsdImage"
+type: docs
+weight: 680
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/setresolution/
+---
+{{< psd/tize >}}
+## PsdImage.SetResolution method
+
+Stelt de resolutie in voor deze [`PsdImage`](../).
+
+```csharp
+public override void SetResolution(double dpiX, double dpiY)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| dpiX | Double | De horizontale resolutie, in dots per inch, van de [`RasterImage`](../../../aspose.psd/rasterimage/). |
+| dpiY | Double | De verticale resolutie, in dots per inch, van de [`RasterImage`](../../../aspose.psd/rasterimage/). |
+
+### Zie ook
+
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.fileformats.psd/psdimage/timeline/_index.md
+++ b/netherlands/net/aspose.psd.fileformats.psd/psdimage/timeline/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PsdImage.Timeline"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdImage-eigenschap. Haalt de Timeline van deze PsdImage op."
+type: docs
+weight: 250
+url: /nl/net/aspose.psd.fileformats.psd/psdimage/timeline/
+---
+{{< psd/tize >}}
+## PsdImage.Timeline property
+
+Haalt de `Timeline` van deze [`PsdImage`](../) op.
+
+```csharp
+public Timeline Timeline { get; }
+```
+
+## Voorbeelden
+
+De volgende code toont een nieuwe benadering om met de Timeline te werken.
+
+```csharp
+[C#]
+
+string sourceFile = "4_animated.psd";
+string outputFile = "output_edited.psd";
+
+using (var psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    Timeline timeline = psdImage.Timeline;
+    
+    // Voeg nog een frame toe
+    List<Frame> frames = new List<Frame>(timeline.Frames);
+    frames.Add(new Frame());
+    timeline.Frames = frames.ToArray();
+
+    timeline.SwitchActiveFrame(4);
+
+    psdImage.Save(outputFile);
+}
+```
+
+### Zie ook
+
+* class [Timeline](../../../aspose.psd.fileformats.psd.layers.animation/timeline/)
+* class [PsdImage](../)
+* namespace [Aspose.PSD.FileFormats.Psd](../../../aspose.psd.fileformats.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Class PngLoadOptions"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.ImageLoadOptions.PngLoadOptions class. De png-laadopties"
+type: docs
+weight: 5240
+url: /nl/net/aspose.psd.imageloadoptions/pngloadoptions/
+---
+{{< psd/tize >}}
+## PngLoadOptions class
+
+De png-laadopties.
+
+```csharp
+[Obsolete("Should be replaced with base \"LoadOptions\" class because it contains ony one obsolete \"StrictMode\" property.")]
+public class PngLoadOptions : LoadOptions
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [PngLoadOptions](pngloadoptions/)() | De standaardconstructor. |
+
+## Eigenschappen
+
+| Naam | Beschrijving |
+| --- | --- |
+| [BufferSizeHint](../../aspose.psd/loadoptions/buffersizehint/) { get; set; } | Geeft of stelt de buffergroottehint in, die de maximaal toegestane grootte voor alle interne buffers definieert. |
+| [DataBackgroundColor](../../aspose.psd/loadoptions/databackgroundcolor/) { get; set; } | Geeft of stelt de achtergrond van de [`Image`](../../aspose.psd/image/) [`Color`](../../aspose.psd/color/) in. |
+| [DataRecoveryMode](../../aspose.psd/loadoptions/datarecoverymode/) { get; set; } | Geeft of stelt de gegevensherstelmodus in. |
+| [ProgressEventHandler](../../aspose.psd/loadoptions/progresseventhandler/) { get; set; } | Haalt of stelt de voortgangs‑eventhandler in. |
+| [StrictMode](../../aspose.psd.imageloadoptions/pngloadoptions/strictmode/) { get; set; } | Haalt of stelt een waarde in die aangeeft of [strict mode] actief is. |
+| [UseIccProfileConversion](../../aspose.psd/loadoptions/useiccprofileconversion/) { get; set; } | Haalt of stelt een waarde in die aangeeft of ICC‑profielconversie moet worden toegepast. |
+
+### Zie ook
+
+* class [LoadOptions](../../aspose.psd/loadoptions/)
+* namespace [Aspose.PSD.ImageLoadOptions](../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PngLoadOptions.PngLoadOptions"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PngLoadOptions constructor. De standaardconstructor"
+type: docs
+weight: 10
+url: /nl/net/aspose.psd.imageloadoptions/pngloadoptions/pngloadoptions/
+---
+{{< psd/tize >}}
+## PngLoadOptions constructor
+
+De standaardconstructor.
+
+```csharp
+public PngLoadOptions()
+```
+
+### Zie ook
+
+* class [PngLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/_index.md
@@ -1,0 +1,29 @@
+---
+title: "PngLoadOptions.StrictMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PngLoadOptions eigenschap. Haalt op of stelt een waarde in die aangeeft of strikte modus"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.imageloadoptions/pngloadoptions/strictmode/
+---
+{{< psd/tize >}}
+## PngLoadOptions.StrictMode property
+
+Haalt of stelt een waarde in die aangeeft of [strict mode] actief is.
+
+```csharp
+[Obsolete("This redundant property should be replaced with an expression: \"LoadOptions.DataRecoveryMode == DataRecoveryMode.ConsistentRecover\".")]
+public bool StrictMode { get; set; }
+```
+
+### Property Value
+
+`true` als [strict mode]; anders `false`.
+
+### Zie ook
+
+* class [PngLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/_index.md
@@ -1,0 +1,50 @@
+---
+title: "PsdLoadOptions.AllowNonChangedLayerRepaint"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdLoadOptions eigenschap. Haalt op of stelt in of de oorspronkelijke laagpixels behouden moeten blijven tijdens het renderen als de laag niet is gewijzigd"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.imageloadoptions/psdloadoptions/allownonchangedlayerrepaint/
+---
+{{< psd/tize >}}
+## PsdLoadOptions.AllowNonChangedLayerRepaint property
+
+Haalt op of stelt in of de oorspronkelijke laagpixels behouden moeten blijven tijdens het renderen als de laag niet is gewijzigd.
+
+```csharp
+public bool AllowNonChangedLayerRepaint { get; set; }
+```
+
+### Property Value
+
+`true` om de oorspronkelijke pixels van onveranderde lagen te behouden; anders `false`.
+
+## Voorbeelden
+
+De volgende code toont het nieuwe gedrag dat automatisch opnieuw schilderen van lagen vóór wijzigingen voorkomt.
+
+```csharp
+[C#]
+
+string srcFile = "psdnet2400.psd";
+string output1 = "unchanged-2400.png";
+string output2 = "updated-2400.png";
+
+using (var psdImage = (PsdImage)Image.Load(srcFile,
+new PsdLoadOptions() { AllowNonChangedLayerRepaint = false /* The new default behaviour */ }))
+{
+    psdImage.Save(output1, new PngOptions());
+
+    ((TextLayer)psdImage.Layers[1]).TextData.UpdateLayerData();
+
+    psdImage.Save(output2, new PngOptions());
+}
+```
+
+### Zie ook
+
+* class [PsdLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/_index.md
@@ -1,0 +1,79 @@
+---
+title: "PsdLoadOptions.ReadOnlyType"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdLoadOptions eigenschap. Haalt op of stelt de alleen-lezen modus in die wordt gebruikt bij het laden van een PSD-afbeelding"
+type: docs
+weight: 80
+url: /nl/net/aspose.psd.imageloadoptions/psdloadoptions/readonlytype/
+---
+{{< psd/tize >}}
+## PsdLoadOptions.ReadOnlyType property
+
+Haalt op of stelt de alleen-lezen modus in die wordt gebruikt bij het laden van een PSD-afbeelding.
+
+```csharp
+public ReadOnlyMode ReadOnlyType { get; set; }
+```
+
+### Property Value
+
+Een van de [`ReadOnlyMode`](../readonlymode/) waarden:
+
+* !:ReadOnlyMode.None – No restrictions. Image content can be modified.
+* !:ReadOnlyMode.Default – The image is fully read-only.
+* !:ReadOnlyMode.MetadataEdit – Only metadata can be edited (such as [`ImageResources`](../../../aspose.psd.fileformats.psd/psdimage/imageresources/)), while image pixel content remains read-only.
+
+## Voorbeelden
+
+Toont het bewerken en opslaan van PSD‑metadata met behulp van ReadOnlyMode.MetadataEdit.
+
+```csharp
+[C#]
+
+string sourceFile = "psdnet2382.psd";
+string outputFile = "output.psd";
+
+string testMetadata = "Updated metadata text";
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(sourceFile,
+    new PsdLoadOptions() { ReadOnlyType = ReadOnlyMode.MetadataEdit })) // Sets the of ReadOnlyMode to true
+{
+    AssertAreNotEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+
+    // Metadata wijzigen in ReadOnlyMode
+    psdImage.XmpData.Meta.AdobeXmpToolkit = testMetadata;
+
+    // Gewijzigde metadata opslaan in ReadOnlyMode
+    psdImage.Save(outputFile);
+}
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(outputFile)) // Sets the of ReadOnlyMode to true
+{
+    AssertAreEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects should be equal, but they don't.");
+    }
+}
+
+void AssertAreNotEqual(object obj1, object obj2)
+{
+    if (object.Equals(obj1, obj2))
+    {
+        throw new Exception("Objects should not be equal, but they are equal.");
+    }
+}
+```
+
+### Zie ook
+
+* enum [ReadOnlyMode](../../readonlymode/)
+* class [PsdLoadOptions](../)
+* namespace [Aspose.PSD.ImageLoadOptions](../../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageloadoptions/readonlymode/_index.md
+++ b/netherlands/net/aspose.psd.imageloadoptions/readonlymode/_index.md
@@ -1,0 +1,77 @@
+---
+title: "Enum ReadOnlyMode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.ImageLoadOptions.ReadOnlyMode enum. Specificeert de alleen‑lezen modi die beschikbaar zijn bij het laden van een PSD‑afbeelding."
+type: docs
+weight: 5260
+url: /nl/net/aspose.psd.imageloadoptions/readonlymode/
+---
+{{< psd/tize >}}
+## ReadOnlyMode enumeration
+
+Specificeert de alleen‑lezen modi die beschikbaar zijn bij het laden van een PSD‑afbeelding.
+
+```csharp
+public enum ReadOnlyMode
+```
+
+### Waarden
+
+| Naam | Waarde | Beschrijving |
+| --- | --- | --- |
+| None | `0` | Er worden geen alleen‑lezen beperkingen toegepast. De afbeelding kan volledig worden bewerkt. |
+| Default | `1` | Standaardmodus. De afbeelding is volledig alleen‑lezen en kan niet worden bewerkt. |
+| MetadataEdit | `2` | Staat toe de metadata van de afbeelding te bewerken terwijl de afbeeldingsinhoud alleen‑lezen blijft. |
+
+## Voorbeelden
+
+Toont het bewerken en opslaan van PSD‑metadata met behulp van ReadOnlyMode.MetadataEdit.
+
+```csharp
+[C#]
+
+string sourceFile = "psdnet2382.psd";
+string outputFile = "output.psd";
+
+string testMetadata = "Updated metadata text";
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(sourceFile,
+    new PsdLoadOptions() { ReadOnlyType = ReadOnlyMode.MetadataEdit })) // Sets the of ReadOnlyMode to true
+{
+    AssertAreNotEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+
+    // Metadata wijzigen in ReadOnlyMode
+    psdImage.XmpData.Meta.AdobeXmpToolkit = testMetadata;
+
+    // Gewijzigde metadata opslaan in ReadOnlyMode
+    psdImage.Save(outputFile);
+}
+
+using (PsdImage psdImage = (PsdImage)Aspose.PSD.Image.Load(outputFile)) // Sets the of ReadOnlyMode to true
+{
+    AssertAreEqual(testMetadata, psdImage.XmpData.Meta.AdobeXmpToolkit);
+}
+
+void AssertAreEqual(object expected, object actual)
+{
+    if (!object.Equals(expected, actual))
+    {
+        throw new Exception("Objects should be equal, but they don't.");
+    }
+}
+
+void AssertAreNotEqual(object obj1, object obj2)
+{
+    if (object.Equals(obj1, obj2))
+    {
+        throw new Exception("Objects should not be equal, but they are equal.");
+    }
+}
+```
+
+### Zie ook
+
+* namespace [Aspose.PSD.ImageLoadOptions](../../aspose.psd.imageloadoptions/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/_index.md
+++ b/netherlands/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/_index.md
@@ -1,0 +1,29 @@
+---
+title: "JpegOptions.DefaultMemoryAllocationLimit"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "JpegOptions eigenschap. Haalt op of stelt de standaard geheugenallocatielimiet in"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd.imageoptions/jpegoptions/defaultmemoryallocationlimit/
+---
+{{< psd/tize >}}
+## JpegOptions.DefaultMemoryAllocationLimit property
+
+Haalt op of stelt de standaard geheugenallocatielimiet in.
+
+```csharp
+[Obsolete("Use Aspose.PSD.Image.BufferSizeHint, Aspose.PSD.ImageOptionsBase.BufferSizeHint or Aspose.PSD.LoadOptions.BufferSizeHint instead.")]
+public int DefaultMemoryAllocationLimit { get; set; }
+```
+
+### Property Value
+
+De standaard geheugenallocatielimiet.
+
+### Zie ook
+
+* class [JpegOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/_index.md
+++ b/netherlands/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/_index.md
@@ -1,0 +1,56 @@
+---
+title: "PsdOptions.BackgroundContents"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdOptions eigenschap. Haalt de kleur van de achtergrond op of stelt deze in. Deze kan worden gezien onder transparante objecten"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.imageoptions/psdoptions/backgroundcontents/
+---
+{{< psd/tize >}}
+## PsdOptions.BackgroundContents property
+
+Haalt de kleur van de achtergrond op of stelt deze in. Deze kan worden gezien onder transparante objecten.
+
+```csharp
+public RawColor BackgroundContents { get; set; }
+```
+
+## Voorbeelden
+
+De volgende code demonstreert de ondersteuning van de BackgroundContents‑eigenschap in PsdOptions.
+
+```csharp
+[C#]
+
+// Semi-transparantie wordt onjuist verwerkt in de preview van het psd‑bestand.
+// BackgroundContents toegewezen aan Wit. Transparante gebieden moeten een witte kleur hebben.
+
+string sourceFile = "frog_nosymb.psd";
+string outputFile = "frog_nosymb_backgroundcontents_output.psd";
+
+using (PsdImage psdImage = (PsdImage)Image.Load(sourceFile))
+{
+    RawColor backgroundColor = new RawColor(PixelDataFormat.Rgb32Bpp);
+    int argbValue = 255 << 24 | 255 << 16 | 255 << 8 | 255;
+    backgroundColor.SetAsInt(argbValue); // White
+
+    PsdOptions psdOptions = new PsdOptions(psdImage)
+    {
+        ColorMode = ColorModes.Rgb,
+        CompressionMethod = CompressionMethod.RLE,
+        ChannelsCount = 4,
+        BackgroundContents = backgroundColor,
+    };
+
+    psdImage.Save(outputFile, psdOptions);
+}
+```
+
+### Zie ook
+
+* class [RawColor](../../../aspose.psd.fileformats.psd.core.rawcolor/rawcolor/)
+* class [PsdOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageoptions/psdoptions/updatemetadata/_index.md
+++ b/netherlands/net/aspose.psd.imageoptions/psdoptions/updatemetadata/_index.md
@@ -1,0 +1,55 @@
+---
+title: "PsdOptions.UpdateMetadata"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PsdOptions eigenschap. Haalt op of stelt een waarde in die aangeeft of metadata moet worden bijgewerkt. Als de waarde true is, wordt de metadata bijgewerkt tijdens het opslaan van een afbeelding"
+type: docs
+weight: 110
+url: /nl/net/aspose.psd.imageoptions/psdoptions/updatemetadata/
+---
+{{< psd/tize >}}
+## PsdOptions.UpdateMetadata property
+
+Haalt op of stelt een waarde in die aangeeft of [update metadata]. Als de waarde true is, wordt de metadata bijgewerkt tijdens het opslaan van een afbeelding.
+
+```csharp
+public bool UpdateMetadata { get; set; }
+```
+
+### Property Value
+
+`true` als [update metadata]; anders `false`.
+
+## Voorbeelden
+
+De volgende code toont het gebruik van de UpdateMetadata-optie om de CreatorTool-waarde in xmp-gegevens bij te werken.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Als je wilt dat de creator-tool verandert, zorg er dan voor dat de eigenschap "UpdateMetadata" op true is ingesteld. Deze staat standaard op true.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Afbeelding opslaan.
+    image.Save(path, psdOptions);
+
+    // Controleren van de creator-tool in code.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Hier zal de bijgewerkte informatie over de creator‑tool staan.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Zie ook
+
+* class [PsdOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/_index.md
+++ b/netherlands/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/_index.md
@@ -1,0 +1,29 @@
+---
+title: "TiffOptions.DefaultMemoryAllocationLimit"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "TiffOptions eigenschap. Haalt de standaard geheugenallocatielimiet op of stelt deze in"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.imageoptions/tiffoptions/defaultmemoryallocationlimit/
+---
+{{< psd/tize >}}
+## TiffOptions.DefaultMemoryAllocationLimit property
+
+Haalt op of stelt de standaard geheugenallocatielimiet in.
+
+```csharp
+[Obsolete("Use Aspose.PSD.Image.BufferSizeHint, Aspose.PSD.ImageOptionsBase.BufferSizeHint or Aspose.PSD.LoadOptions.BufferSizeHint instead.")]
+public int DefaultMemoryAllocationLimit { get; set; }
+```
+
+### Property Value
+
+De standaard geheugenallocatielimiet.
+
+### Zie ook
+
+* class [TiffOptions](../)
+* namespace [Aspose.PSD.ImageOptions](../../../aspose.psd.imageoptions/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/_index.md
+++ b/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/_index.md
@@ -1,0 +1,59 @@
+---
+title: "XmpBasicPackage.ContainsKey"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "XmpBasicPackage methode. Bepaalt of de opgegeven sleutel aanwezig is"
+type: docs
+weight: 40
+url: /nl/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/containskey/
+---
+{{< psd/tize >}}
+## XmpBasicPackage.ContainsKey method
+
+Bepaalt of de opgegeven sleutel aanwezig is.
+
+```csharp
+public override bool ContainsKey(string key)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| sleutel | String | De te controleren sleutel. |
+
+### Retourwaarde
+
+Retourneert true als de opgegeven sleutel aanwezig is.
+
+## Voorbeelden
+
+De volgende code toont het gebruik van de UpdateMetadata-optie om de CreatorTool-waarde in xmp-gegevens bij te werken.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Als je wilt dat de creator-tool verandert, zorg er dan voor dat de eigenschap "UpdateMetadata" op true is ingesteld. Deze staat standaard op true.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Afbeelding opslaan.
+    image.Save(path, psdOptions);
+
+    // Controleren van de creator-tool in code.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Hier zal de bijgewerkte informatie over de creator‑tool staan.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Zie ook
+
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/_index.md
+++ b/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/_index.md
@@ -1,0 +1,63 @@
+---
+title: "XmpBasicPackage.Item"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "XmpBasicPackage eigenschap. Haalt het Object op of stelt het in met de opgegeven sleutel"
+type: docs
+weight: 20
+url: /nl/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/item/
+---
+{{< psd/tize >}}
+## XmpBasicPackage indexer
+
+Haalt het Object op of stelt het in met de opgegeven sleutel.
+
+```csharp
+public override object this[string key] { get; set; }
+```
+
+| Parameter | Beschrijving |
+| --- | --- |
+| sleutel | De sleutel die de waarde identificeert. |
+
+### Retourwaarde
+
+Retourneert het Object met de opgegeven sleutel.
+
+### Property Value
+
+Het Object.
+
+## Voorbeelden
+
+De volgende code toont het gebruik van de UpdateMetadata-optie om de CreatorTool-waarde in xmp-gegevens bij te werken.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Als je wilt dat de creator-tool verandert, zorg er dan voor dat de eigenschap "UpdateMetadata" op true is ingesteld. Deze staat standaard op true.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Afbeelding opslaan.
+    image.Save(path, psdOptions);
+
+    // Controleren van de creator-tool in code.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Hier zal de bijgewerkte informatie over de creator‑tool staan.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Zie ook
+
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/_index.md
+++ b/netherlands/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/_index.md
@@ -1,0 +1,57 @@
+---
+title: "XmpBasicPackage.SetValue"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "XmpBasicPackage methode. Stelt de waarde in"
+type: docs
+weight: 120
+url: /nl/net/aspose.psd.xmp.schemas.xmpbaseschema/xmpbasicpackage/setvalue/
+---
+{{< psd/tize >}}
+## XmpBasicPackage.SetValue method
+
+Stelt de waarde in.
+
+```csharp
+public override void SetValue(string key, IXmlValue value)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| sleutel | String | De tekenreeksrepresentatie van de sleutel die wordt geïdentificeerd met de toegevoegde waarde. |
+| waarde | IXmlValue | De waarde om aan toe te voegen. |
+
+## Voorbeelden
+
+De volgende code toont het gebruik van de UpdateMetadata-optie om de CreatorTool-waarde in xmp-gegevens bij te werken.
+
+```csharp
+[C#]
+
+string path = "output.psd";
+
+using (var image = new PsdImage(100, 100))
+{
+    // Als je wilt dat de creator-tool verandert, zorg er dan voor dat de eigenschap "UpdateMetadata" op true is ingesteld. Deze staat standaard op true.
+    var psdOptions = new PsdOptions();
+    psdOptions.UpdateMetadata = true;
+
+    // Afbeelding opslaan.
+    image.Save(path, psdOptions);
+
+    // Controleren van de creator-tool in code.
+    var xmpData = image.XmpData;
+    var basicPackage = image.XmpData.GetPackage(Namespaces.XmpBasic);
+
+    // Hier zal de bijgewerkte informatie over de creator‑tool staan.
+    var currentCreatorTool = (string)basicPackage[":CreatorTool"];
+}
+```
+
+### Zie ook
+
+* interface [IXmlValue](../../../aspose.psd.xmp/ixmlvalue/)
+* class [XmpBasicPackage](../)
+* namespace [Aspose.PSD.Xmp.Schemas.XmpBaseSchema](../../../aspose.psd.xmp.schemas.xmpbaseschema/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/cmykcolor/fromparams/_index.md
+++ b/netherlands/net/aspose.psd/cmykcolor/fromparams/_index.md
@@ -1,0 +1,36 @@
+---
+title: "CmykColor.FromParams"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykColor-methode. Maakt een CmykColor-structuur aan vanuit 32-bit cyaan, magenta, geel en zwart waarden. Deze methode is verouderd. Gebruik a.u.b. de effectievere FromComponents."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd/cmykcolor/fromparams/
+---
+{{< psd/tize >}}
+## CmykColor.FromParams method
+
+Maakt een [`CmykColor`](../) structuur aan vanuit 32-bit cyaan, magenta, geel en zwart waarden. Deze methode is verouderd. Gebruik a.u.b. de effectievere [`FromComponents`](../../cmykcolorhelper/fromcomponents/) .
+
+```csharp
+[Obsolete]
+public static CmykColor FromParams(int cyan, int magenta, int yellow, int black)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cyaan | Int32 | Het cyaancomponent. Geldige waarden zijn 0 tot en met 255. |
+| magenta | Int32 | Het magentacomponent. Geldige waarden zijn 0 tot en met 255. |
+| geel | Int32 | Het geelcomponent. Geldige waarden zijn 0 tot en met 255. |
+| zwart | Int32 | Het zwarte component. Geldige waarden zijn 0 tot en met 255. |
+
+### Retourwaarde
+
+De [`CmykColor`](../).
+
+### Zie ook
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/cmykcolor/toargb32/_index.md
+++ b/netherlands/net/aspose.psd/cmykcolor/toargb32/_index.md
@@ -1,0 +1,33 @@
+---
+title: "CmykColor.ToArgb32"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykColor-methode. De conversie van CMYKColor naar 32-bit ARGB-kleur met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik de effectievere ToArgb32."
+type: docs
+weight: 110
+url: /nl/net/aspose.psd/cmykcolor/toargb32/
+---
+{{< psd/tize >}}
+## CmykColor.ToArgb32 method
+
+De conversie van CMYKColor naar 32-bit ARGB-kleur met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik de effectievere [`ToArgb32`](../../cmykcolorhelper/toargb32/).
+
+```csharp
+[Obsolete]
+public static int[] ToArgb32(CmykColor[] cmykPixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | De pixels van het type CMYKColor in CMYK-indeling. |
+
+### Retourwaarde
+
+De array van de 32-bit ARGB-kleur.
+
+### Zie ook
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/cmykcolor/tocmyk/_index.md
+++ b/netherlands/net/aspose.psd/cmykcolor/tocmyk/_index.md
@@ -1,0 +1,58 @@
+---
+title: "CmykColor.ToCmyk"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykColor-methode. De conversie van 32bit ARGB-kleur naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere ToCmyk."
+type: docs
+weight: 120
+url: /nl/net/aspose.psd/cmykcolor/tocmyk/
+---
+{{< psd/tize >}}
+## ToCmyk(int[]) {#tocmyk_1}
+
+De conversie van 32-bit ARGB-kleur naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmyk(int[] argbPixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| argbPixels | Int32[] | De pixels van het 32-bit ARGB-formaat. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor[].
+
+### Zie ook
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmyk(int) {#tocmyk}
+
+De conversie van 32-bit ARGB naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmyk(int argbPixel)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| argbPixel | Int32 | De pixel van het 32-bit ARGB-formaat. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor.
+
+### Zie ook
+
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/cmykcolor/tocolor/_index.md
+++ b/netherlands/net/aspose.psd/cmykcolor/tocolor/_index.md
@@ -1,0 +1,60 @@
+---
+title: "CmykColor.ToColor"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykColor-methode. De conversie van CMYKColor naar Color met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere ToArgb."
+type: docs
+weight: 130
+url: /nl/net/aspose.psd/cmykcolor/tocolor/
+---
+{{< psd/tize >}}
+## ToColor(CmykColor[]) {#tocolor_1}
+
+De conversie van CMYKColor naar Color met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToArgb`](../../cmykcolorhelper/toargb/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColor(CmykColor[] cmykPixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | De pixels van het type CMYKColor in CMYK-indeling. |
+
+### Retourwaarde
+
+De array van de ARGB-kleuren.
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColor(CmykColor) {#tocolor}
+
+De conversie van CMYKColor naar Color. Deze methode is verouderd. Gebruik een effectievere [`ToArgb`](../../cmykcolorhelper/toargb/).
+
+```csharp
+[Obsolete]
+public static Color ToColor(CmykColor cmykPixel)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixel | CmykColor | De pixels van het type CMYKColor in CMYK-indeling. |
+
+### Retourwaarde
+
+De Color[].
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/cmykcolor/tocoloricc/_index.md
+++ b/netherlands/net/aspose.psd/cmykcolor/tocoloricc/_index.md
@@ -1,0 +1,116 @@
+---
+title: "CmykColor.ToColorIcc"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "CmykColor-methode. De conversie van CMYKColor naar Color met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere ToArgbIcc."
+type: docs
+weight: 140
+url: /nl/net/aspose.psd/cmykcolor/tocoloricc/
+---
+{{< psd/tize >}}
+## ToColorIcc(CmykColor[]) {#tocoloricc_2}
+
+De conversie van CMYKColor naar Color met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColorIcc(CmykColor[] cmykPixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | De pixels van het type CMYKColor in CMYK-indeling. |
+
+### Retourwaarde
+
+De Color[].
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor) {#tocoloricc}
+
+De conversie van CMYKColor naar Color met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color ToColorIcc(CmykColor cmykPixel)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixel | CmykColor | De pixel van het type CMYKColor in CMYK-indeling. |
+
+### Retourwaarde
+
+De [`Color`](../../color/).
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor[], Stream, Stream) {#tocoloricc_3}
+
+De conversie van CMYKColor naar Color met icc-conversie. Deze methode is verouderd. Gebruik een effectievere [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color[] ToColorIcc(CmykColor[] cmykPixels, Stream cmykIccStream, Stream rgbIccStream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixels | CmykColor[] | De pixels van het type CMYKColor in CMYK-indeling. |
+| cmykIccStream | Stroom | De stream die het icc cmyk-profiel bevat. |
+| rgbIccStream | Stroom | De stream die het icc rgb-profiel bevat. |
+
+### Retourwaarde
+
+De Color[].
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToColorIcc(CmykColor, Stream, Stream) {#tocoloricc_1}
+
+De conversie van CMYKColor naar Color met icc-conversie. Deze methode is verouderd. Gebruik een effectievere [`ToArgbIcc`](../../cmykcolorhelper/toargbicc/).
+
+```csharp
+[Obsolete]
+public static Color ToColorIcc(CmykColor cmykPixel, Stream cmykIccStream, Stream rgbIccStream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| cmykPixel | CmykColor | De pixel van het type CMYKColor in CMYK-indeling. |
+| cmykIccStream | Stroom | De stream die het icc cmyk-profiel bevat. |
+| rgbIccStream | Stroom | De stream die het icc rgb-profiel bevat. |
+
+### Retourwaarde
+
+De [`Color`](../../color/).
+
+### Zie ook
+
+* struct [Color](../../color/)
+* struct [CmykColor](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/color/tocmyk/_index.md
+++ b/netherlands/net/aspose.psd/color/tocmyk/_index.md
@@ -1,0 +1,60 @@
+---
+title: "Color.ToCmyk"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Color-methode. De conversie van Color naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere ToCmyk."
+type: docs
+weight: 1620
+url: /nl/net/aspose.psd/color/tocmyk/
+---
+{{< psd/tize >}}
+## ToCmyk(Color[]) {#tocmyk_1}
+
+De conversie van Color naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmyk(Color[] pixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixels | Color[] | De pixels van het type Color in RGB-indeling. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor[].
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmyk(Color) {#tocmyk}
+
+De conversie van Color naar CMYKColor. Deze methode is verouderd. Gebruik een effectievere [`ToCmyk`](../../cmykcolorhelper/tocmyk/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmyk(Color pixel)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixel | Color | De pixel van het type Color in RGB-indeling. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor.
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/color/tocmykicc/_index.md
+++ b/netherlands/net/aspose.psd/color/tocmykicc/_index.md
@@ -1,0 +1,116 @@
+---
+title: "Color.ToCmykIcc"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Color-methode. De conversie van Color naar CMYKColor met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere ToCmykIcc."
+type: docs
+weight: 1630
+url: /nl/net/aspose.psd/color/tocmykicc/
+---
+{{< psd/tize >}}
+## ToCmykIcc(Color) {#tocmykicc}
+
+De conversie van Color naar CMYKColor met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmykIcc(Color pixel)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixel | Color | De pixel van het type Color in RGB-indeling. |
+
+### Retourwaarde
+
+De [`CmykColor`](../../cmykcolor/).
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color[]) {#tocmykicc_2}
+
+De conversie van Color naar CMYKColor met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmykIcc(Color[] pixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixels | Color[] | De pixels van het type Color in RGB-indeling. |
+
+### Retourwaarde
+
+De !:CmykColor[].
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color[], Stream, Stream) {#tocmykicc_3}
+
+De conversie van Color naar CMYKColor met icc-conversie. Deze methode is verouderd. Gebruik een effectievere [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor[] ToCmykIcc(Color[] pixels, Stream rgbIccStream, Stream cmykIccStream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixels | Color[] | De pixels van het type Color in RGB-indeling. |
+| rgbIccStream | Stroom | De stream die het icc rgb-profiel bevat. |
+| cmykIccStream | Stroom | De stream die het icc cmyk-profiel bevat. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor[].
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+---
+
+## ToCmykIcc(Color, Stream, Stream) {#tocmykicc_1}
+
+De conversie van Color naar CMYKColor met icc-conversie en standaardprofielen. Deze methode is verouderd. Gebruik een effectievere [`ToCmykIcc`](../../cmykcolorhelper/tocmykicc/).
+
+```csharp
+[Obsolete]
+public static CmykColor ToCmykIcc(Color pixel, Stream rgbIccStream, Stream cmykIccStream)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| pixel | Color | De pixel van het type Color in RGB-indeling. |
+| rgbIccStream | Stroom | De stream die het icc rgb-profiel bevat. |
+| cmykIccStream | Stroom | De stream die het icc cmyk-profiel bevat. |
+
+### Retourwaarde
+
+De Aspose:PSD:CmykColor[].
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Color](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/fontsettings/getsystemalternativefont/_index.md
+++ b/netherlands/net/aspose.psd/fontsettings/getsystemalternativefont/_index.md
@@ -1,0 +1,28 @@
+---
+title: "FontSettings.GetSystemAlternativeFont"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "FontSettings-eigenschap. Haalt of stelt een waarde in die aangeeft of een alternatief lettertype wordt opgehaald."
+type: docs
+weight: 20
+url: /nl/net/aspose.psd/fontsettings/getsystemalternativefont/
+---
+{{< psd/tize >}}
+## FontSettings.GetSystemAlternativeFont property
+
+Haalt of stelt een waarde in die aangeeft of [get alternative font].
+
+```csharp
+public static bool GetSystemAlternativeFont { get; set; }
+```
+
+### Property Value
+
+`true` als [get alternative font]; anders `false`.
+
+### Zie ook
+
+* class [FontSettings](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/fontsettings/removefontcachefile/_index.md
+++ b/netherlands/net/aspose.psd/fontsettings/removefontcachefile/_index.md
@@ -1,0 +1,47 @@
+---
+title: "FontSettings.RemoveFontCacheFile"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "FontSettings-methode. Verwijdert het lettertypecachebestand."
+type: docs
+weight: 100
+url: /nl/net/aspose.psd/fontsettings/removefontcachefile/
+---
+{{< psd/tize >}}
+## FontSettings.RemoveFontCacheFile method
+
+Verwijdert het lettertypecachebestand.
+
+```csharp
+public static void RemoveFontCacheFile()
+```
+
+## Voorbeelden
+
+De volgende code toont de methode voor het verwijderen van het bestand met de cache van geladen lettertypen.
+
+```csharp
+[C#]
+
+string src = "SimpleText.psd";
+
+FontSettings.RemoveFontCacheFile();
+
+using (var psdImage = (PsdImage)Image.Load(src))
+{
+    foreach (var layer in psdImage.Layers)
+    {
+        if (layer is TextLayer textLayer)
+        {
+            textLayer.GetFonts();
+        }
+    }
+}
+```
+
+### Zie ook
+
+* class [FontSettings](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/graphics/paintableimageoptions/_index.md
+++ b/netherlands/net/aspose.psd/graphics/paintableimageoptions/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Graphics.PaintableImageOptions"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Graphics-eigenschap. Haalt of stelt afbeeldingsopties in die worden gebruikt om schilderbare vectorafbeeldingen te maken voor weergave."
+type: docs
+weight: 110
+url: /nl/net/aspose.psd/graphics/paintableimageoptions/
+---
+{{< psd/tize >}}
+## Graphics.PaintableImageOptions property
+
+Haalt of stelt afbeeldingsopties in die worden gebruikt om schilderbare vectorafbeeldingen te maken voor weergave.
+
+```csharp
+public ImageOptionsBase PaintableImageOptions { get; set; }
+```
+
+### Property Value
+
+De afbeeldingsopties die worden gebruikt om schilderbare vectorafbeeldingen te maken voor weergave.
+
+### Zie ook
+
+* class [ImageOptionsBase](../../imageoptionsbase/)
+* class [Graphics](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/image/usepalette/_index.md
+++ b/netherlands/net/aspose.psd/image/usepalette/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Image.UsePalette"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Afbeeldingseigenschap. Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt"
+type: docs
+weight: 150
+url: /nl/net/aspose.psd/image/usepalette/
+---
+{{< psd/tize >}}
+## Image.UsePalette property
+
+Haalt een waarde op die aangeeft of het afbeeldingspalet wordt gebruikt.
+
+```csharp
+public virtual bool UsePalette { get; }
+```
+
+### Property Value
+
+`true` als het palet in de afbeelding wordt gebruikt; anders `false`.
+
+### Zie ook
+
+* class [Image](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/metered/getproductname/_index.md
+++ b/netherlands/net/aspose.psd/metered/getproductname/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metered.GetProductName"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Metered-methode. Haalt de naam van het product op"
+type: docs
+weight: 30
+url: /nl/net/aspose.psd/metered/getproductname/
+---
+{{< psd/tize >}}
+## Metered.GetProductName method
+
+Haalt de naam van het product op.
+
+```csharp
+public string GetProductName()
+```
+
+### Retourwaarde
+
+Naam van gelicentieerd product
+
+### Zie ook
+
+* class [Metered](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/metered/ismeteredlicensed/_index.md
+++ b/netherlands/net/aspose.psd/metered/ismeteredlicensed/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Metered.IsMeteredLicensed"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Metered-methode. Controleer of metered gelicentieerd is"
+type: docs
+weight: 70
+url: /nl/net/aspose.psd/metered/ismeteredlicensed/
+---
+{{< psd/tize >}}
+## Metered.IsMeteredLicensed method
+
+Controleer of metered gelicentieerd is
+
+```csharp
+public static bool IsMeteredLicensed()
+```
+
+### Retourwaarde
+
+Waar of onwaar
+
+### Zie ook
+
+* class [Metered](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/pixelsdata/clone/_index.md
+++ b/netherlands/net/aspose.psd/pixelsdata/clone/_index.md
@@ -1,0 +1,28 @@
+---
+title: "PixelsData.Clone"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PixelsData-methode. Het maakt een volledige kopie van de instantie."
+type: docs
+weight: 40
+url: /nl/net/aspose.psd/pixelsdata/clone/
+---
+{{< psd/tize >}}
+## PixelsData.Clone method
+
+Het maakt een volledige kopie van de instantie.
+
+```csharp
+public object Clone()
+```
+
+### Retourwaarde
+
+De kopie van de instantie.
+
+### Zie ook
+
+* class [PixelsData](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/pluginlicenseexception/_index.md
+++ b/netherlands/net/aspose.psd/pluginlicenseexception/_index.md
@@ -1,0 +1,29 @@
+---
+title: "Class PluginLicenseException"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Aspose.PSD.PluginLicenseException class. Exception voor plug-inlicentie"
+type: docs
+weight: 5750
+url: /nl/net/aspose.psd/pluginlicenseexception/
+---
+{{< psd/tize >}}
+## PluginLicenseException class
+
+Exception voor plug-inlicentie
+
+```csharp
+public class PluginLicenseException : Exception
+```
+
+## Constructors
+
+| Naam | Beschrijving |
+| --- | --- |
+| [PluginLicenseException](pluginlicenseexception/)() | De standaardconstructor. |
+
+### Zie ook
+
+* namespace [Aspose.PSD](../../aspose.psd/)
+* assembly [Aspose.PSD](../../)
+
+

--- a/netherlands/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/_index.md
+++ b/netherlands/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/_index.md
@@ -1,0 +1,24 @@
+---
+title: "PluginLicenseException.PluginLicenseException"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "PluginLicenseException-constructeur. De standaardconstructor."
+type: docs
+weight: 10
+url: /nl/net/aspose.psd/pluginlicenseexception/pluginlicenseexception/
+---
+{{< psd/tize >}}
+## PluginLicenseException constructor
+
+De standaardconstructor.
+
+```csharp
+public PluginLicenseException()
+```
+
+### Zie ook
+
+* class [PluginLicenseException](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/rasterimage/loadcmykpixels/_index.md
+++ b/netherlands/net/aspose.psd/rasterimage/loadcmykpixels/_index.md
@@ -1,0 +1,35 @@
+---
+title: "RasterImage.LoadCmykPixels"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RasterImage-methode. Laadt pixels in CMYK-indeling. Deze methode is verouderd. Gebruik a.u.b. de effectievere LoadCmyk32Pixels-methode"
+type: docs
+weight: 380
+url: /nl/net/aspose.psd/rasterimage/loadcmykpixels/
+---
+{{< psd/tize >}}
+## RasterImage.LoadCmykPixels method
+
+Laadt pixels in CMYK-indeling. Deze methode is verouderd. Gebruik a.u.b. de effectievere [`LoadCmyk32Pixels`](../loadcmyk32pixels/) methode.
+
+```csharp
+[Obsolete]
+public CmykColor[] LoadCmykPixels(Rectangle rectangle)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| rechthoek | Rechthoek | De rechthoek om pixels uit te laden. |
+
+### Retourwaarde
+
+De geladen CMYK-pixelarray.
+
+### Zie ook
+
+* struct [CmykColor](../../cmykcolor/)
+* struct [Rectangle](../../rectangle/)
+* class [RasterImage](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/rasterimage/savecmykpixels/_index.md
+++ b/netherlands/net/aspose.psd/rasterimage/savecmykpixels/_index.md
@@ -1,0 +1,32 @@
+---
+title: "RasterImage.SaveCmykPixels"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "RasterImage-methode. Slaat de pixels op. Deze methode is verouderd. Gebruik a.u.b. de effectievere SaveCmyk32Pixels-methode"
+type: docs
+weight: 530
+url: /nl/net/aspose.psd/rasterimage/savecmykpixels/
+---
+{{< psd/tize >}}
+## RasterImage.SaveCmykPixels method
+
+Slaat de pixels op. Deze methode is verouderd. Gebruik a.u.b. de effectievere [`SaveCmyk32Pixels`](../savecmyk32pixels/) methode.
+
+```csharp
+[Obsolete]
+public void SaveCmykPixels(Rectangle rectangle, CmykColor[] pixels)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| rechthoek | Rechthoek | De rechthoek om pixels in op te slaan. |
+| pixels | CmykColor[] | De CMYK-pixelarray. |
+
+### Zie ook
+
+* struct [Rectangle](../../rectangle/)
+* struct [CmykColor](../../cmykcolor/)
+* class [RasterImage](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/region/gethashcode/_index.md
+++ b/netherlands/net/aspose.psd/region/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Region.GetHashCode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "Region-methode. Haal de hashcode op van het huidige object."
+type: docs
+weight: 60
+url: /nl/net/aspose.psd/region/gethashcode/
+---
+{{< psd/tize >}}
+## Region.GetHashCode method
+
+Haal de hashcode op van het huidige object.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Retourwaarde
+
+De hashcode.
+
+### Zie ook
+
+* class [Region](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/stringformat/customcharident/_index.md
+++ b/netherlands/net/aspose.psd/stringformat/customcharident/_index.md
@@ -1,0 +1,29 @@
+---
+title: "StringFormat.CustomCharIdent"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StringFormat-eigenschap. Haalt de aangepaste tekenident op of stelt deze in."
+type: docs
+weight: 50
+url: /nl/net/aspose.psd/stringformat/customcharident/
+---
+{{< psd/tize >}}
+## StringFormat.CustomCharIdent property
+
+Haalt de aangepaste tekenident op of stelt deze in.
+
+```csharp
+public PointF CustomCharIdent { get; set; }
+```
+
+### Property Value
+
+De aangepaste tekenident.
+
+### Zie ook
+
+* struct [PointF](../../pointf/)
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/stringformat/equals/_index.md
+++ b/netherlands/net/aspose.psd/stringformat/equals/_index.md
@@ -1,0 +1,32 @@
+---
+title: "StringFormat.Equals"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StringFormat-methode. Controleer of objecten gelijk zijn"
+type: docs
+weight: 150
+url: /nl/net/aspose.psd/stringformat/equals/
+---
+{{< psd/tize >}}
+## StringFormat.Equals method
+
+Controleer of objecten gelijk zijn.
+
+```csharp
+public override bool Equals(object obj)
+```
+
+| Parameter | Type | Beschrijving |
+| --- | --- | --- |
+| obj | Object | Het andere object. |
+
+### Retourwaarde
+
+Het resultaat van de gelijkheidsvergelijking.
+
+### Zie ook
+
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+

--- a/netherlands/net/aspose.psd/stringformat/gethashcode/_index.md
+++ b/netherlands/net/aspose.psd/stringformat/gethashcode/_index.md
@@ -1,0 +1,28 @@
+---
+title: "StringFormat.GetHashCode"
+second_title: "Aspose.PSD voor .NET API-referentie"
+description: "StringFormat-methode. Haal de hashcode op van het huidige object"
+type: docs
+weight: 160
+url: /nl/net/aspose.psd/stringformat/gethashcode/
+---
+{{< psd/tize >}}
+## StringFormat.GetHashCode method
+
+Haal de hashcode op van het huidige object.
+
+```csharp
+public override int GetHashCode()
+```
+
+### Retourwaarde
+
+De hashcode.
+
+### Zie ook
+
+* class [StringFormat](../)
+* namespace [Aspose.PSD](../../../aspose.psd/)
+* assembly [Aspose.PSD](../../../)
+
+


### PR DESCRIPTION
🔄 **In progress** — incremental translation of NET API Reference to **Netherlands** (`nl`).

Updated at each cache checkpoint. Source: `english/net`

🤖 Generated by RDA